### PR TITLE
ChoiceMap type unification

### DIFF
--- a/src/genjax/_src/core/datatypes/generative.py
+++ b/src/genjax/_src/core/datatypes/generative.py
@@ -286,7 +286,7 @@ class ChoiceMap(Pytree):
 
     @abc.abstractmethod
     def is_empty(self) -> bool:
-        # TODO(colin): who uses this?
+        # TODO(colin): consider retiring in favor of len(chm) == 0
         return True
 
     @abc.abstractmethod
@@ -407,7 +407,6 @@ class ChoiceValue(ChoiceMap):
     def get_value(self):
         return self.value
 
-    @dispatch
     def merge(self, other: "ChoiceValue"):
         return self, other
 
@@ -1103,17 +1102,6 @@ class GenerativeFunction(Pytree):
 
         return constraints.match(_inactive, _active)
 
-    @dispatch
-    def update(
-        self,
-        key: PRNGKey,
-        prev: Trace,
-        new_constraints: ChoiceMap,
-        diffs: Tuple,
-    ) -> Tuple[Trace, FloatArray, Any, ChoiceMap]:
-        raise NotImplementedError
-
-    @dispatch
     def update(
         self,
         key: PRNGKey,
@@ -1250,6 +1238,12 @@ class HierarchicalChoiceMap(ChoiceMap):
     def flatten(self):
         return (self.trie,), ()
 
+    # TODO(colin): I really think that this should recursively convert
+    # Python dicts to the obvious nested choice map instead of stopping
+    # at the first level. Vector items within should also be promoted
+    # to VectorChoiceMaps. Also there is code duplication with __setitem__
+    # below. The code which switches on the type of the value should have
+    # one implementation.
     @classmethod
     @dispatch
     def new(cls, constraints: Dict):

--- a/src/genjax/_src/core/datatypes/generative.py
+++ b/src/genjax/_src/core/datatypes/generative.py
@@ -266,15 +266,6 @@ class HierarchicalSelection(Selection):
 # Choices #
 ###########
 
-#
-# @dataclass
-# class Choice(Pytree):
-#     @abc.abstractmethod
-#     def filter(self, selection: Selection) -> "Choice":
-#         pass
-#
-
-
 @dataclass
 class ChoiceMap(Pytree):
     @abc.abstractmethod

--- a/src/genjax/_src/core/datatypes/generative.py
+++ b/src/genjax/_src/core/datatypes/generative.py
@@ -400,10 +400,6 @@ class ChoiceValue(ChoiceMap):
     def flatten(self):
         return (self.value,), ()
 
-    @classmethod
-    def new(cls, v):
-        return ChoiceValue(v)
-
     # TODO(colin): get rid of this in favor of len(chm) == 0
     def is_empty(self):
         return False
@@ -1500,7 +1496,7 @@ class LanguageConstructor(Pytree):
 
 # Choices and choice maps
 empty_choice = ChoiceMap
-choice_value = ChoiceValue.new
+choice_value = ChoiceValue
 hierarchical_choice_map = HierarchicalChoiceMap.new
 disjoint_union_choice_map = DisjointUnionChoiceMap.new
 

--- a/src/genjax/_src/core/datatypes/trie.py
+++ b/src/genjax/_src/core/datatypes/trie.py
@@ -115,6 +115,9 @@ class Trie(Pytree, CustomPretty):
     def __hash__(self):
         return hash(self.inner)
 
+    def __len__(self):
+        return len(self.inner)
+
     ###################
     # Pretty printing #
     ###################

--- a/src/genjax/_src/core/interpreters/incremental.py
+++ b/src/genjax/_src/core/interpreters/incremental.py
@@ -207,15 +207,9 @@ def tree_diff_unpack_leaves(v):
 
 
 def static_check_tree_leaves_diff(v):
-    def _inner(v):
-        if static_check_is_diff(v):
-            return True
-        else:
-            return False
-
     return all(
         jtu.tree_leaves(
-            jtu.tree_map(_inner, v, is_leaf=static_check_is_diff),
+            jtu.tree_map(static_check_is_diff, v, is_leaf=static_check_is_diff),
         )
     )
 

--- a/src/genjax/_src/core/pytree/checks.py
+++ b/src/genjax/_src/core/pytree/checks.py
@@ -41,6 +41,8 @@ def static_check_tree_leaves_have_matching_leading_dim(tree):
     leaves = jtu.tree_leaves(broadcast_dim_tree)
     leaf_lengths = set(leaves)
     # all the leaves must have the same first dim size.
-    assert len(leaf_lengths) == 1
-    max_index = list(leaf_lengths).pop()
-    return max_index
+    # TODO(colin): this becomes <2 instead of ==1 b/c we now create a
+    # VectorChoiceMap(ChoiceMap()) in order to dodge duplicative EmptyChoice specialization,
+    # perhaps temporarily...but such a thing should be allowed to satisfy this definition vacuously
+    assert len(leaf_lengths) < 2
+    return leaf_lengths.pop() if leaf_lengths else 0

--- a/src/genjax/_src/generative_functions/combinators/masking_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/masking_combinator.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass
 
-from genjax._src.core.datatypes.generative import Choice
+from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import JAXGenerativeFunction
 from genjax._src.core.datatypes.generative import LanguageConstructor
 from genjax._src.core.datatypes.generative import Trace
@@ -91,7 +91,7 @@ class MaskingCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
     def importance(
         self,
         key: PRNGKey,
-        choice: Choice,
+        choice: ChoiceMap,
         args: Tuple,
     ) -> Tuple[MaskingTrace, FloatArray]:
         (check, inner_args) = args
@@ -104,9 +104,9 @@ class MaskingCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
         self,
         key: PRNGKey,
         prev_trace: MaskingTrace,
-        choice: Choice,
+        choice: ChoiceMap,
         argdiffs: Tuple,
-    ) -> Tuple[MaskingTrace, FloatArray, Any, Choice]:
+    ) -> Tuple[MaskingTrace, FloatArray, Any, ChoiceMap]:
         (check_diff, inner_argdiffs) = argdiffs
         check = tree_diff_primal(check_diff)
         tr, w, rd, d = self.inner.update(key, prev_trace.inner, choice, inner_argdiffs)

