### PR TITLE
Add pyright pre-commit hook

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,12 +17,7 @@ jobs:
       with:
         python-version: 3.11.5
 
-    - name: Install and configure Poetry
-      uses: snok/install-poetry@v1
-
-    - run: poetry install
-
-    # - uses: pre-commit/action@v3.0.0
+  # - uses: pre-commit/action@v3.0.0
 
     - uses: chartboost/ruff-action@v1
       with:
@@ -33,8 +28,3 @@ jobs:
       with:
         version: 0.3.0
         args: --output-format github
-
-
-    - uses: jakebailey/pyright-action@v1
-      with:
-        version: 1.1.358

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,3 +28,8 @@ jobs:
       with:
         version: 0.3.0
         args: --output-format github
+
+
+    - uses: jakebailey/pyright-action@v1
+      with:
+        version: 1.1.352

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,7 +24,6 @@ jobs:
 
     # - uses: pre-commit/action@v3.0.0
 
-
     - uses: chartboost/ruff-action@v1
       with:
         version: 0.3.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,13 @@ jobs:
       with:
         python-version: 3.11.5
 
-  # - uses: pre-commit/action@v3.0.0
+    - name: Install and configure Poetry
+      uses: snok/install-poetry@v1
+
+    - run: poetry install
+
+    # - uses: pre-commit/action@v3.0.0
+
 
     - uses: chartboost/ruff-action@v1
       with:
@@ -32,4 +38,4 @@ jobs:
 
     - uses: jakebailey/pyright-action@v1
       with:
-        version: 1.1.352
+        version: 1.1.358

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -1,0 +1,27 @@
+name: Pyright type checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - nightly
+
+jobs:
+  pyright:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.11.5
+
+    - name: Install and configure Poetry
+      uses: snok/install-poetry@v1
+
+    - run: poetry install
+
+    - uses: jakebailey/pyright-action@v1
+      with:
+        version: 1.1.358

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,10 @@ repos:
 
       - id: ruff-format
         types_or: [ python, pyi, jupyter ]
+
+
+repos:
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.352
+    hooks:
+    - id: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,12 @@ repos:
     hooks:
       - id: nbstripout
 
+  - repo: https://github.com/python-poetry/poetry
+    rev: 1.7.1
+    hooks:
+      - id: poetry-check
+      - id: poetry-install
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.0
     hooks:
@@ -35,9 +41,8 @@ repos:
       - id: ruff-format
         types_or: [ python, pyi, jupyter ]
 
-
 repos:
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.352
+    rev: v1.1.358
     hooks:
     - id: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+default_install_hook_types:
+  - pre-commit
+  - post-checkout
+  - post-merge
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
@@ -27,7 +32,7 @@ repos:
       - id: nbstripout
 
   - repo: https://github.com/python-poetry/poetry
-    rev: 1.7.1
+    rev: 1.8.2
     hooks:
       - id: poetry-check
       - id: poetry-install
@@ -41,7 +46,6 @@ repos:
       - id: ruff-format
         types_or: [ python, pyi, jupyter ]
 
-repos:
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.358
     hooks:

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,8 +38,15 @@ nox.options.sessions = ("tests", "lint", "build")
 
 
 @session(python=python_version)
+def prepare(session):
+    session.run_always(
+        "poetry", "install", "--with", "dev", "--all-extras", external=True
+    )
+
+
+@session(python=python_version)
 def tests(session):
-    session.run_always("poetry", "install", "--with", "dev", external=True)
+    prepare(session)
     session.run(
         "poetry",
         "run",
@@ -53,12 +60,13 @@ def tests(session):
         "benchmarks",
         "-n",
         "auto",
+        external=True,
     )
 
 
 @session(python=python_version)
 def coverage(session):
