### PR TITLE
Add pypi release GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11.5
+
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Configure deploy key
+        run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_KEY }}
+
+      - name: Install deps
+        run: poetry install
+
+      - name: Deploy to PyPI
+        run: poetry publish --build


### PR DESCRIPTION
This PR adds an action that will deploy to PyPI on the creation of a new release: https://github.com/probcomp/genjax/releases