### PR TITLE
Test docs in CI, all docs in strict mode

### DIFF
--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -1,4 +1,4 @@
-name: Test Docs
+name: Test mkdocs build
 
 on:
   pull_request:
@@ -26,9 +26,6 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.INSIDER_SSH_KEY }}
 
-      - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
-
       - uses: actions/setup-python@v4
         with:
           python-version: 3.11.5
@@ -43,4 +40,4 @@ jobs:
         run: pip install nox-poetry
 
       - name: Run Docs Build
-        run: nox -r -s docs-build
+        run: nox -r -s mkdocs

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -1,0 +1,46 @@
+name: Test Docs
+
+on:
+  pull_request:
+
+env:
+  POETRY_EXPERIMENTAL_SYSTEM_GIT_CLIENT: true
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # This works via GitHub's "deploy keys". This repo has a secret set up
+      # with the private key, and the mkdocs-material-insiders clone in the
+      # library has the public key set as a deploy key.
+      - name: Configure SSH key for mkdocs-material-insiders
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.INSIDER_SSH_KEY }}
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11.5
+
+      - name: Setup Nox
+        uses: daisylb/setup-nox@v2.1.0
+
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Install nox-poetry
+        run: pip install nox-poetry
+
+      - name: Run Docs Build
+        run: nox -r -s docs-build

--- a/noxfile.py
+++ b/noxfile.py
@@ -161,6 +161,18 @@ def build(session):
     session.run("poetry", "build")
 
 
+@session(name="mkdocs", python=python_version)
+def mkdocs(session: Session) -> None:
+    """run the mkdocs-only portion of the docs build."""
+    session.run_always(
+        "poetry", "install", "--with", "docs", "--with", "dev", external=True
+    )
+    build_dir = Path("site")
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+    session.run("poetry", "run", "mkdocs", "build", "--strict")
+
+
 @session(name="docs-build", python=python_version)
 def docs_build(session: Session) -> None:
     """Build the documentation."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -170,7 +170,7 @@ def docs_build(session: Session) -> None:
     build_dir = Path("site")
     if build_dir.exists():
         shutil.rmtree(build_dir)
-    session.run("poetry", "run", "mkdocs", "build")
+    session.run("poetry", "run", "mkdocs", "build", "--strict")
     session.run(
         "poetry", "run", "quarto", "render", "notebooks", "--execute", external=True
     )


### PR DESCRIPTION
This PR checks that the docs (via mkdocs) don't contain any errors by running in strict mode.

The new action only runs on PRs, since the docs build happens anyway 