### PR TITLE
Run notebooks on docs deploy, strip cell output in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,19 +13,24 @@
 # limitations under the License.
 
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
-  hooks:
-    - id: check-yaml
-      args: [--unsafe]
-    - id: end-of-file-fixer
-    - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+        args: [--unsafe]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
 
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.11
-  hooks:
-    - id: ruff
-      types_or: [ python, pyi, jupyter ]
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.1
+    hooks:
+      - id: nbstripout
 
-    - id: ruff-format
-      types_or: [ python, pyi, jupyter ]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.11
+    hooks:
+      - id: ruff
+        types_or: [ python, pyi, jupyter ]
+
+      - id: ruff-format
+        types_or: [ python, pyi, jupyter ]

--- a/notebooks/advanced/smc_language/smc_language.ipynb
+++ b/notebooks/advanced/smc_language/smc_language.ipynb
@@ -50,7 +50,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/advanced/smc_language/smc_language.ipynb
+++ b/notebooks/advanced/smc_language/smc_language.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "26771b31-4710-4ae3-960d-a643873461e4",
    "metadata": {},
    "outputs": [],

--- a/notebooks/concepts/incremental_computation/incremental.ipynb
+++ b/notebooks/concepts/incremental_computation/incremental.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "id": "79bc5678-235d-441c-9cc0-2ecd8f31daed",
    "metadata": {},
    "outputs": [],
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "id": "feb13e84-c9a6-4845-8271-841903b0eb14",
    "metadata": {},
    "outputs": [],
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "id": "3aa8bfe6-fa2e-4b81-8e69-bca3e05e3ecb",
    "metadata": {},
    "outputs": [],
@@ -152,21 +152,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "id": "859e6b77-40ff-4dc4-9206-9c745862a361",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "StaticTrace(gen_fn=StaticGenerativeFunction(source=<function model at 0x130649120>), args=(2.0,), retval=Array(3.6991668, dtype=float32), address_choices=Trie(inner={'a': DistributionTrace(gen_fn=TFPDistribution(make_distribution=<class 'tensorflow_probability.substrates.jax.distributions.normal.Normal'>), args=(2.0, 1.0), value=Array(0.32779634, dtype=float32), score=Array(-2.317071, dtype=float32)), 'b': DistributionTrace(gen_fn=TFPDistribution(make_distribution=<class 'tensorflow_probability.substrates.jax.distributions.normal.Normal'>), args=(2.0, 1.0), value=Array(1.6706116, dtype=float32), score=Array(-0.97318685, dtype=float32)), 'c': DistributionTrace(gen_fn=TFPDistribution(make_distribution=<class 'tensorflow_probability.substrates.jax.distributions.normal.Normal'>), args=(Array(1.998408, dtype=float32), 1.0), value=Array(3.6991668, dtype=float32), score=Array(-2.3652287, dtype=float32))}), cache=Trie(inner={}), score=Array(-5.6554866, dtype=float32))"
-      ]
-     },
-     "execution_count": 58,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "key, sub_key = jax.random.split(key)\n",
     "tr = model.simulate(sub_key, (2.0,))\n",
@@ -187,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "id": "5488356c-fba5-49cb-8ae5-851548dc0855",
    "metadata": {},
    "outputs": [],
@@ -300,21 +289,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "id": "b80ae672-4b0d-46b5-9b64-1323639e9861",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Diff(primal=5.0, tangent=_NoChange())"
-      ]
-     },
-     "execution_count": 60,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Diff(5.0, NoChange)"
    ]
@@ -337,21 +315,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "id": "a25241e2-237c-47c3-8c7b-edf1d0258ff0",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DistributionTrace(gen_fn=TFPDistribution(make_distribution=<class 'tensorflow_probability.substrates.jax.distributions.normal.Normal'>), args=(0.0, 1.0), value=Array(0.27442896, dtype=float32), score=Array(-0.95659417, dtype=float32))"
-      ]
-     },
-     "execution_count": 61,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "key, sub_key = jax.random.split(key)\n",
     "dist_tr = genjax.normal.simulate(sub_key, (0.0, 1.0))\n",
@@ -360,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "id": "329f3c3a-4e9c-4a8a-b222-9b596e8197ba",
    "metadata": {},
    "outputs": [],
@@ -388,21 +355,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "id": "b4140fd3-4cf0-4f94-81de-766c71ef484b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(Array(0.27442896, dtype=float32), Array(0.27442896, dtype=float32))"
-      ]
-     },
-     "execution_count": 63,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "(dist_tr.get_retval(), ret_diff.get_retval())"
    ]