--- a/src/genjax/_src/generative_functions/combinators/switch/switch_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/switch/switch_combinator.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 
 import jax
 
-from genjax._src.core.datatypes.generative import Choice
+from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import JAXGenerativeFunction
 from genjax._src.core.datatypes.generative import LanguageConstructor
 from genjax._src.core.datatypes.generative import Trace
@@ -194,7 +194,7 @@ class SwitchCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
     def importance(
         self,
         key: PRNGKey,
-        chm: Choice,
+        chm: ChoiceMap,
         args: Tuple,
     ) -> Tuple[SwitchTrace, FloatArray]:
         switch = args[0]
@@ -210,7 +210,7 @@ class SwitchCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
         self,
         key: PRNGKey,
         prev: Trace,
-        constraints: Choice,
+        constraints: ChoiceMap,
         argdiffs: Tuple,
     ):
         def _inner_update(br, key):
@@ -263,7 +263,7 @@ class SwitchCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
         self,
         key: PRNGKey,
         prev: Trace,
-        constraints: Choice,
+        constraints: ChoiceMap,
         argdiffs: Tuple,
     ):
         def _inner_importance(br, key, prev, constraints, argdiffs):
@@ -312,7 +312,7 @@ class SwitchCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
         self,
         key: PRNGKey,
         prev: SwitchTrace,
-        constraints: Choice,
+        constraints: ChoiceMap,
         argdiffs: Tuple,
     ) -> Tuple[SwitchTrace, FloatArray, Any, Any]:
         index_argdiff = argdiffs[0]
@@ -325,7 +325,7 @@ class SwitchCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
     @typecheck
     def assess(
         self,
-        chm: Choice,
+        chm: ChoiceMap,
         args: Tuple,
     ) -> Tuple[FloatArray, Any]:
         switch = args[0]

