### PR TITLE
The remainder of the `new` rewrites.

### DIFF
--- a/notebooks/intermediate/smc/smc_with_translators.ipynb
+++ b/notebooks/intermediate/smc/smc_with_translators.ipynb
@@ -80,7 +80,7 @@
     "    index_sel = genjax.indexed_select(0)\n",
     "    obs_init = obs.slice(0)\n",
     "    key, sub_key = jax.random.split(key)\n",
-    "    smc_state = smc.smc_initialize(chain, 5).apply(sub_key, obs_init, (0, init_state))\n",
+    "    smc_state = smc.smc_initialize(chain, n_particles=5).apply(sub_key, obs_init, (0, init_state))\n",
     "\n",
     "    # Now, scan over the observations, and use the translator\n",
     "    # to perform SMC extend steps.\n",

--- a/src/genjax/__init__.py
+++ b/src/genjax/__init__.py
@@ -26,5 +26,6 @@ from .extras import *
 from .generative_functions import *
 from .inference import *
 from .information import *
+from .shortcuts import *
 
 __version__ = metadata.version("genjax")

--- a/src/genjax/_src/core/datatypes/generative.py
+++ b/src/genjax/_src/core/datatypes/generative.py
@@ -14,7 +14,6 @@
 
 import abc
 from dataclasses import dataclass, field
-from typing import Union
 
 import jax
 import jax.numpy as jnp
