### PR TITLE
Split sugar callee methods into `__call__` and `apply`.

### DIFF
--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -47,6 +47,8 @@ Hashable = btyping.Hashable
 FrozenSet = btyping.FrozenSet
 Optional = btyping.Optional
 Type = btyping.Type
+Protocol = btyping.Protocol
+
 
 # Types of Python literals.
 Int = int

--- a/src/genjax/_src/generative_functions/supports_callees.py
+++ b/src/genjax/_src/generative_functions/supports_callees.py
@@ -14,16 +14,15 @@
 
 from dataclasses import dataclass
 
-from genjax._src.core.datatypes.generative import GenerativeFunction
 from genjax._src.core.pytree.pytree import Pytree
-from genjax._src.core.typing import Any, Dict, PRNGKey, Tuple
+from genjax._src.core.typing import Any, Callable, Dict, List, PRNGKey, Protocol, Tuple
 
 
 # This class is used to allow syntactic sugar (e.g. the `@` operator)
 # in languages which support callees for generative functions via a `trace` intrinsic.
 @dataclass
 class SugaredGenerativeFunctionCall(Pytree):
-    gen_fn: GenerativeFunction
+    gen_fn: Callable
     kwargs: Dict
     args: Tuple
 
@@ -38,10 +37,10 @@ class SugaredGenerativeFunctionCall(Pytree):
 # C.f. above.
 # This stack will not interact with JAX tracers at all
 # so it's safe, and will be resolved at JAX tracing time.
-GLOBAL_TRACE_HANDLER_STACK = []
+GLOBAL_TRACE_HANDLER_STACK: List[Callable] = []
 
 
-def handle_off_trace_stack(addr, gen_fn, args):
+def handle_off_trace_stack(addr, gen_fn: Callable, args):
     handler = GLOBAL_TRACE_HANDLER_STACK[-1]
     return handler(addr, gen_fn, args)
 
@@ -56,11 +55,21 @@ def push_trace_overload_stack(handler, fn):
     return wrapped
 
 
+class CanSimulate(Protocol):
+    def simulate(self, key: PRNGKey, args: Tuple) -> Any:
+        ...
+
+    def __call__(self, *args, **kwargs) -> Any:
+        ...
+
+
 # This mixin overloads the call functionality for this generative function
 # and allows usage of shorthand notation in the static DSL.
 class SupportsCalleeSugar:
-    def __call__(self, *args: Any, **kwargs) -> SugaredGenerativeFunctionCall:
+    def __call__(
+        self: CanSimulate, *args: Any, **kwargs
+    ) -> SugaredGenerativeFunctionCall:
         return SugaredGenerativeFunctionCall(self, kwargs, args)
 
-    def apply(self, key: PRNGKey, args: Tuple) -> Any:
+    def apply(self: CanSimulate, key: PRNGKey, args: Tuple) -> Any:
         return self.simulate(key, args).get_retval()

--- a/src/genjax/_src/generative_functions/supports_callees.py
+++ b/src/genjax/_src/generative_functions/supports_callees.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 
 from genjax._src.core.datatypes.generative import GenerativeFunction
 from genjax._src.core.pytree.pytree import Pytree
-from genjax._src.core.typing import Any, Dict, PRNGKey, Tuple, dispatch
+from genjax._src.core.typing import Any, Dict, PRNGKey, Tuple
 
 
 # This class is used to allow syntactic sugar (e.g. the `@` operator)
@@ -59,10 +59,8 @@ def push_trace_overload_stack(handler, fn):
 # This mixin overloads the call functionality for this generative function
 # and allows usage of shorthand notation in the static DSL.
 class SupportsCalleeSugar:
-    @dispatch
     def __call__(self, *args: Any, **kwargs) -> SugaredGenerativeFunctionCall:
         return SugaredGenerativeFunctionCall(self, kwargs, args)
 
-    @dispatch
     def apply(self, key: PRNGKey, args: Tuple) -> Any:
         return self.simulate(key, args).get_retval()

--- a/src/genjax/_src/generative_functions/supports_callees.py
+++ b/src/genjax/_src/generative_functions/supports_callees.py
@@ -64,7 +64,5 @@ class SupportsCalleeSugar:
         return SugaredGenerativeFunctionCall(self, kwargs, args)
 
     @dispatch
-    def __call__(self, key: PRNGKey, args: Tuple) -> Any:
-        tr = self.simulate(key, args)
-        retval = tr.get_retval()
-        return retval
+    def apply(self, key: PRNGKey, args: Tuple) -> Any:
+        return self.simulate(key, args).get_retval()

--- a/tests/generative_functions/test_interpreted_language.py
+++ b/tests/generative_functions/test_interpreted_language.py
@@ -569,7 +569,7 @@ class TestInterpretedLanguageSugar:
         tr = simple_normal.simulate(key, ())
 
         key = jax.random.PRNGKey(314159)
-        v = simple_normal(key, ())
+        v = simple_normal.apply(key, ())
         assert tr.get_retval() == v
 
 

--- a/tests/generative_functions/test_static_language.py
+++ b/tests/generative_functions/test_static_language.py
@@ -542,7 +542,7 @@ class TestStaticLanguageSugar:
         tr = simple_normal.simulate(key, ())
 
         key = jax.random.PRNGKey(314159)
-        v = simple_normal(key, ())
+        v = simple_normal.apply(key, ())
         assert tr.get_retval() == v
 
 


### PR DESCRIPTION
One usability issue that remains in GenJAX is that `@dispatch` is used for two implementations of `__call__` in SugaredGenerativeFunctionCall. IDEs will type-check against one or the other, and typically pick the `(key, *args)` form, since it's defined later, and appears to override the `(*args, **kwargs)` form.

Having a `@dispatch` on __call__ thus "redlines" all the users' function invoications.

I therefore propose that we take the less-common use, where you manually supply the key and pass the args as a tuple, and rename it `apply`, by analogy with LISP, where apply is used when you already have your arguments in a list and don't want to splat them out into a function call.

Using the technique described [here](https://stackoverflow.com/questions/51930339/how-do-i-correctly-add-type-hints-to-mixin-classes), added type information for `SupportsCalleeSugar` to describe the constrains it imposes on the class into which it is mixed 