### PR TITLE
Fix noxfile linting step

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -132,7 +132,7 @@ def mypy(session) -> None:
 @session(python=python_version)
 def lint(session: Session) -> None:
     session.run_always("poetry", "install", "--with", "dev", external=True)
-    session.run("ruff", "check", "--select", "I", "--fix", ".")
+    session.run("ruff", "check", "--fix", ".")
     session.run("ruff", "format", ".")
 
 


### PR DESCRIPTION
The intent of this option is already supplied by `pyproject.toml`, and adding it here overrides all settings in `pyproject.toml`, effectively disabling all linting except for import sorting.