--- a/src/genjax/_src/generative_functions/combinators/switch/switch_datatypes.py
+++ b/src/genjax/_src/generative_functions/combinators/switch/switch_datatypes.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Sequence
 
 import jax.numpy as jnp
 import jax.tree_util as jtu
 from rich.tree import Tree
 
 import genjax._src.core.pretty_printing as gpp
-from genjax._src.core.datatypes.generative import Choice
 from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import GenerativeFunction
 from genjax._src.core.datatypes.generative import HierarchicalSelection
@@ -135,7 +133,7 @@ class SwitchChoiceMap(ChoiceMap):
         raise NotImplementedError
 
     @dispatch
-    def merge(self, other: Choice) -> Tuple[Choice, Choice]:
+    def merge(self, other: ChoiceMap) -> Tuple[ChoiceMap, ChoiceMap]:
         new_submaps, new_discard = list(
             zip(*map(lambda v: v.merge(other), self.submaps))
         )

--- a/src/genjax/_src/generative_functions/combinators/vector/map_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/map_combinator.py
@@ -277,17 +277,6 @@ class MapCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
         map_tr = MapTrace(self, tr, args, retval, jnp.sum(scores))
         return (map_tr, w)
 
-    # @dispatch
-    # def importance(
-    #     self,
-    #     key: PRNGKey,
-    #     chm: EmptyChoice,
-    #     args: Tuple,
-    # ) -> Tuple[MapTrace, FloatArray]:
-    #     map_tr = self.simulate(key, args)
-    #     w = 0.0
-    #     return (map_tr, w)
-
     @dispatch
     def importance(
         self,
@@ -413,22 +402,6 @@ class MapCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
             return self.update(key, prev, VectorChoiceMap.new(ChoiceMap()), argdiffs)
         else:
             raise NotImplementedError
-        # prev_inaxes_tree = jtu.tree_map(
-        #     lambda v: None if v.shape == () else 0, prev.inner
-        # )
-        # args = tree_diff_primal(argdiffs)
-        # original_args = prev.get_args()
-        # self._static_check_broadcastable(args)
-        # broadcast_dim_length = self._static_broadcast_dim_length(args)
-        # sub_keys = jax.random.split(key, broadcast_dim_length)
-        # (tr, w, retval_diff, discard) = jax.vmap(
-        #     self.maybe_restore_arguments_kernel_update,
-        #     in_axes=(0, prev_inaxes_tree, 0, self.in_axes, self.in_axes),
-        # )(sub_keys, prev.inner, chm, original_args, argdiffs)
-        # w = jnp.sum(w)
-        # retval = tr.get_retval()
-        # map_tr = MapTrace(self, tr, args, retval, jnp.sum(tr.get_score()))
-        # return (map_tr, w, retval_diff, discard)
 
     @typecheck
     def assess(

--- a/src/genjax/_src/generative_functions/combinators/vector/repeat_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/repeat_combinator.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 import jax
 import jax.numpy as jnp
 
-from genjax._src.core.datatypes.generative import Choice
+from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import JAXGenerativeFunction
 from genjax._src.core.datatypes.generative import LanguageConstructor
 from genjax._src.core.datatypes.generative import Selection
@@ -101,9 +101,9 @@ class RepeatCombinator(JAXGenerativeFunction):
         self,
         key: PRNGKey,
         prev: RepeatTrace,
-        choice: Choice,
+        choice: ChoiceMap,
         argdiffs: Tuple,
-    ) -> Tuple[RepeatTrace, FloatArray, Any, Choice]:
+    ) -> Tuple[RepeatTrace, FloatArray, Any, ChoiceMap]:
         pass
 
     @dispatch

--- a/src/genjax/_src/generative_functions/combinators/vector/unfold_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/unfold_combinator.py
@@ -24,7 +24,6 @@ import jax.tree_util as jtu
 from jax.experimental import checkify
 
 from genjax._src.checkify import optional_check
-from genjax._src.core.datatypes.generative import Choice
 from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import GenerativeFunction
 from genjax._src.core.datatypes.generative import HierarchicalSelection
