### PR TITLE
link interpreted Jupyter demo to doc tree. Some interpreted code golf.

### DIFF
--- a/notebooks/_quarto.yml
+++ b/notebooks/_quarto.yml
@@ -38,6 +38,9 @@ website:
           - href: concepts/introduction/intro_to_genjax.ipynb
             text: Introduction
 
+          - href: concepts/introduction/intro_interpreted.ipynb
+            text: Introduction (interpreted dialect)
+
           - href: concepts/incremental_computation/incremental.ipynb
             text: (WIP) Incremental computing
 

--- a/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
+++ b/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
@@ -18,7 +18,6 @@ import jax
 import jax.numpy as jnp
 from tensorflow_probability.substrates import jax as tfp
 
-from genjax._src.core.datatypes.generative import JAXGenerativeFunction
 from genjax._src.core.typing import Callable, Sequence
 from genjax._src.generative_functions.distributions.distribution import ExactDensity
 
@@ -26,7 +25,7 @@ tfd = tfp.distributions
 
 
 @dataclass
-class TFPDistribution(JAXGenerativeFunction, ExactDensity):
+class TFPDistribution(ExactDensity):
     """
     A `GenerativeFunction` wrapper around [TensorFlow Probability distributions](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions).
 

--- a/src/genjax/_src/generative_functions/interpreted/fn.py
+++ b/src/genjax/_src/generative_functions/interpreted/fn.py
@@ -81,6 +81,7 @@ class Handler(object):
     def handle(self, gen_fn: GenerativeFunction, args: Tuple, addr: Any):
         raise NotImplementedError
 
+
 # A primitive used in our language to denote invoking another generative function.
 # Its behavior depends on the handler which is at the top of the stack
 # when the primitive is invoked.

--- a/src/genjax/_src/generative_functions/interpreted/fn.py
+++ b/src/genjax/_src/generative_functions/interpreted/fn.py
@@ -17,7 +17,6 @@
 # implementation (c.f. Pyro's [`poutine`](https://docs.pyro.ai/en/stable/poutine.html)
 # for instance, although the code in this module is quite readable and localized).
 
-import abc
 import functools
 import itertools
 from dataclasses import dataclass, field
@@ -46,7 +45,6 @@ from genjax._src.core.typing import (
     Any,
     ArrayLike,
     Callable,
-    FloatArray,
     List,
     PRNGKey,
     Tuple,
@@ -59,15 +57,15 @@ from genjax.core.exceptions import AddressReuse
 
 # Our main idiom to express non-standard interpretation is an
 # (effect handler)-inspired dispatch stack.
-_INTERPRETED_STACK = []
+_INTERPRETED_STACK: List["Handler"] = []
 
 
 # When `handle` is invoked, it dispatches the information in `msg`
 # to the handler at the top of the stack (end of list).
-def handle(msg):
+def handle(gen_fn: GenerativeFunction, args: Tuple, addr: Any):
     assert _INTERPRETED_STACK
     handler = _INTERPRETED_STACK[-1]
-    v = handler.process_message(msg)
+    v = handler.handle(gen_fn, args, addr)
     return v
 
 
@@ -80,18 +78,15 @@ class Handler(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is None:
-            assert _INTERPRETED_STACK[-1] is self
-            _INTERPRETED_STACK.pop()
+            p = _INTERPRETED_STACK.pop()
+            assert p is self
         else:
             if self in _INTERPRETED_STACK:
                 loc = _INTERPRETED_STACK.index(self)
-                for _ in range(loc, len(_INTERPRETED_STACK)):
-                    _INTERPRETED_STACK.pop()
+                del _INTERPRETED_STACK[loc:]
 
-    @abc.abstractmethod
-    def process_message(self, msg):
-        pass
-
+    def handle(self, gen_fn: GenerativeFunction, args: Tuple, addr: Any):
+        raise NotImplementedError
 
 # A primitive used in our language to denote invoking another generative function.
 # Its behavior depends on the handler which is at the top of the stack
@@ -113,14 +108,7 @@ def trace(addr: Any, gen_fn: GenerativeFunction) -> Callable:
     assert _INTERPRETED_STACK
 
     def invoke(*args: Tuple):
-        return handle(
-            {
-                "type": "trace",
-                "addr": addr,
-                "gen_fn": gen_fn,
-                "args": args,
-            }
-        )
+        return handle(gen_fn, args, addr)
 
     # Defer the behavior of this call to the handler.
     return invoke
@@ -157,10 +145,7 @@ class SimulateHandler(Handler):
     choice_state: Trie = field(default_factory=Trie)
     trace_visitor: AddressVisitor = field(default_factory=AddressVisitor)
 
-    def process_message(self, msg):
-        gen_fn = msg["gen_fn"]
-        args = msg["args"]
-        addr = msg["addr"]
+    def handle(self, gen_fn: GenerativeFunction, args: Tuple, addr: Any):
         self.trace_visitor.visit(addr)
         self.key, sub_key = jax.random.split(self.key)
         tr = gen_fn.simulate(sub_key, args)
@@ -180,10 +165,7 @@ class ImportanceHandler(Handler):
     choice_state: Trie = field(default_factory=Trie)
     trace_visitor: AddressVisitor = field(default_factory=AddressVisitor)
 
-    def process_message(self, msg):
-        gen_fn = msg["gen_fn"]
-        args = msg["args"]
-        addr = msg["addr"]
+    def handle(self, gen_fn: GenerativeFunction, args: Tuple, addr: Any):
         self.trace_visitor.visit(addr)
         sub_map = self.constraints.get_submap(addr)
         self.key, sub_key = jax.random.split(self.key)
@@ -206,10 +188,7 @@ class UpdateHandler(Handler):
     choice_state: Trie = field(default_factory=Trie)
     trace_visitor: AddressVisitor = field(default_factory=AddressVisitor)
 
-    def process_message(self, msg):
-        gen_fn = msg["gen_fn"]
-        args = msg["args"]
-        addr = msg["addr"]
+    def handle(self, gen_fn: GenerativeFunction, args: Tuple, addr: Any):
         self.trace_visitor.visit(addr)
         sub_map = self.constraints.get_submap(addr)
         # sub_trace = self.previous_trace.get_choices().get_submap(addr)
@@ -241,10 +220,7 @@ class AssessHandler(Handler):
     score: ArrayLike = 0.0
     trace_visitor: AddressVisitor = field(default_factory=AddressVisitor)
 
-    def process_message(self, msg):
-        gen_fn = msg["gen_fn"]
-        args = msg["args"]
-        addr = msg["addr"]
+    def handle(self, gen_fn: GenerativeFunction, args: Tuple, addr: Any):
         self.trace_visitor.visit(addr)
         sub_map = self.constraints.get_submap(addr)
         (score, retval) = gen_fn.assess(sub_map, args)
@@ -414,7 +390,7 @@ class InterpretedGenerativeFunction(GenerativeFunction, SupportsCalleeSugar):
         self,
         choice_map: ChoiceMap,
         args: Tuple,
-    ) -> Tuple[FloatArray | float, Any]:
+    ) -> Tuple[ArrayLike, Any]:
         syntax_sugar_handled = push_trace_overload_stack(
             handler_trace_with_interpreted, self.source
         )

--- a/src/genjax/_src/generative_functions/interpreted/fn.py
+++ b/src/genjax/_src/generative_functions/interpreted/fn.py
@@ -94,7 +94,7 @@ class Handler(object):
 
 
 # A primitive used in our language to denote invoking another generative function.
-# It's behavior depends on the handler which is at the top of the stack
+# Its behavior depends on the handler which is at the top of the stack
 # when the primitive is invoked.
 def trace(addr: Any, gen_fn: GenerativeFunction) -> Callable:
     """Invoke a generative function, binding its generative semantics with the