@@ -417,21 +373,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "id": "628a16ba-a3c8-493b-8ce0-5dfdc22cb568",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Array(-0.22557098, dtype=float32)"
-      ]
-     },
-     "execution_count": 64,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "w"
    ]
@@ -446,23 +391,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "id": "516ce45c-b0f4-49b8-8a96-ab47c2954a92",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{ lambda a:f32[] b:f32[]; c:u32[2] d:f32[] e:f32[]. let\n",
-       "    \n",
-       "  in (0.0, 1.0, a, b, 0.0, a) }"
-      ]
-     },
-     "execution_count": 65,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# dist_tr.update is equivalent to model.update(key, tr, ...)\n",
     "jaxpr = jax.make_jaxpr(dist_tr.update)(\n",

--- a/notebooks/intermediate/smc/smc_with_translators.ipynb
+++ b/notebooks/intermediate/smc/smc_with_translators.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "a884970f-6e4e-4646-a5a2-15131259c100",
    "metadata": {
     "tags": []
@@ -143,26 +143,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "01ee209e-46fd-4554-ae1c-bb73af5301d6",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3.9875028</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1;36m3.9875028\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from jax.experimental.checkify import checkify\n",
     "\n",

--- a/notebooks/internals/developers/jax_intro.ipynb
+++ b/notebooks/internals/developers/jax_intro.ipynb
@@ -268,7 +268,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/internals/developers/jax_intro.ipynb
+++ b/notebooks/internals/developers/jax_intro.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "01a048ad-10ec-49ef-b07d-79f122fd0026",
    "metadata": {
     "tags": []
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "a67d57af-851b-40a7-9ffa-1d9b05d0c942",
    "metadata": {
     "tags": []
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "ef7e0ef3-2d07-49fe-ba8b-39845b6d5fa8",
    "metadata": {
     "tags": []
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "23380f35-fad5-413a-bc56-6662841e2f57",
    "metadata": {
     "tags": []
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "68ca8568-afeb-481b-adb7-c2ba7565f658",
    "metadata": {
     "tags": []
@@ -145,31 +145,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "23cbce0b-3305-42a6-8334-5a14fe2a6d70",
    "metadata": {
     "tags": [
      "raises-exception"
     ]
    },
-   "outputs": [
-    {
-     "ename": "NotImplementedError",
-     "evalue": "Abstract evaluation for 'foo' not implemented",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[12], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mjax\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmake_jaxpr\u001b[49m\u001b[43m(\u001b[49m\u001b[43mf\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m5.0\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "    \u001b[0;31m[... skipping hidden 6 frame]\u001b[0m\n",
-      "Cell \u001b[0;32mIn[11], line 2\u001b[0m, in \u001b[0;36mf\u001b[0;34m(x)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mf\u001b[39m(x):\n\u001b[0;32m----> 2\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfoo\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[10], line 2\u001b[0m, in \u001b[0;36mfoo\u001b[0;34m(*args)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mfoo\u001b[39m(\u001b[38;5;241m*\u001b[39margs):\n\u001b[0;32m----> 2\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfoo_p\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbind\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "    \u001b[0;31m[... skipping hidden 4 frame]\u001b[0m\n",
-      "File \u001b[0;32m~/research/genjax/.nox/jupyter/lib/python3.11/site-packages/jax/_src/core.py:369\u001b[0m, in \u001b[0;36mPrimitive.abstract_eval\u001b[0;34m(self, *args, **params)\u001b[0m\n\u001b[1;32m    368\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mabstract_eval\u001b[39m(\u001b[38;5;28mself\u001b[39m, \u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mparams):\n\u001b[0;32m--> 369\u001b[0m   \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mAbstract evaluation for \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m not implemented\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    370\u001b[0m                             \u001b[38;5;241m.\u001b[39mformat(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mname))\n",
-      "\u001b[0;31mNotImplementedError\u001b[0m: Abstract evaluation for 'foo' not implemented"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "jax.make_jaxpr(f)(5.0)"
    ]
@@ -186,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "848c5a59-3cc5-4f93-845a-7da5ea620908",
    "metadata": {
     "tags": []

--- a/noxfile.py
+++ b/noxfile.py
@@ -171,7 +171,9 @@ def docs_build(session: Session) -> None:
     if build_dir.exists():
         shutil.rmtree(build_dir)
     session.run("poetry", "run", "mkdocs", "build")
-    session.run("quarto", "render", "notebooks", external=True)
+    session.run(
+        "poetry", "run", "quarto", "render", "notebooks", "--execute", external=True
+    )
 
 
 @session(name="docs-serve", python=python_version)


### PR DESCRIPTION
This PR:

- Strips all cell outputs from the git-committed version of the notebooks
- re-generates all outputs in the `docs-build` task