@@ -37,7 +36,6 @@ from genjax._src.core.typing import (
     Any,
     BoolArray,
     Callable,
-    Dict,
     FloatArray,
     IntArray,
     List,
@@ -1250,19 +1248,6 @@ class HierarchicalChoiceMap(ChoiceMap):
     def flatten(self):
         return (self.trie,), ()
 
-    @classmethod
-    def from_dict(cls, constraints: Dict):
-        assert isinstance(constraints, Dict)
-        trie = Trie()
-        for k, v in constraints.items():
-            v = (
-                ChoiceValue(v)
-                if not isinstance(v, ChoiceMap) and not isinstance(v, Trace)
-                else v
-            )
-            trie[k] = v
-        return HierarchicalChoiceMap(trie)
-
     def is_empty(self):
         return self.trie.is_empty()
 
@@ -1463,26 +1448,6 @@ class DisjointUnionChoiceMap(ChoiceMap):
 
 # Choices and choice maps
 choice_value = ChoiceValue
-
-
-def choice_map(
-    *vs,
-) -> Union[ChoiceValue, HierarchicalChoiceMap, DisjointUnionChoiceMap]:
-    if len(vs) == 0:
-        return HierarchicalChoiceMap()
-    elif len(vs) == 1:
-        v = vs[0]
-        if isinstance(v, dict):
-            return HierarchicalChoiceMap.from_dict(v)
-        else:
-            return ChoiceValue(v)
-    else:
-        if not all(map(lambda m: isinstance(m, ChoiceMap), vs)):
-            raise TypeError(
-                "To create a union ChoiceMap, all arguments must be ChoiceMaps"
-            )
-        return DisjointUnionChoiceMap(*vs)
-
 
 # TODO: experimental for dynamic addresses.
 # @dispatch

--- a/src/genjax/_src/core/interpreters/incremental.py
+++ b/src/genjax/_src/core/interpreters/incremental.py
@@ -121,10 +121,8 @@ class StaticIntChange(ChangeTangent):
     def flatten(self):
         return (), (self.dv,)
 
-    @classmethod
-    def new(cls, dv):
-        assert static_check_is_concrete(dv)
-        return StaticIntChange(dv)
+    def __post_init__(self):
+        assert static_check_is_concrete(self.dv)
 
     def should_flatten(self):
         return True
@@ -147,12 +145,9 @@ class Diff(Pytree):
     def flatten(self):
         return (self.primal, self.tangent), ()
 
-    # TODO(colin): ask McCoy: the check is safe to run from JAX, or no?
-    @classmethod
-    def new(cls, primal, tangent):
-        assert not isinstance(primal, Diff)
-        static_check_is_change_tangent(tangent)
-        return Diff(primal, tangent)
+    def __post_init__(self):
+        assert not isinstance(self.primal, Diff)
+        static_check_is_change_tangent(self.tangent)
 
     def get_primal(self):
         return self.primal
@@ -330,4 +325,4 @@ def incremental(f: Callable):
 # Shorthands #
 ##############
 
-diff = Diff.new
+diff = Diff

--- a/src/genjax/_src/generative_functions/combinators/vector/map_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/map_combinator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The `MapCombinator` is a generative function combinator which exposes vectorization on the input arguments of a provided generative function callee. 
+The `MapCombinator` is a generative function combinator which exposes vectorization on the input arguments of a provided generative function callee.
 
 This vectorization is implemented using `jax.vmap`, and the combinator expects the user to specify `in_axes` as part of the construction of an instance of this combinator.
 """
@@ -78,7 +78,7 @@ class MapTrace(Trace):
         return self.args
 
     def get_choices(self):
-        return VectorChoiceMap.new(self.inner.strip())
+        return VectorChoiceMap(self.inner.strip())
 
     def get_gen_fn(self):
         return self.gen_fn
@@ -181,25 +181,6 @@ class MapCombinator(JAXGenerativeFunction, SupportsCalleeSugar):
 
     def flatten(self):
         return (self.kernel,), (self.in_axes,)
-
-    @typecheck
-    @classmethod
-    def new(
-        cls,
-        kernel: JAXGenerativeFunction,
-        in_axes: Tuple,
-    ) -> "MapCombinator":
-        """The preferred direct constructor for `MapCombinator` generative function
-        instances.
-
-        Arguments:
-            kernel: A single `JAXGenerativeFunction` instance.
-            in_axes: A tuple specifying which `args` to broadcast over.
-
-        Returns:
-            instance: A `MapCombinator` instance.
-        """
-        return MapCombinator(in_axes, kernel)
 
     def __abstract_call__(self, *args) -> Any:
         return jax.vmap(self.kernel.__abstract_call__, in_axes=self.in_axes)(*args)

--- a/src/genjax/_src/generative_functions/combinators/vector/unfold_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/unfold_combinator.py
@@ -91,7 +91,7 @@ class UnfoldTrace(Trace):
             if jnp.array(self.dynamic_length, copy=False).shape
             else jnp.arange(self.unfold.max_length) <= self.dynamic_length
         )
-        return VectorChoiceMap.new(Mask(mask_flags, self.inner.strip()))
+        return VectorChoiceMap(Mask(mask_flags, self.inner.strip()))
 
     def get_gen_fn(self):
         return self.unfold

--- a/src/genjax/_src/generative_functions/combinators/vector/vector_datatypes.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/vector_datatypes.py
@@ -152,7 +152,7 @@ class IndexedChoiceMap(ChoiceMap):
             return self.get_submap(addr[0])
         idx = addr[0]
         (slice_index,) = jnp.nonzero(idx == self.indices, size=1)
-        #slice_index = self.indices[slice_index[0]] if self.indices.shape else idx
+        # slice_index = self.indices[slice_index[0]] if self.indices.shape else idx
         submap = jtu.tree_map(lambda v: v[slice_index] if v.shape else v, self.inner)
         submap = submap.get_submap(addr[1:])
         if isinstance(submap, EmptyChoice):

--- a/src/genjax/_src/generative_functions/combinators/vector/vector_datatypes.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/vector_datatypes.py
@@ -152,7 +152,6 @@ class IndexedChoiceMap(ChoiceMap):
             return self.get_submap(addr[0])
         idx = addr[0]
         (slice_index,) = jnp.nonzero(idx == self.indices, size=1)
-        # slice_index = self.indices[slice_index[0]] if self.indices.shape else idx
         submap = jtu.tree_map(lambda v: v[slice_index] if v.shape else v, self.inner)
         submap = submap.get_submap(addr[1:])
         if isinstance(submap, EmptyChoice):

--- a/src/genjax/_src/generative_functions/combinators/vector/vector_datatypes.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/vector_datatypes.py
@@ -20,14 +20,16 @@ import rich.tree as rich_tree
 
 import genjax._src.core.pretty_printing as gpp
 from genjax._src.core.datatypes.generative import (
-    AllSelection,
     ChoiceMap,
+    ChoiceValue,
     EmptyChoice,
+    HierarchicalChoiceMap,
     HierarchicalSelection,
     Mask,
     Selection,
-    choice_map,
 )
+from genjax._src.core.datatypes.hashable_dict import hashable_dict
+from genjax._src.core.datatypes.trie import Trie
 from genjax._src.core.pytree.checks import (
     static_check_tree_leaves_have_matching_leading_dim,
 )
@@ -36,9 +38,7 @@ from genjax._src.core.typing import (
     Dict,
     Int,
     IntArray,
-    List,
     Tuple,
-    Union,
     dispatch,
     static_check_is_concrete,
 )
@@ -64,6 +64,9 @@ class IndexedSelection(Selection):
             self.indices,
             self.inner,
         ), ()
+
+    def __post_init__(self):
+        static_check_tree_leaves_have_matching_leading_dim((self.inner, self.indices))
 
     @dispatch
     def has_addr(self, addr: IntArray):
@@ -98,49 +101,21 @@ class IndexedChoiceMap(ChoiceMap):
     def flatten(self):
         return (self.indices, self.inner), ()
 
-    # TODO(colin): Ask McCoy: Maybe a way to unify all these interfaces would
-    # be to take a dict argument with integer keys, as in:
-    #
-    # IndexedChoiceMap.from_dict({
-    #   1: x,
-    #   2: y
-    # })
-    # The indices and values would then look "zipped together" in the source code
-    # pyright-wise, we could enforce the int type constraint on the dict keys
-
     @classmethod
-    @dispatch
-    def new(cls, idx: Int, inner: ChoiceMap) -> ChoiceMap:
-        idx = jnp.array(idx)
-        return IndexedChoiceMap.new(idx, inner)
+    def from_dict(self, d: Dict[int, Any]) -> ChoiceMap:
+        """Produce an IndexedChoiceMap from a dictionary with integer keys.
 
-    @classmethod
-    @dispatch
-    def new(cls, indices: IntArray, inner: ChoiceMap) -> ChoiceMap:
-        # Promote raw integers (or scalars) to non-null leading dim.
-        indices = jnp.array(indices, copy=False)
+        IndexedChoiceMap.from_dict({
+          1: 1.0
+          2: 3.0
+        })
 
-        # Verify that dimensions are consistent before creating an
-        # `IndexedChoiceMap`.
-        _ = static_check_tree_leaves_have_matching_leading_dim((inner, indices))
-
-        # if you try to wrap around an EmptyChoice, do nothing.
-        if isinstance(inner, EmptyChoice):
-            return inner
-
-        return IndexedChoiceMap(indices, inner)
-
-    @classmethod
-    @dispatch
-    def new(cls, indices: List, inner: ChoiceMap) -> ChoiceMap:
-        indices = jnp.array(indices)
-        return IndexedChoiceMap.new(indices, inner)
-
-    @classmethod
-    @dispatch
-    def new(cls, indices: Any, inner: Dict) -> ChoiceMap:
-        inner = choice_map(inner)
-        return IndexedChoiceMap.new(indices, inner)
+        is equivalent to indexed_choice_map([1, 2], choice_map({"x": [1.0, 3.0]}))
+        """
+        sorted_keys = sorted(d.keys())
+        hd = hashable_dict()
+        hd["x"] = ChoiceValue(jnp.array([d[k] for k in sorted_keys]))
+        return IndexedChoiceMap(jnp.array(sorted_keys), HierarchicalChoiceMap(Trie(hd)))
 
     def is_empty(self):
         return self.inner.is_empty()
@@ -175,11 +150,11 @@ class IndexedChoiceMap(ChoiceMap):
     def get_submap(self, addr: Tuple):
         if len(addr) == 1:
             return self.get_submap(addr[0])
-        idx, *rest = addr
+        idx = addr[0]
         (slice_index,) = jnp.nonzero(idx == self.indices, size=1)
-        slice_index = self.indices[slice_index[0]] if self.indices.shape else idx
+        #slice_index = self.indices[slice_index[0]] if self.indices.shape else idx
         submap = jtu.tree_map(lambda v: v[slice_index] if v.shape else v, self.inner)
-        submap = submap.get_submap(tuple(rest))
+        submap = submap.get_submap(addr[1:])
         if isinstance(submap, EmptyChoice):
             return submap
         else:
@@ -242,35 +217,8 @@ class VectorChoiceMap(ChoiceMap):
     def flatten(self):
         return (self.inner,), ()
 
-    # TODO(colin): Ask McCoy: I'm uncomfortable having the constructor for one
-    # class return an object of another type, so maybe we want another
-    # helper function here. Can we enforce that the type of inner is an array?
-    @classmethod
-    @dispatch
-    def new(
-        cls,
-        inner: EmptyChoice,
-    ) -> EmptyChoice:
-        return inner
-
-    @classmethod
-    @dispatch
-    def new(
-        cls,
-        inner: Dict,
-    ) -> ChoiceMap:
-        chm = choice_map(inner)
-        return VectorChoiceMap.new(chm)
-
-    @classmethod
-    @dispatch
-    def new(
-        cls,
-        inner: Any,
-    ) -> ChoiceMap:
-        # Static assertion: all leaves must have same first dim size.
-        static_check_tree_leaves_have_matching_leading_dim(inner)
-        return VectorChoiceMap(inner)
+    def __post_int__(self):
+        static_check_tree_leaves_have_matching_leading_dim(self.inner)
 
     def is_empty(self):
         return self.inner.is_empty()
@@ -293,7 +241,7 @@ class VectorChoiceMap(ChoiceMap):
         self,
         selection: Selection,
     ) -> ChoiceMap:
-        return VectorChoiceMap.new(self.inner.filter(selection))
+        return VectorChoiceMap(self.inner.filter(selection))
 
     def get_selection(self):
         subselection = self.inner.get_selection()
@@ -385,42 +333,3 @@ class VectorChoiceMap(ChoiceMap):
         tree = rich_tree.Tree("[bold](VectorChoiceMap)")
         tree.add(self.inner.__rich_tree__())
         return tree
-
-
-################################
-# Extend select and choice_map #
-################################
-
-
-# @dispatch
-# def choice_map(indices: List[Int], submaps: List[ChoiceMap]):
-#     # submaps must have same Pytree structure to use
-#     # optimized representation.
-#     assert static_check_tree_structure_equivalence(submaps)
-#     index_arr = jnp.array(indices)
-#     return indexed_choice_map(index_arr, submaps)
-
-
-# @dispatch
-# def choice_map(index: Int, submap: ChoiceMap):
-#     expanded = jtu.tree_map(lambda v: jnp.expand_dims(v, axis=0), submap)
-#     return indexed_choice_map([index], expanded)
-
-
-##############
-# Shorthands #
-##############
-
-
-def indexed_select(idx: Union[Int, IntArray], *choices: Selection):
-    idx = jnp.atleast_1d(idx)
-    if len(choices) == 0:
-        return IndexedSelection(idx, AllSelection())
-    elif len(choices) == 1 and isinstance(choices[0], Selection):
-        return IndexedSelection(idx, choices[0])
-    else:
-        return IndexedSelection(idx, HierarchicalSelection.from_addresses(choices))
-
-
-indexed_choice_map = IndexedChoiceMap.new
-vector_choice_map = VectorChoiceMap.new

--- a/src/genjax/_src/gensp/inference/sequential_monte_carlo.py
+++ b/src/genjax/_src/gensp/inference/sequential_monte_carlo.py
@@ -373,27 +373,6 @@ class SMCSequencePropagator(SMCPropagator):
     def flatten(self):
         return (self.sequence,)
 
-    # TODO(colin): possible alternatives to this are overloading `+` operator
-    # or adding a `.then` method
-    @classmethod
-    def new(fst: SMCPropagator, snd: SMCPropagator):
-        if isinstance(fst, SMCSequencePropagator) and isinstance(
-            snd, SMCSequencePropagator
-        ):
-            return SMCSequencePropagator(
-                [*fst.sequence, *snd.sequence],
-            )
-        elif isinstance(fst, SMCSequencePropagator):
-            return SMCSequencePropagator(
-                [*fst.sequence, snd],
-            )
-        elif isinstance(snd, SMCSequencePropagator):
-            return SMCSequencePropagator(
-                [fst, *snd.sequence],
-            )
-        else:
-            return SMCSequencePropagator([fst, snd])
-
     def propagate_target(self, target: Target, args_sequence: Sequence[Tuple]):
         for propagator, args in zip(self.sequence, args_sequence):
             target = propagator.propagate_target(target, *args)

--- a/src/genjax/_src/inference/smc/init.py
+++ b/src/genjax/_src/inference/smc/init.py
@@ -87,8 +87,14 @@ class SMCInitializeFromProposal(SMCAlgorithm):
         lws = model_scores - proposal_scores
         return SMCState(self.n_particles, particles, lws, 0.0, True)
 
+
 @dispatch
-def smc_initialize(model: GenerativeFunction, proposal: Optional[GenerativeFunction] = None, *, n_particles: int) -> SMCAlgorithm:
+def smc_initialize(
+    model: GenerativeFunction,
+    proposal: Optional[GenerativeFunction] = None,
+    *,
+    n_particles: int,
+) -> SMCAlgorithm:
     if proposal is not None:
         return SMCInitializeFromProposal(n_particles, model, proposal)
     else:

--- a/src/genjax/_src/inference/smc/init.py
+++ b/src/genjax/_src/inference/smc/init.py
@@ -14,13 +14,13 @@
 
 
 from dataclasses import dataclass
-from typing import Optional
 
 import jax
 
 from genjax._src.core.datatypes.generative import ChoiceMap, GenerativeFunction
 from genjax._src.core.typing import (
     Int,
+    Optional,
     PRNGKey,
     Tuple,
     dispatch,

--- a/src/genjax/core/datatypes.py
+++ b/src/genjax/core/datatypes.py
@@ -27,7 +27,6 @@ from genjax._src.core.datatypes.generative import (
     NoneSelection,
     Selection,
     Trace,
-    choice_map,
     choice_value,
     select,
 )
@@ -50,7 +49,6 @@ __all__ = [
     "ChoiceValue",
     "choice_value",
     "HierarchicalChoiceMap",
-    "choice_map",
     "DisjointUnionChoiceMap",
     "Trace",
     "Selection",

--- a/src/genjax/generative_functions/combinators/__init__.py
+++ b/src/genjax/generative_functions/combinators/__init__.py
@@ -23,11 +23,6 @@ from genjax._src.generative_functions.combinators.vector.map_combinator import (
 )
 from genjax._src.generative_functions.combinators.vector.repeat_combinator import Repeat
 from genjax._src.generative_functions.combinators.vector.unfold_combinator import Unfold
-from genjax._src.generative_functions.combinators.vector.vector_datatypes import (
-    indexed_choice_map,
-    indexed_select,
-    vector_choice_map,
-)
 
 __all__ = [
     "Masking",
@@ -37,7 +32,4 @@ __all__ = [
     "Unfold",
     "Switch",
     "SwitchCombinator",
-    "vector_choice_map",
-    "indexed_select",
-    "indexed_choice_map",
 ]

--- a/src/genjax/shortcuts.py
+++ b/src/genjax/shortcuts.py
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Union
 
 import jax.numpy as jnp
-from jaxtyping import ArrayLike
 
 from genjax._src.core.datatypes.generative import (
     AllSelection,
@@ -31,7 +29,7 @@ from genjax._src.core.datatypes.trie import Trie
 from genjax._src.core.pytree.checks import (
     static_check_tree_leaves_have_matching_leading_dim,
 )
-from genjax._src.core.typing import IntArray
+from genjax._src.core.typing import ArrayLike, IntArray, Union
 from genjax._src.generative_functions.combinators.vector.vector_datatypes import (
     IndexedChoiceMap,
     IndexedSelection,

--- a/src/genjax/shortcuts.py
+++ b/src/genjax/shortcuts.py
@@ -1,0 +1,125 @@
+# Copyright 2023 MIT Probabilistic Computing Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Union
+
+import jax.numpy as jnp
+from jaxtyping import ArrayLike
+
+from genjax._src.core.datatypes.generative import (
+    AllSelection,
+    Choice,
+    ChoiceMap,
+    ChoiceValue,
+    DisjointUnionChoiceMap,
+    EmptyChoice,
+    HierarchicalChoiceMap,
+    HierarchicalSelection,
+    Selection,
+)
+from genjax._src.core.datatypes.trie import Trie
+from genjax._src.core.pytree.checks import (
+    static_check_tree_leaves_have_matching_leading_dim,
+)
+from genjax._src.core.typing import IntArray
+from genjax._src.generative_functions.combinators.vector.vector_datatypes import (
+    IndexedChoiceMap,
+    IndexedSelection,
+    VectorChoiceMap,
+)
+
+
+def trie_from_dict(constraints: dict):
+    trie = Trie()
+    for k, v in constraints.items():
+        if isinstance(v, dict):
+            trie[k] = trie_from_dict(v)
+        else:
+            trie[k] = choice_map(v)
+    return trie
+
+def choice_map(*vs) -> ChoiceMap:
+    """Shortcut constructor for GenJAX ChoiceMap objects.
+
+    When called with no arguments, returns an empty (mutable) choice map which
+    you can populate using the subscript operator as in
+
+        ```python
+        chm = genjax.choice_map()
+        chm["x"] = 3.0
+        ```
+
+    When called with a dictionary argument, the equivalent HierarchicalChoiceMap
+    will be created and returned. (Exception: in the event that all the keys in
+    the dictory are integers, an IndexedChoiceMap is produced.)
+
+    When called with a single argument of any other type, constructs a ChoiceValue.
+
+    Finally, if called with a sequence of other ChoiceMap objects, produces a
+    DisjointUnionChoiceMap.
+    """
+    if len(vs) == 0:
+        return HierarchicalChoiceMap()
+    elif len(vs) == 1:
+        v = vs[0]
+        if isinstance(v, Choice):
+            return v
+        elif isinstance(v, dict):
+            if all(isinstance(k, int) for k in v.keys()):
+                return IndexedChoiceMap.from_dict(v)
+            else:
+                return HierarchicalChoiceMap(trie_from_dict(v))
+        else:
+            return ChoiceValue(v)
+    else:
+        if not all(map(lambda m: isinstance(m, ChoiceMap), vs)):
+            raise TypeError(
+                "To create a union ChoiceMap, all arguments must be ChoiceMaps"
+            )
+        return DisjointUnionChoiceMap(*vs)
+
+
+def indexed_choice_map(ks: ArrayLike, inner: ChoiceMap) -> Union[IndexedChoiceMap, EmptyChoice]:
+    if isinstance(inner, EmptyChoice):
+        return inner
+
+    indices = jnp.array(ks, copy=False)
+    static_check_tree_leaves_have_matching_leading_dim((inner, indices))
+    return IndexedChoiceMap(jnp.array(ks), choice_map(inner))
+
+def vector_choice_map(c):
+    if isinstance(c, EmptyChoice):
+        return c
+    elif isinstance(c, ChoiceMap):
+        return VectorChoiceMap(c)
+    elif isinstance(c, dict):
+        return VectorChoiceMap(choice_map(c))
+    else:
+        raise NotImplementedError(f"Creating VectorChoiceMap from {type(c)}")
+
+def indexed_select(idx: Union[int, IntArray], *choices: Selection):
+    idx = jnp.atleast_1d(idx)
+    if len(choices) == 0:
+        return IndexedSelection(idx, AllSelection())
+    elif len(choices) == 1 and isinstance(choices[0], Selection):
+        return IndexedSelection(idx, choices[0])
+    else:
+        return IndexedSelection(idx, HierarchicalSelection.from_addresses(choices))
+
+
+__all__ = [
+    "choice_map",
+    "indexed_choice_map",
+    "vector_choice_map",
+    "indexed_select"
+]

--- a/src/genjax/shortcuts.py
+++ b/src/genjax/shortcuts.py
@@ -67,14 +67,14 @@ def choice_map(*vs: ChoiceMappable) -> ChoiceMap:
         chm["x"] = 3.0
         ```
 
-    When called with a dictionary argument, the equivalent HierarchicalChoiceMap
+    When called with a dictionary argument, the equivalent :py:class:`HierarchicalChoiceMap`
     will be created and returned. (Exception: in the event that all the keys in
-    the dict are integers, an IndexedChoiceMap is produced.)
+    the dict are integers, an :py:class:`IndexedChoiceMap` is produced.)
 
-    When called with a single argument of any other type, constructs a ChoiceValue.
+    When called with a single argument of any other type, constructs a :py:class:`ChoiceValue`.
 
-    Finally, if called with a sequence of other ChoiceMap objects, produces a
-    DisjointUnionChoiceMap.
+    Finally, if called with a sequence of other :py:class:`ChoiceMap` objects, produces a
+    :py:class:`DisjointUnionChoiceMap`.
     """
     if len(vs) == 0:
         return HierarchicalChoiceMap()
@@ -100,10 +100,10 @@ def indexed_choice_map(
 ) -> Union[IndexedChoiceMap, EmptyChoice]:
     """Construct an indexed choice map from an array of indices and an inner choice map.
 
-    The indices may be a bare integer, or a list or [[jnp.Array]] of integers; it will be
-    promoted to a [[jnp.Array]] if needed.
+    The indices may be a bare integer, or a list or :py:class:`jnp.Array` of integers;
+    it will be promoted to a :py:class:`jnp.Array` if needed.
 
-    The inner choice map can of any form accepted by the shortcut [[choice_map]].
+    The inner choice map can of any form accepted by the shortcut py:func:`choice_map`.
     """
     if isinstance(inner, EmptyChoice):
         return inner
@@ -116,8 +116,8 @@ def indexed_choice_map(
 def vector_choice_map(c: ChoiceMappable) -> VectorChoiceMap:
     """Construct a vector choice map from the given one.
 
-    If `c` is the [[EmptyChoice]], it is returned unmodified; otherwise
-    `c` may be of any type accepted by the [[choice_map]] shortcut;
+    If `c` is the :py:class:`EmptyChoice`, it is returned unmodified; otherwise
+    `c` may be of any type accepted by the :py:func:`choice_map` shortcut;
     the result is `VectorChoiceMap(choice_map(c))`.
     """
     if isinstance(c, EmptyChoice):

--- a/src/genjax/shortcuts.py
+++ b/src/genjax/shortcuts.py
@@ -48,6 +48,7 @@ def trie_from_dict(constraints: dict):
             trie[k] = choice_map(v)
     return trie
 
+
 def choice_map(*vs) -> ChoiceMap:
     """Shortcut constructor for GenJAX ChoiceMap objects.
 
@@ -89,13 +90,16 @@ def choice_map(*vs) -> ChoiceMap:
         return DisjointUnionChoiceMap(*vs)
 
 
-def indexed_choice_map(ks: ArrayLike, inner: ChoiceMap) -> Union[IndexedChoiceMap, EmptyChoice]:
+def indexed_choice_map(
+    ks: ArrayLike, inner: ChoiceMap
+) -> Union[IndexedChoiceMap, EmptyChoice]:
     if isinstance(inner, EmptyChoice):
         return inner
 
     indices = jnp.array(ks, copy=False)
     static_check_tree_leaves_have_matching_leading_dim((inner, indices))
     return IndexedChoiceMap(jnp.array(ks), choice_map(inner))
+
 
 def vector_choice_map(c):
     if isinstance(c, EmptyChoice):
@@ -107,6 +111,7 @@ def vector_choice_map(c):
     else:
         raise NotImplementedError(f"Creating VectorChoiceMap from {type(c)}")
 
+
 def indexed_select(idx: Union[int, IntArray], *choices: Selection):
     idx = jnp.atleast_1d(idx)
     if len(choices) == 0:
@@ -117,9 +122,4 @@ def indexed_select(idx: Union[int, IntArray], *choices: Selection):
         return IndexedSelection(idx, HierarchicalSelection.from_addresses(choices))
 
 
-__all__ = [
-    "choice_map",
-    "indexed_choice_map",
-    "vector_choice_map",
-    "indexed_select"
-]
+__all__ = ["choice_map", "indexed_choice_map", "vector_choice_map", "indexed_select"]

--- a/tests/core/test_shortcuts.py
+++ b/tests/core/test_shortcuts.py
@@ -1,0 +1,61 @@
+
+# Copyright 2023 MIT Probabilistic Computing Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import genjax
+import jax.numpy as jnp
+
+
+class TestShortcuts:
+    def test_no_args_gives_empty_map(self):
+        assert genjax.choice_map() == genjax.HierarchicalChoiceMap()
+
+    def test_bare_value_gives_choice_value(self):
+        assert genjax.choice_map(3) == genjax.ChoiceValue(3)
+        v1 = genjax.choice_map(jnp.array([1.0, 2.0]))
+        v2 = genjax.ChoiceValue(jnp.array([1.0, 2.0]))
+        assert isinstance(v1, genjax.ChoiceValue) and (v1.value == v2.value).all()
+
+    def test_choice_map_from_dict(self):
+        hcm = genjax.HierarchicalChoiceMap()
+        hcm["x"] = 3
+        hcm["y"] = 4
+        assert genjax.choice_map({
+            "x": 3,
+            "y": 4
+        }) == hcm
+
+    def test_hierarchical_choice_map_from_dict(self):
+        hcm = genjax.HierarchicalChoiceMap()
+        hcm["x", "xa"] = 3
+        hcm["x", "xb"] = 4
+        hcm["y", "ya"] = 5
+        hcm["y", "yb"] = 6
+        assert genjax.choice_map({
+            "x": { "xa": 3, "xb": 4 },
+            "y": { "ya": 5, "yb": 6 },
+        }) == hcm
+
+    def test_indexed_choice_map(self):
+        icm1 = genjax.indexed_choice_map(jnp.array([1, 2, 3]), genjax.choice_map({"x": jnp.array([10, 20, 30])}))
+        icm2 = genjax.choice_map({
+            1: 10,
+            2: 20,
+            3: 30
+        })
+        for j in range(1, 4):
+            for m in [icm1, icm2]:
+                assert m.has_submap((j, "x"))
+                assert m[(j, "x")].unmask() == 10*j

--- a/tests/core/test_shortcuts.py
+++ b/tests/core/test_shortcuts.py
@@ -1,4 +1,3 @@
-
 # Copyright 2023 MIT Probabilistic Computing Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,10 +31,7 @@ class TestShortcuts:
         hcm = genjax.HierarchicalChoiceMap()
         hcm["x"] = 3
         hcm["y"] = 4
-        assert genjax.choice_map({
-            "x": 3,
-            "y": 4
-        }) == hcm
+        assert genjax.choice_map({"x": 3, "y": 4}) == hcm
 
     def test_hierarchical_choice_map_from_dict(self):
         hcm = genjax.HierarchicalChoiceMap()
@@ -43,19 +39,22 @@ class TestShortcuts:
         hcm["x", "xb"] = 4
         hcm["y", "ya"] = 5
         hcm["y", "yb"] = 6
-        assert genjax.choice_map({
-            "x": { "xa": 3, "xb": 4 },
-            "y": { "ya": 5, "yb": 6 },
-        }) == hcm
+        assert (
+            genjax.choice_map(
+                {
+                    "x": {"xa": 3, "xb": 4},
+                    "y": {"ya": 5, "yb": 6},
+                }
+            )
+            == hcm
+        )
 
     def test_indexed_choice_map(self):
-        icm1 = genjax.indexed_choice_map(jnp.array([1, 2, 3]), genjax.choice_map({"x": jnp.array([10, 20, 30])}))
-        icm2 = genjax.choice_map({
-            1: 10,
-            2: 20,
-            3: 30
-        })
+        icm1 = genjax.indexed_choice_map(
+            jnp.array([1, 2, 3]), genjax.choice_map({"x": jnp.array([10, 20, 30])})
+        )
+        icm2 = genjax.choice_map({1: 10, 2: 20, 3: 30})
         for j in range(1, 4):
             for m in [icm1, icm2]:
                 assert m.has_submap((j, "x"))
-                assert m[(j, "x")].unmask() == 10*j
+                assert m[(j, "x")].unmask() == 10 * j

--- a/tests/inference/smc/test_basic_smc.py
+++ b/tests/inference/smc/test_basic_smc.py
@@ -45,7 +45,7 @@ class TestSimpleSMC:
             choice_map({"x": jnp.array([1.0])}),
         )
         key, sub_key = jax.random.split(key)
-        smc_state = smc.smc_initialize(chain, 100).apply(
+        smc_state = smc.smc_initialize(chain, n_particles=100).apply(
             sub_key, obs, (init_len, init_state)
         )
         obs = indexed_choice_map(
@@ -78,7 +78,7 @@ class TestSimpleSMC:
         def extend_smc_no_resampling(key, obs, init_state):
             obs_slice = obs.slice(0)
             key, sub_key = jax.random.split(key)
-            smc_state = smc.smc_initialize(chain, 100).apply(
+            smc_state = smc.smc_initialize(chain, n_particles=100).apply(
                 sub_key, obs_slice, (0, init_state)
             )
             obs = jtu.tree_map(lambda v: v[1:], obs)
@@ -123,7 +123,7 @@ class TestSimpleSMC:
         def extending_smc(key, obs, init_state):
             obs_slice = obs.slice(0)
             key, sub_key = jax.random.split(key)
-            smc_state = smc.smc_initialize(chain, 100).apply(
+            smc_state = smc.smc_initialize(chain, n_particles=100).apply(
                 sub_key, obs_slice, (0, init_state)
             )
             obs = jtu.tree_map(lambda v: v[1:], obs)
@@ -200,7 +200,7 @@ class TestSimpleSMC:
                 ),
             )
 
-        smc_state = jax.jit(genjax.smc.smc_initialize(chain, 5).apply)(
+        smc_state = jax.jit(genjax.smc.smc_initialize(chain, n_particles=5).apply)(
             key, make_choice_map(0), (0, jnp.ones(361))
         )
 


### PR DESCRIPTION
- the only one left is DataSharedSumTree.new; that constructor name could be changed, but it's not apparent what a better name would be.

- There are some news in the runtime debugger, but that's not shipping with the next version so I left it alone

I created a new module, genjax.shortcuts, to hold things like choice_map(). Doing so allows a single function to create any kind of choice map without circular import problems and allows a single point of documentation for the shortcut policy.

The SMC things had an unusual parameter order dicatated by the JAX/static requirement, so I made n_particles a required keyword parameter of the shortcut to keep things looking nice.