--- a/src/genjax/_src/generative_functions/static/static_gen_fn.py
+++ b/src/genjax/_src/generative_functions/static/static_gen_fn.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 
 from genjax._src.core.datatypes.generative import (
     Choice,
+    GenerativeFunction,
     HierarchicalChoiceMap,
     JAXGenerativeFunction,
     Trace,
@@ -55,7 +56,7 @@ from genjax._src.generative_functions.supports_callees import (
 @typecheck
 def handler_trace_with_static(
     addr,
-    gen_fn: JAXGenerativeFunction,
+    gen_fn: GenerativeFunction,
     args: Tuple,
 ):
     return trace(addr, gen_fn)(*args)

--- a/tests/generative_functions/test_interpreted_language.py
+++ b/tests/generative_functions/test_interpreted_language.py
@@ -759,3 +759,15 @@ class TestCombinator:
 
         assert model1.__doc__ == "model docstring"
         assert model2.__doc__ is None
+
+class TestMinimalInterpretedFunction:
+    def test(self):
+
+        @genjax.interpreted
+        def model():
+            y = genjax.normal(0.0, 1.0) @ "y"
+            return y
+
+        key = jax.random.PRNGKey(0)
+        tr = model.simulate(key, ())
+        assert jnp.abs(tr.get_retval() - jnp.array(-1.2515389)) < 1e-5

--- a/tests/generative_functions/test_interpreted_language.py
+++ b/tests/generative_functions/test_interpreted_language.py
@@ -760,9 +760,9 @@ class TestCombinator:
         assert model1.__doc__ == "model docstring"
         assert model2.__doc__ is None
 
+
 class TestMinimalInterpretedFunction:
     def test(self):
-
         @genjax.interpreted
         def model():
             y = genjax.normal(0.0, 1.0) @ "y"


### PR DESCRIPTION
We also relax type constraint on TFPDistribution. Formerly, `TFPDistribution` had both `ExactDensity` and `JAXGenerativeFunction` as type constraints. But:
- `ExactDensity` is a already subclass of `GenerativeFunction`, creating a diamond inheritance
- nothing in the implementation of `TFPDistribution` is JAX-specific and furthermore the interpreted dialect shares these implementations of probability distributions