-    session.run_always("poetry", "install", "--with", "dev", external=True)
+    prepare(session)
     session.run(
         "poetry",
         "run",
@@ -78,7 +86,7 @@ def coverage(session):
 
 @session(python=python_version)
 def benchmark(session):
-    session.run_always("poetry", "install", "--with", "dev", external=True)
+    prepare(session)
     session.run(
         "coverage",
         "run",
@@ -97,7 +105,7 @@ def benchmark(session):
 @session(python=python_version)
 def xdoctests(session) -> None:
     """Run examples with xdoctest."""
-    session.run_always("poetry", "install", "--with", "dev", external=True)
+    prepare(session)
     if session.posargs:
         args = [package, *session.posargs]
     else:
@@ -112,7 +120,7 @@ def xdoctests(session) -> None:
 @session(python=python_version)
 def nbmake(session) -> None:
     """Execute jupyter notebooks as tests"""
-    session.run_always("poetry", "install", "--with", "dev", external=True)
+    prepare(session)
     session.run(
         "poetry",
         "run",
@@ -133,31 +141,15 @@ def safety(session) -> None:
 
 
 @session(python=python_version)
-def mypy(session) -> None:
-    """Type-check using mypy."""
-    args = session.posargs or ["src", "tests", "docs/conf.py"]
-    session.run_always("poetry", "install", "--with", "dev", external=True)
-    session.run("mypy", *args)
-    if not session.posargs:
-        session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")
-
-
-@session(python=python_version)
 def lint(session: Session) -> None:
-    session.run_always("poetry", "install", "--with", "dev", external=True)
+    prepare(session)
     session.run("ruff", "check", "--fix", ".")
     session.run("ruff", "format", ".")
 
 
 @session(python=python_version)
 def build(session):
-    session.run_always(
-        "poetry",
-        "install",
-        "--with",
-        "dev",
-        external=True,
-    )
+    prepare(session)
     session.run("poetry", "build")
 
 
@@ -200,12 +192,12 @@ def docs_serve(session: Session) -> None:
 @session(name="notebooks-serve", python=python_version)
 def notebooks_serve(session: Session) -> None:
     """Build the documentation."""
-    session.run_always("poetry", "install", "--with", "dev", external=True)
+    prepare(session)
     session.run("quarto", "preview", "notebooks", external=True)
 
 
 @session(name="jupyter", python=python_version)
 def jupyter(session: Session) -> None:
     """Build the documentation."""
-    session.run_always("poetry", "install", "--with", "dev", external=True)
+    prepare(session)
     session.run("jupyter-lab", external=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -157,7 +157,14 @@ def build(session):
 def mkdocs(session: Session) -> None:
     """Run the mkdocs-only portion of the docs build."""
     session.run_always(
-        "poetry", "install", "--with", "docs", "--with", "dev", external=True
+        "poetry",
+        "install",
+        "--with",
+        "docs",
+        "--with",
+        "dev",
+        "--all-extras",
+        external=True,
     )
     build_dir = Path("site")
     if build_dir.exists():
@@ -169,7 +176,14 @@ def mkdocs(session: Session) -> None:
 def docs_build(session: Session) -> None:
     """Build the documentation."""
     session.run_always(
-        "poetry", "install", "--with", "docs", "--with", "dev", external=True
+        "poetry",
+        "install",
+        "--with",
+        "docs",
+        "--with",
+        "dev",
+        "--all-extras",
+        external=True,
     )
     build_dir = Path("site")
     if build_dir.exists():

--- a/poetry.lock
+++ b/poetry.lock
@@ -242,7 +242,7 @@ lxml = ["lxml"]
 name = "blackjax"
 version = "0.9.6"
 description = "Flexible and fast inference in Python"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "blackjax-0.9.6-py3-none-any.whl", hash = "sha256:d1c20dd15a63944a7b5c835bac4900aadf8630bedb0d7e51ab7fc63255eb0dd7"},
@@ -799,13 +799,6 @@ files = [
     {file = "dm_tree-0.1.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fa42a605d099ee7d41ba2b5fb75e21423951fd26e5d50583a00471238fb3021d"},
     {file = "dm_tree-0.1.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b7764de0d855338abefc6e3ee9fe40d301668310aa3baea3f778ff051f4393"},
     {file = "dm_tree-0.1.8-cp311-cp311-win_amd64.whl", hash = "sha256:a5d819c38c03f0bb5b3b3703c60e4b170355a0fc6b5819325bf3d4ceb3ae7e80"},
-    {file = "dm_tree-0.1.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ea9e59e0451e7d29aece402d9f908f2e2a80922bcde2ebfd5dcb07750fcbfee8"},
-    {file = "dm_tree-0.1.8-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:94d3f0826311f45ee19b75f5b48c99466e4218a0489e81c0f0167bda50cacf22"},
-    {file = "dm_tree-0.1.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:435227cf3c5dc63f4de054cf3d00183790bd9ead4c3623138c74dde7f67f521b"},
-    {file = "dm_tree-0.1.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09964470f76a5201aff2e8f9b26842976de7889300676f927930f6285e256760"},
-    {file = "dm_tree-0.1.8-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:75c5d528bb992981c20793b6b453e91560784215dffb8a5440ba999753c14ceb"},
-    {file = "dm_tree-0.1.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0a94aba18a35457a1b5cd716fd7b46c5dafdc4cf7869b4bae665b91c4682a8e"},
-    {file = "dm_tree-0.1.8-cp312-cp312-win_amd64.whl", hash = "sha256:96a548a406a6fb15fe58f6a30a57ff2f2aafbf25f05afab00c8f5e5977b6c715"},
     {file = "dm_tree-0.1.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8c60a7eadab64c2278861f56bca320b2720f163dca9d7558103c3b77f2416571"},
     {file = "dm_tree-0.1.8-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:af4b3d372f2477dcd89a6e717e4a575ca35ccc20cc4454a8a4b6f8838a00672d"},
     {file = "dm_tree-0.1.8-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:de287fabc464b8734be251e46e06aa9aa1001f34198da2b6ce07bd197172b9cb"},
@@ -925,7 +918,7 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 name = "fastprogress"
 version = "1.0.3"
 description = "A nested progress with plotting options for fastai"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "fastprogress-1.0.3-py3-none-any.whl", hash = "sha256:6dfea88f7a4717b0a8d6ee2048beae5dbed369f932a368c5dd9caff34796f7c5"},
@@ -1312,14 +1305,14 @@ files = [
 importlib-metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
 ml-dtypes = ">=0.2.0"
 numpy = [
-    {version = ">=1.22", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.23.2", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=1.22", markers = "python_version < \"3.11\""},
 ]
 opt-einsum = "*"
 scipy = [
-    {version = ">=1.9", markers = "python_version < \"3.12\""},
     {version = ">=1.11.1", markers = "python_version >= \"3.12\""},
+    {version = ">=1.9", markers = "python_version < \"3.12\""},
 ]
 
 [package.extras]
@@ -1367,8 +1360,8 @@ files = [
 ml-dtypes = ">=0.2.0"
 numpy = ">=1.22"
 scipy = [
-    {version = ">=1.9", markers = "python_version < \"3.12\""},
     {version = ">=1.11.1", markers = "python_version >= \"3.12\""},
+    {version = ">=1.9", markers = "python_version < \"3.12\""},
 ]
 
 [package.extras]
@@ -1378,7 +1371,7 @@ cuda12-pip = ["nvidia-cublas-cu12 (>=12.1.3.1)", "nvidia-cuda-cupti-cu12 (>=12.1
 name = "jaxopt"
 version = "0.8.3"
 description = "Hardware accelerated, batchable and differentiable optimizers in JAX."
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "jaxopt-0.8.3-py3-none-any.whl", hash = "sha256:4be2f82798393682529c9ca5046e5397ac6c8657b8acb6bf275e773b28df15b6"},
@@ -2442,10 +2435,10 @@ files = [
 
 [package.dependencies]
 numpy = [
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.23.3", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
     {version = ">=1.21.2", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">1.20", markers = "python_version < \"3.10\""},
-    {version = ">=1.23.3", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 
 [package.extras]
@@ -2820,6 +2813,7 @@ optional = false
 python-versions = ">=3.9"
 files = [
     {file = "pandas-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90c6fca2acf139569e74e8781709dccb6fe25940488755716d1d354d6bc58bce"},
+    {file = "pandas-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c7adfc142dac335d8c1e0dcbd37eb8617eac386596eb9e1a1b77791cf2498238"},
     {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4abfe0be0d7221be4f12552995e58723c7422c80a659da13ca382697de830c08"},
     {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8635c16bf3d99040fdf3ca3db669a7250ddf49c55dc4aa8fe0ae0fa8d6dcc1f0"},
     {file = "pandas-2.2.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:40ae1dffb3967a52203105a077415a86044a2bea011b5f321c6aa64b379a3f51"},
@@ -2840,6 +2834,7 @@ files = [
     {file = "pandas-2.2.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:43498c0bdb43d55cb162cdc8c06fac328ccb5d2eabe3cadeb3529ae6f0517c32"},
     {file = "pandas-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:d187d355ecec3629624fccb01d104da7d7f391db0311145817525281e2804d23"},
     {file = "pandas-2.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0ca6377b8fca51815f382bd0b697a0814c8bda55115678cbc94c30aacbb6eff2"},
+    {file = "pandas-2.2.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9057e6aa78a584bc93a13f0a9bf7e753a5e9770a30b4d758b8d5f2a62a9433cd"},
     {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:001910ad31abc7bf06f49dcc903755d2f7f3a9186c0c040b827e522e9cef0863"},
     {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66b479b0bd07204e37583c191535505410daa8df638fd8e75ae1b383851fe921"},
     {file = "pandas-2.2.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a77e9d1c386196879aa5eb712e77461aaee433e54c68cf253053a73b7e49c33a"},
@@ -2850,9 +2845,9 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3395,7 +3390,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4188,7 +4182,7 @@ test = ["flake8", "isort", "pytest"]
 name = "tinygp"
 version = "0.2.4"
 description = "The tiniest of Gaussian Process libraries"
-optional = false
+optional = true
 python-versions = ">=3.9"
 files = [
     {file = "tinygp-0.2.4-py3-none-any.whl", hash = "sha256:607da8dfb5d009066b84000d4e94ca68ca165613cdc1d223256891da0afc9beb"},
@@ -4582,11 +4576,11 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [extras]
-all = []
-blackjax = []
-tinygp = []
+all = ["blackjax", "tinygp"]
+blackjax = ["blackjax"]
+tinygp = ["tinygp"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "9860b69492612b1db3f5144de40ebcb92696d13201acecf43cb804fd3d5e580d"
+content-hash = "afaef377d51d2d881a8ebb6a3eaaba1a7f06c38ce3fb9aa32fa7bf06750f3e0f"

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ fail_under = 45
 [tool.pyright]
 venvPath = "."
 venv = ".venv"
-include = ["src"]
+include = ["src", "tests"]
 exclude = [
     "**/__pycache__",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 Changelog = "https://github.com/probcomp/genjax/releases"
 
 [tool.poetry.dependencies]
+blackjax = { version = "^0.9.6", optional = true }
 python = ">=3.9,<3.13"
 jax = "^0.4.25"
 numpy = "^1.26.4"
@@ -46,6 +47,7 @@ dill = "^0.3.8"
 pygments = "^2.17.2"
 plum-dispatch = "^2.3.2"
 equinox = "^0.11.3"
+tinygp = { version = "^0.2.3", optional = true }
 typing_extensions = ">=4.6.0,<5"
 oryx = "^0.2.6"
 deprecated = "^1.2.14"
@@ -54,7 +56,6 @@ deprecated = "^1.2.14"
 optional = true
 
 [tool.poetry.group.dev.dependencies]
-blackjax = "^0.9.6"
 coverage = "^7.0.0"
 matplotlib = "^3.6.2"
 mypy = "^0.991"
@@ -65,7 +66,6 @@ pytest-xdist = {version = "^3.2.0", extras = ["psutil"] }
 ruff = "^0.1.3"
 safety = "^2.3.5"
 seaborn = "^0.12.1"
-tinygp = "^0.2.3"
 xdoctest = "^1.1.0"
 jupyterlab = "^4.1.6"
 nox = "^2024.3.2"


### PR DESCRIPTION
This PR:

- Adds a pre-commit hook for poetry, running both `poetry-check` to make sure that the `pyproject.toml` is well-formed AND running `poetry install` for the user after checkout and after a merge to make sure deps stay up to date
- Adds a pre-commit hook for the pyright type checker
- deletes the `mypy` type checker entry in `noxfile.py`
- adds a new `prepare` step for installing dependencies.to `noxfile.py`
- all noxfile.py tasks now run `poetry install` with the `--all-extras` flag
- `tinygp` and `blackjax` are now properly optional dependencies. This is required for extras to work as pointed out by `poetry-check`

Obviously we have many type errors to fix. I vote to merge this and then start chipping away at the problems ASAP so we can get to a good state. @femtomc , wdyt?