### PR TITLE
Fix tag-based versioning in Release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Poetry uses the list of tags to assign a version during actions. There is also a `fetch-tags` option https://github.com/actions/checkout/pull/579, but it bugs out currently when you try and use it on an action that was triggered by the creation of a tag. We can try that, but let's see how slow this is on the next release.

TODO:

 - [ ] fix the pypi logo by uploading to to CDN on GitHub?
 - [ ] Run `poetry self add "poetry-dynamic-versioning[plugin]"` in the Poetry install for the GitHub action