### PR TITLE
Pin Ruff version, upgrade to 0.3.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,8 +21,10 @@ jobs:
 
     - uses: chartboost/ruff-action@v1
       with:
+        version: 0.3.0
         args: format --check
 
     - uses: chartboost/ruff-action@v1
       with:
+        version: 0.3.0
         args: --output-format github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: nbstripout
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.11
+    rev: v0.3.0
     hooks:
       - id: ruff
         types_or: [ python, pyi, jupyter ]

--- a/src/genjax/_src/adev/primitives.py
+++ b/src/genjax/_src/adev/primitives.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Defines ADEV primitives."""
 
-
 import jax
 import jax.numpy as jnp
 from jax.interpreters.ad import instantiate_zeros, recast_to_float0, zeros_like_jaxval

--- a/src/genjax/_src/core/pytree.py
+++ b/src/genjax/_src/core/pytree.py
@@ -16,7 +16,6 @@
 The Pytree interface determines how data classes behave across JAX-transformed function boundaries - it provides a user with the freedom to declare subfields of a class as "static" (meaning, the value of the field cannot be a JAX traced value, it must be a Python literal, or a constant array - and the value is embedded in the `PyTreeDef` of any instance) or "dynamic" (meaning, the value may be a JAX traced value).
 """
 
-
 import equinox as eqx
 import jax.numpy as jnp
 import jax.tree_util as jtu

--- a/src/genjax/_src/generative_functions/combinators/drop_arguments.py
+++ b/src/genjax/_src/generative_functions/combinators/drop_arguments.py
@@ -20,7 +20,6 @@ The `DropArgumentsGenerativeFunction` exposes GFI methods which eliminate stored
 This is useful to avoid unnecessary allocations in e.g. `MapCombinator` which uses `jax.vmap` as part of its implementation, causing the arguments stored in its callee's trace to be expanded and stored (unnecessarily). `DropArgumentsGenerativeFunction` eliminates the stored arguments in the callee's trace -- and allows us to retain a single copy of the arguments in the `MapCombinator` caller's `MapTrace`.
 """
 
-
 from genjax._src.core.datatypes.generative import (
     ChoiceMap,
     GenerativeFunction,

--- a/src/genjax/_src/generative_functions/supports_callees.py
+++ b/src/genjax/_src/generative_functions/supports_callees.py
@@ -51,11 +51,9 @@ def push_trace_overload_stack(handler, fn):
 
 
 class CanSimulate(Protocol):
-    def simulate(self, key: PRNGKey, args: Tuple) -> Any:
-        ...
+    def simulate(self, key: PRNGKey, args: Tuple) -> Any: ...
 
-    def __call__(self, *args, **kwargs) -> Any:
-        ...
+    def __call__(self, *args, **kwargs) -> Any: ...
 
 
 # This mixin overloads the call functionality for this generative function

--- a/src/genjax/_src/inference/exact_testbed.py
+++ b/src/genjax/_src/inference/exact_testbed.py
@@ -14,7 +14,6 @@
 """A module containing a test suite for inference based on exact inference in hidden
 Markov models (HMMs)."""
 
-
 import jax
 import jax.numpy as jnp
 

--- a/src/genjax/_src/information/aide.py
+++ b/src/genjax/_src/information/aide.py
@@ -14,7 +14,6 @@
 """This module contains an implementation of (Auxiliary inference divergence estimator)
 from Cusumano-Towner et al, 2017."""
 
-
 import jax
 import jax.numpy as jnp
 from jax.scipy.special import logsumexp

--- a/src/genjax/_src/information/sdos.py
+++ b/src/genjax/_src/information/sdos.py
@@ -14,7 +14,6 @@
 """This module contains an implementation of (Symmetric divergence over datasets) from
 Domke, 2021."""
 
-
 import jax
 import jax.numpy as jnp
 from jax.scipy.special import logsumexp


### PR DESCRIPTION
This PR:

- upgrades the ruff version in `.pre-commit-config.yml` to `0.3.0`
- pins the same version in the `pre-commit.yml` action, so we don't get surprised again by an auto-upgrade

Here's the 0.3.0 changelog for Ruff: https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md