@@ -640,9 +639,9 @@ class UnfoldCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
         self,
         key: PRNGKey,
         prev: UnfoldTrace,
-        chm: Choice,
+        chm: ChoiceMap,
         argdiffs: Tuple,
-    ) -> Tuple[UnfoldTrace, FloatArray, Any, Choice]:
+    ) -> Tuple[UnfoldTrace, FloatArray, Any, ChoiceMap]:
         length = argdiffs[0]
         state = argdiffs[1]
         static_args = argdiffs[2:]

--- a/src/genjax/_src/generative_functions/combinators/vector/unfold_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/unfold_combinator.py
@@ -617,9 +617,6 @@ class UnfoldCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
         state: Any,
         *static_args: Any,
     ):
-        # TODO(colin): we deleted the update_specialized for EmptyChoice above,
-        # but we will probably have to put it back. First thing to check is
-        # to see if we can reuse the VectorCM implementation with an empty vector?
         raise NotImplementedError
 
     @dispatch

--- a/src/genjax/_src/generative_functions/interpreted/__init__.py
+++ b/src/genjax/_src/generative_functions/interpreted/__init__.py
@@ -32,7 +32,6 @@ from plum import dispatch
 
 from genjax._src.core.datatypes.generative import (
     ChoiceMap,
-    EmptyChoice,
     HierarchicalSelection,
 )
 from genjax._src.core.datatypes.generative import GenerativeFunction
@@ -359,12 +358,12 @@ class InterpretedGenerativeFunction(GenerativeFunction, SupportsCalleeSugar):
                 HierarchicalChoiceMap(discard),
             )
 
-    @dispatch
-    def update(
-        self, key: PRNGKey, prev_trace: Trace, choice: EmptyChoice, argdiffs: Tuple
-    ) -> Tuple[InterpretedTrace, ArrayLike, Any, ChoiceMap]:
-        return self.update(key, prev_trace, HierarchicalChoiceMap.new({}), argdiffs)
-
+    # @dispatch
+    # def update(
+    #     self, key: PRNGKey, prev_trace: Trace, choice: EmptyChoice, argdiffs: Tuple
+    # ) -> Tuple[InterpretedTrace, ArrayLike, Any, ChoiceMap]:
+    #     return self.update(key, prev_trace, HierarchicalChoiceMap.new({}), argdiffs)
+    #
     def assess(
         self,
         choice_map: ChoiceMap,

--- a/src/genjax/_src/generative_functions/interpreted/__init__.py
+++ b/src/genjax/_src/generative_functions/interpreted/__init__.py
@@ -358,12 +358,6 @@ class InterpretedGenerativeFunction(GenerativeFunction, SupportsCalleeSugar):
                 HierarchicalChoiceMap(discard),
             )
 
