### PR TITLE
Restore __abstract_call__ to distributions

### DIFF
--- a/src/genjax/_src/core/datatypes/generative.py
+++ b/src/genjax/_src/core/datatypes/generative.py
@@ -1197,13 +1197,6 @@ class GenerativeFunction(Pytree):
     ) -> Trace:
         raise NotImplementedError
 
-    def __abstract_call__(self, *args) -> Any:
-        """Used to support JAX tracing, although this default implementation
-        involves no JAX operations (it takes a fixed-key sample from the
-        return value). Generative functions may customize this to improve
-        compilation time."""
-        return self.simulate(jax.random.PRNGKey(0), args).get_retval()
-
 
 @dataclass
 class JAXGenerativeFunction(GenerativeFunction, Pytree):
@@ -1255,6 +1248,13 @@ class JAXGenerativeFunction(GenerativeFunction, Pytree):
         )
         choice_gradient_tree, _ = jax.grad(scorer)(grad, nograd)
         return choice_gradient_tree
+
+    def __abstract_call__(self, *args) -> Any:
+        """Used to support JAX tracing, although this default implementation
+        involves no JAX operations (it takes a fixed-key sample from the
+        return value). Generative functions may customize this to improve
+        compilation time."""
+        return self.simulate(jax.random.PRNGKey(0), args).get_retval()
 
 
 ########################

--- a/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
+++ b/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
@@ -18,6 +18,7 @@ import jax
 import jax.numpy as jnp
 from tensorflow_probability.substrates import jax as tfp
 
+from genjax._src.core.datatypes.generative import JAXGenerativeFunction
 from genjax._src.core.typing import Callable, Sequence
 from genjax._src.generative_functions.distributions.distribution import ExactDensity
 
@@ -25,7 +26,7 @@ tfd = tfp.distributions
 
 
 @dataclass
-class TFPDistribution(ExactDensity):
+class TFPDistribution(ExactDensity, JAXGenerativeFunction):
     """
     A `GenerativeFunction` wrapper around [TensorFlow Probability distributions](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions).
 


### PR DESCRIPTION
PR #875 removed diamond inheritance from ExactDensities but it turns out that to play nice with JAX the `__abstract_call__` method is needed. It has no JAX content of its own, so we move it up to GenerativeFunction, which shares the (innocuous) method with the interpreted dialect.

Or maybe it's necessary for the `ExactDensity` implementors to be `JAXGenerativeFunctions` and not merely `GenerativeFunctions`. I think it's cleaner if we don't inherit `GenerativeFunction` in more than one way, but there may be a constraint here that I can't see