### PR TITLE
Use poetry to create version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ pip install nox
 pip install nox-poetry
 git clone https://github.com/probcomp/genjax
 cd genjax
+poetry self add "poetry-dynamic-versioning[plugin]"
 poetry install
 poetry run jupyter-lab
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,8 @@ show_column_numbers = true
 show_error_codes = true
 show_error_context = true
 
+[tool.poetry-dynamic-versioning]
+enable = true
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"

--- a/src/genjax/__init__.py
+++ b/src/genjax/__init__.py
@@ -33,8 +33,6 @@ from .information import *
 from .language_decorator import *
 
 
-__version__ = "0.0.1"
-
 ####################################################
 #
 #   The exports defined above are the public API.

--- a/src/genjax/__init__.py
+++ b/src/genjax/__init__.py
@@ -32,6 +32,9 @@ from .inference import *
 from .information import *
 from .language_decorator import *
 
+from importlib import metadata
+
+__version__ = metadata.version("genjax")
 
 ####################################################
 #


### PR DESCRIPTION
```Python
>>> import genjax
>>> from importlib import metadata
>>> metadata.version('genjax')
'0.0.0.post1804.dev0+646aa278'
```

Note that we will have version == 0.0.0 until we put a tag on some version. This is kind of ugly, but it beats having the version always be 0.0.1 no matter what the branch. 