### PR TITLE
Tweaks for the next release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,21 @@
-name: Release to PyPI
+name: Release to Artifact Registry
 
 on:
   release:
     types: [published]
+
+env:
+  ARTIFACT_REGISTRY: https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This is here so that the versioning plugin will be able to see tags
+          # and version using them.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         with:
@@ -17,11 +24,31 @@ jobs:
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
 
-      - name: Configure deploy key
-        run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_KEY }}
+      - name: Configure deploy keys
+        run: |
+          poetry self add poetry-dynamic-versioning[plugin]
+          poetry config pypi-token.pypi ${{ secrets.PYPI_API_KEY }}
+          poetry self add keyrings.google-artifactregistry-auth
+          poetry config repositories.gcp {{ env.ARTIFACT_REGISTRY }}
+
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: "${{ secrets.SERVICE_ACCOUNT_KEY }}"
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Display gcloud info
+        run: gcloud info
 
       - name: Install deps
         run: poetry install
 
-      - name: Deploy to PyPI
-        run: poetry publish --build
+      # NOTE: re-enable this once we deploy publicly and remove the artifact
+      # registry options.
+      # - name: Deploy to PyPI
+      #   run: poetry publish --build
+
+      - name: Deploy to Artifact Registry
+        run: poetry publish --build --repository gcp

--- a/README.md
+++ b/README.md
@@ -48,12 +48,26 @@ GenJAX is an implementation of Gen on top of [JAX](https://github.com/google/jax
 
 ## Quickstart
 
-Install GenJAX via [PyPI](https://pypi.org/project/genjax/):
+GenJAX is currently private. To configure your machine to access the package:
 
-```sh
-pip install genjax
+- Ask @sritchie to add you to the `probcomp-caliban` project on Google Cloud.
+- [Install the Google Cloud command line tools](https://cloud.google.com/sdk/docs/install).
+- Follow the instructions on the [installation page](https://cloud.google.com/sdk/docs/install)
+- run `gcloud init` as described [in this guide](https://cloud.google.com/sdk/docs/initializing) and configure the tool with the `probcomp-caliban` project ID.
+
+To install GenJAX using `pip`:
+
+```bash
+pip install keyring keyrings.google-artifactregistry-auth
+pip install genjax --extra-index-url https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/simple/
 ```
 
+If you're using Poetry:
+
+```bash
+poetry source add --priority=explicit gcp https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/simple/
+poetry add genjax --source gcp
+```
 Then install [JAX](https://github.com/google/jax) using [this
 guide](https://jax.readthedocs.io/en/latest/installation.html) to choose the
 command for the architecture you're targeting. To run GenJAX without GPU

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -152,9 +152,47 @@ Before cutting a new release:
   PRs merged since the last release
 - Click "Publish Release"
 
-This will build and publish the new version to PyPI.
+This will build and publish the new version to Artifact Registry.
+
+### Manually publishing to Google Artifact Registry
+
+- Ask @sritchie to add you to the `probcomp-caliban` project on Google Cloud.
+- [Install the Google Cloud command line
+  tools](https://cloud.google.com/sdk/docs/install).
+- Follow the instructions on the [installation
+  page](https://cloud.google.com/sdk/docs/install)
+- run `gcloud init` as described [in this
+  guide](https://cloud.google.com/sdk/docs/initializing) and configure the tool
+  with the ID of your new Cloud project.
+- Make sure you've added the dynamic versioning plugin, then configure poetry to
+  deploy to the `probcomp-caliban` artifact registry:
+
+```shell
+poetry self add poetry-dynamic-versioning[plugin]
+poetry self add keyrings.google-artifactregistry-auth
+poetry config repositories.gcp https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/
+```
+
+- create a new version tag on the `main` branch of the form
+  `v<MAJOR>.<MINOR>.<INCREMENTAL>`, like `v.0.1.0`, and push the tag to the
+  remote repository:
+
+```sh
+git tag v0.1.0
+git push --tags
+```
+
+- use Poetry to build and publish the artifact to Artifact Registry:
+
+```sh
+poetry publish --build --repository gcp
+```
+
 
 ### Manually publishing to PyPI
+
+> NOTE: please only do this once we've made the repository public and released a
+> version to PyPI.
 
 To publish a version manually, you'll need to be added to the GenJAX Maintainers
 list on PyPI, or ask a [current maintainer from the project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
-name = "GenJAX"
-version = "0.0.1"
+name = "genjax"
+version = "0.0.0"
 description = "Probabilistic programming with Gen, built on top of JAX."
 authors = [
   "McCoy R. Becker <mccoyb@mit.edu>",
@@ -34,7 +34,7 @@ classifiers = [
 Changelog = "https://github.com/probcomp/genjax/releases"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.9"
 jax = "^0.4.20"
 numpy = "^1.26.3"
 tensorflow-probability = "^0.23.0"


### PR DESCRIPTION
This PR:

- reconfigures the GitHub Action to release to our internal artifact registry
- adds instructions on how to publish to and pull from the artifact registry
- resets the hardcoded version to the suggested `0.0.0`  (the real version will be overridden by the poetry plugin)
- changes the package name to lowercase `genjax` as requested by @femtomc 