-    # @dispatch
-    # def update(
-    #     self, key: PRNGKey, prev_trace: Trace, choice: EmptyChoice, argdiffs: Tuple
-    # ) -> Tuple[InterpretedTrace, ArrayLike, Any, ChoiceMap]:
-    #     return self.update(key, prev_trace, HierarchicalChoiceMap.new({}), argdiffs)
-    #
     def assess(
         self,
         choice_map: ChoiceMap,

--- a/src/genjax/_src/generative_functions/static/static_gen_fn.py
+++ b/src/genjax/_src/generative_functions/static/static_gen_fn.py
@@ -15,7 +15,7 @@
 import functools
 from dataclasses import dataclass
 
-from genjax._src.core.datatypes.generative import Choice
+from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import HierarchicalChoiceMap
 from genjax._src.core.datatypes.generative import JAXGenerativeFunction
 from genjax._src.core.datatypes.generative import LanguageConstructor
@@ -107,7 +107,7 @@ class StaticGenerativeFunction(
     def importance(
         self,
         key: PRNGKey,
-        chm: Choice,
+        chm: ChoiceMap,
         args: Tuple,
     ) -> Tuple[StaticTrace, FloatArray]:
         syntax_sugar_handled = push_trace_overload_stack(
@@ -142,9 +142,9 @@ class StaticGenerativeFunction(
         self,
         key: PRNGKey,
         prev: Trace,
-        constraints: Choice,
+        constraints: ChoiceMap,
         argdiffs: Tuple,
-    ) -> Tuple[Trace, FloatArray, Any, Choice]:
+    ) -> Tuple[Trace, FloatArray, Any, ChoiceMap]:
         assert static_check_tree_leaves_diff(argdiffs)
         syntax_sugar_handled = push_trace_overload_stack(
             handler_trace_with_static, self.source
@@ -180,7 +180,7 @@ class StaticGenerativeFunction(
     @typecheck
     def assess(
         self,
-        chm: Choice,
+        chm: ChoiceMap,
         args: Tuple,
     ) -> Tuple[FloatArray, Any]:
         syntax_sugar_handled = push_trace_overload_stack(

--- a/src/genjax/_src/generative_functions/static/static_transforms.py
+++ b/src/genjax/_src/generative_functions/static/static_transforms.py
@@ -212,9 +212,6 @@ class AddressVisitor(Pytree):
 # in your code, that your derived instance has a `constraints` field.
 @dataclass
 class StaticLanguageHandler(StatefulHandler):
-    # TODO(colin): there are a lot of type errors here because the
-    #
-
     # By default, the interpreter handlers for this language
     # handle the two primitives we defined above
     # (`trace_p`, for random choices, and `cache_p`, for deterministic caching)

--- a/src/genjax/_src/generative_functions/static/static_transforms.py
+++ b/src/genjax/_src/generative_functions/static/static_transforms.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass
 import jax
 import jax.tree_util as jtu
 
-from genjax._src.core.datatypes.generative import Choice
 from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import GenerativeFunction
 from genjax._src.core.datatypes.generative import Trace
@@ -246,7 +245,7 @@ class StaticLanguageHandler(StatefulHandler):
         self.address_choices[addr] = tr
 
     @typecheck
-    def set_discard_state(self, addr, ch: Choice):
+    def set_discard_state(self, addr, ch: ChoiceMap):
         addr = tree_map_collapse_const(addr)
         self.discard_choices[addr] = ch
 

--- a/src/genjax/_src/generative_functions/static/static_transforms.py
+++ b/src/genjax/_src/generative_functions/static/static_transforms.py
@@ -21,7 +21,6 @@ import jax.tree_util as jtu
 
 from genjax._src.core.datatypes.generative import Choice
 from genjax._src.core.datatypes.generative import ChoiceMap
-from genjax._src.core.datatypes.generative import EmptyChoice
 from genjax._src.core.datatypes.generative import GenerativeFunction
 from genjax._src.core.datatypes.generative import Trace
 from genjax._src.core.datatypes.trie import Trie
@@ -214,6 +213,9 @@ class AddressVisitor(Pytree):
 # in your code, that your derived instance has a `constraints` field.
 @dataclass
 class StaticLanguageHandler(StatefulHandler):
+    # TODO(colin): there are a lot of type errors here because the
+    #
+
     # By default, the interpreter handlers for this language
     # handle the two primitives we defined above
     # (`trace_p`, for random choices, and `cache_p`, for deterministic caching)
@@ -224,11 +226,15 @@ class StaticLanguageHandler(StatefulHandler):
         self.address_visitor.visit(addr)
 
     def get_submap(self, addr):
-        if isinstance(self.constraints, EmptyChoice):
-            return self.constraints
-        else:
-            addr = tree_map_collapse_const(addr)
-            return self.constraints.get_submap(addr)
+        # TODO(colin): again, here, we want the empty choice map to have the same behavior as
+        # EmptyChoice. For example, if the addr doesn't exist, we want the behavior to be the
+        # same in that case.
+
+        # if isinstance(self.constraints, EmptyChoice):
+        #     return self.constraints
+        # else:
+        addr = tree_map_collapse_const(addr)
+        return self.constraints.get_submap(addr)
 
     def get_subtrace(self, addr):
         addr = tree_map_collapse_const(addr)

--- a/src/genjax/_src/gensp/core.py
+++ b/src/genjax/_src/gensp/core.py
@@ -27,7 +27,6 @@ from dataclasses import dataclass
 
 from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import ChoiceValue
-from genjax._src.core.datatypes.generative import EmptyChoice
 from genjax._src.core.datatypes.generative import Selection
 from genjax._src.core.datatypes.generative import GenerativeFunction
 from genjax._src.core.interpreters.forward import InitialStylePrimitive

--- a/src/genjax/_src/gensp/grasp.py
+++ b/src/genjax/_src/gensp/grasp.py
@@ -33,7 +33,6 @@ from tensorflow_probability.substrates import jax as tfp
 from genjax._src.core.datatypes.generative import AllSelection
 from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import ChoiceValue
-from genjax._src.core.datatypes.generative import EmptyChoice
 from genjax._src.core.datatypes.generative import GenerativeFunction
 from genjax._src.core.datatypes.generative import Selection
 from genjax._src.core.pytree.pytree import Pytree

--- a/src/genjax/_src/gensp/inference/importance_sampling.py
+++ b/src/genjax/_src/gensp/inference/importance_sampling.py
@@ -21,7 +21,6 @@ import numpy as np
 
 from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import ChoiceValue
-from genjax._src.core.datatypes.generative import EmptyChoice
 from genjax._src.core.typing import Int
 from genjax._src.core.typing import PRNGKey
 from genjax._src.core.typing import dispatch
@@ -52,7 +51,7 @@ class DefaultImportance(SPDistribution):
         key, sub_key = jax.random.split(key)
         sub_keys = jax.random.split(sub_key, self.num_particles)
         (lws, tr) = jax.vmap(target.importance, in_axes=(0, None))(
-            sub_keys, EmptyChoice()
+            sub_keys, ChoiceMap()
         )
         tw = jax.scipy.special.logsumexp(lws)
         lnw = lws - tw
@@ -73,9 +72,7 @@ class DefaultImportance(SPDistribution):
     ):
         key, sub_key = jax.random.split(key)
         sub_keys = jax.random.split(key, self.num_particles - 1)
-        (lws, _) = jax.vmap(target.importance, in_axes=(0, None))(
-            sub_keys, EmptyChoice()
-        )
+        (lws, _) = jax.vmap(target.importance, in_axes=(0, None))(sub_keys, ChoiceMap())
         inner_chm = chm.get_value()
         assert isinstance(inner_chm, ChoiceMap)
         (retained_w, retained_tr) = target.importance(key, inner_chm)

--- a/src/genjax/_src/gensp/inference/sequential_monte_carlo.py
+++ b/src/genjax/_src/gensp/inference/sequential_monte_carlo.py
@@ -40,7 +40,6 @@ from jax.scipy.special import logsumexp
 
 from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import ChoiceValue
-from genjax._src.core.datatypes.generative import EmptyChoice
 from genjax._src.core.datatypes.generative import Trace
 from genjax._src.core.interpreters.incremental import tree_diff_primal
 from genjax._src.core.pytree.pytree import Pytree

--- a/src/genjax/_src/gensp/inference/sequential_monte_carlo.py
+++ b/src/genjax/_src/gensp/inference/sequential_monte_carlo.py
@@ -516,7 +516,7 @@ class SMCInit(SMCAlgorithm):
         # Set retained.
         key, kept = self.q.importance(
             key,
-            ChoiceValue.new(choices),
+            ChoiceValue(choices),
             (target,),
         )
 

--- a/src/genjax/_src/gensp/inference/sequential_monte_carlo.py
+++ b/src/genjax/_src/gensp/inference/sequential_monte_carlo.py
@@ -298,7 +298,7 @@ class SMCExtendPropagator(SMCPropagator):
             key, merged, new_target.args
         )
         key, (_, _, previous_trace, discard) = new_retained_trace.update(
-            key, EmptyChoice(), argdiffs
+            key, ChoiceMap(), argdiffs
         )
         previous_latents = retained.filter(discard.get_selection().complement())
         key, (_, forward_weight_retained) = self.k.assess(
@@ -379,7 +379,7 @@ class SMCSequencePropagator(SMCPropagator):
         return (self.sequence,)
 
     @classmethod
-    def new(fst: SMCPropagator, snd: SMCPropagator):
+    def new(cls, fst: SMCPropagator, snd: SMCPropagator):
         if isinstance(fst, SMCSequencePropagator) and isinstance(
             snd, SMCSequencePropagator
         ):

--- a/src/genjax/_src/inference/translator.py
+++ b/src/genjax/_src/inference/translator.py
@@ -21,7 +21,6 @@ import jax.tree_util as jtu
 from jax.experimental.checkify import check
 
 from genjax._src.checkify import optional_check
-from genjax._src.core.datatypes.generative import Choice
 from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import GenerativeFunction
 from genjax._src.core.datatypes.generative import Trace
@@ -96,7 +95,7 @@ class ExtendingTraceTranslator(TraceTranslator):
     p_argdiffs: Tuple
     q_forward: GenerativeFunction
     q_forward_args: Tuple
-    new_observations: Choice
+    new_observations: ChoiceMap
 
     def flatten(self):
         return (
@@ -112,7 +111,7 @@ class ExtendingTraceTranslator(TraceTranslator):
         p_argdiffs: Tuple,
         q_forward: GenerativeFunction,
         q_forward_args: Tuple,
-        new_obs: Choice,
+        new_obs: ChoiceMap,
         choice_map_forward: Callable,
         choice_map_inverse: Callable,
         check_bijection: Bool,
@@ -301,7 +300,7 @@ class TraceKernelTraceTranslator(TraceTranslator):
         aux_choices, K_score, new_choices = self.K.propose(
             sub_key, (prev_model_choices, self.K_args)
         )
-        assert isinstance(new_choices, Choice)
+        assert isinstance(new_choices, ChoiceMap)
         J_log_abs_det = self.value_and_jacobian_correction(
             aux_choices, prev_model_choices
         )

--- a/src/genjax/_src/information/sdos.py
+++ b/src/genjax/_src/information/sdos.py
@@ -97,7 +97,7 @@ class SymmetricDivergenceOverDatasets(Pytree):
         # Compute estimate of log q(z | x)
         constraints = obs_chm
         target = Target(self.p, p_args, constraints)
-        latent_chm = ChoiceValue.new(latent_chm)
+        latent_chm = ChoiceValue(latent_chm)
         key, sub_key = jax.random.split(key)
         bwd_weights = jax.vmap(_inner_q, in_axes=(None, 0, None, None))(
             sub_key, key_indices_q, latent_chm, (target,)

--- a/src/genjax/core/datatypes.py
+++ b/src/genjax/core/datatypes.py
@@ -16,7 +16,6 @@ from genjax._src.core.datatypes.generative import AllSelection
 from genjax._src.core.datatypes.generative import ChoiceMap
 from genjax._src.core.datatypes.generative import ChoiceValue
 from genjax._src.core.datatypes.generative import DisjointUnionChoiceMap
-from genjax._src.core.datatypes.generative import EmptyChoice
 from genjax._src.core.datatypes.generative import GenerativeFunction
 from genjax._src.core.datatypes.generative import HierarchicalChoiceMap
 from genjax._src.core.datatypes.generative import HierarchicalSelection
@@ -53,7 +52,6 @@ __all__ = [
     "trie",
     # Generative datatypes.
     "ChoiceMap",
-    "EmptyChoice",
     "empty_choice",
     "ChoiceValue",
     "choice_value",

--- a/tests/generative_functions/test_distributions.py
+++ b/tests/generative_functions/test_distributions.py
@@ -15,8 +15,7 @@
 import jax
 
 import genjax
-from genjax import ChoiceValue
-from genjax import EmptyChoice
+from genjax import ChoiceMap, ChoiceValue
 from genjax import mask
 from genjax.incremental import NoChange
 from genjax.incremental import UnknownChange
@@ -33,7 +32,7 @@ class TestDistributions:
         key = jax.random.PRNGKey(314159)
 
         # No constraint.
-        (tr, w) = genjax.normal.importance(key, EmptyChoice(), (0.0, 1.0))
+        (tr, w) = genjax.normal.importance(key, ChoiceMap(), (0.0, 1.0))
         assert w == 0.0
 
         # Constraint, no mask.
@@ -74,7 +73,7 @@ class TestDistributions:
         (new_tr, w, _, _) = genjax.normal.update(
             sub_key,
             tr,
-            EmptyChoice(),
+            ChoiceMap(),
             (diff(0.0, NoChange), diff(1.0, NoChange)),
         )
         assert new_tr.get_value() == tr.get_value()
@@ -100,7 +99,7 @@ class TestDistributions:
         (new_tr, w, _, _) = genjax.normal.update(
             sub_key,
             tr,
-            EmptyChoice(),
+            ChoiceMap(),
             (diff(1.0, UnknownChange), diff(1.0, NoChange)),
         )
         assert new_tr.get_value() == tr.get_value()

--- a/tests/generative_functions/test_static_language.py
+++ b/tests/generative_functions/test_static_language.py
@@ -296,7 +296,7 @@ class TestImportance:
         assert w == pytest.approx(score_2, 0.0001)
 
         # No constraints.
-        chm = genjax.EmptyChoice()
+        chm = genjax.ChoiceMap()
         (tr, w) = simple_normal.importance(key, chm, ())
         y1 = tr["y1"]
         y2 = tr["y2"]

--- a/tests/generative_functions/test_switch_combinator.py
+++ b/tests/generative_functions/test_switch_combinator.py
@@ -123,7 +123,7 @@ class TestSwitch:
         switch = genjax.Switch(simple_normal, simple_bernoulli)
 
         key = jax.random.PRNGKey(314159)
-        chm = genjax.EmptyChoice()
+        chm = genjax.ChoiceMap()
         jitted = jax.jit(switch.importance)
         key, sub_key = jax.random.split(key)
         (tr, w) = jitted(sub_key, chm, (0,))
@@ -209,7 +209,7 @@ class TestSwitch:
             genjax.mask(jnp.array(True), genjax.empty_choice()),
             tree_diff_no_change((1, 0.0)),
         )
-        assert isinstance(d, genjax.EmptyChoice)
+        assert len(d) == 0
         assert w == 0.0
         (tr, w, rd, d) = jax.jit(switch.update)(
             key,
@@ -217,7 +217,7 @@ class TestSwitch:
             genjax.mask(jnp.array(False), genjax.empty_choice()),
             tree_diff_no_change((1, 0.0)),
         )
-        assert isinstance(d, genjax.EmptyChoice)
+        assert len(d) == 0
         assert w == 0.0
 
     def test_switch_update_updates_score(self):

--- a/tests/generative_functions/test_unfold_combinator.py
+++ b/tests/generative_functions/test_unfold_combinator.py
@@ -116,7 +116,7 @@ class TestUnfoldSimpleNormal:
             assert tr.get_score() == pytest.approx(tr.project(sel), 1e-4)
 
         # No constraints
-        chm = genjax.EmptyChoice()
+        chm = genjax.ChoiceMap()
         for t in range(0, 10):
             key, sub_key = jax.random.split(key)
             (tr, _) = two_layer_chain.importance(sub_key, chm, (t, 0.3))

--- a/tests/generative_functions/test_vector_datatypes.py
+++ b/tests/generative_functions/test_vector_datatypes.py
@@ -66,7 +66,7 @@ class TestIndexChoiceMap:
             [0, 3], genjax.choice_map({"z": jnp.array([3.0, 5.0])})
         )
         st = chm.get_submap((2, "x"))
-        assert st == genjax.EmptyChoice()
+        assert len(st) == 0
         # When index is not available, always returns the first index slice inside of a Mask with a False flag.
         st = chm.get_submap((2, "z"))
         assert isinstance(st, genjax.Mask)


### PR DESCRIPTION
The types `Choice` and `EmptyChoice` are deleted. The root of the type hierarchy is now `ChoiceMap`, which can be instantiated to produce an empty choice object.  Choice objects support the `len()` operation.  ChoiceValue is now a subtype of ChoiceMap.