### PR TITLE
Fix issue where scores/weights could be floats (instead of ArrayLikes)

### DIFF
--- a/src/genjax/_src/generative_functions/interpreted/interpreted_gen_fn.py
+++ b/src/genjax/_src/generative_functions/interpreted/interpreted_gen_fn.py
@@ -21,6 +21,7 @@ import itertools
 from dataclasses import dataclass
 
 import jax
+import jax.numpy as jnp
 from beartype import beartype
 from equinox import module_update_wrapper
 
@@ -128,7 +129,7 @@ class AddressVisitor(Pytree):
 @dataclass
 class SimulateHandler(Handler):
     key: PRNGKey
-    score: FloatArray = 0.0
+    score: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
     choice_state: Trie = Pytree.field(default_factory=Trie)
     trace_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
 
@@ -146,8 +147,8 @@ class SimulateHandler(Handler):
 class ImportanceHandler(Handler):
     key: PRNGKey
     constraints: ChoiceMap
-    score: FloatArray = 0.0
-    weight: FloatArray = 0.0
+    score: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
+    weight: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
     choice_state: Trie = Pytree.field(default_factory=Trie)
     trace_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
 
@@ -168,7 +169,7 @@ class UpdateHandler(Handler):
     key: PRNGKey
     previous_trace: Trace
     constraints: ChoiceMap
-    weight: FloatArray = 0.0
+    weight: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
     discard: Trie = Pytree.field(default_factory=Trie)
     choice_state: Trie = Pytree.field(default_factory=Trie)
     trace_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
@@ -201,7 +202,7 @@ class UpdateHandler(Handler):
 @dataclass
 class AssessHandler(Handler):
     constraints: ChoiceMap
-    score: FloatArray = 0.0
+    score: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
     trace_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
 
     def handle(self, gen_fn: GenerativeFunction, args: Tuple, addr: Any):
@@ -243,7 +244,7 @@ class InterpretedTrace(Trace):
         return self.args
 
     def project(self, selection: HierarchicalSelection) -> FloatArray:
-        weight = 0.0
+        weight = jnp.zeros(())
         for k, subtrace in self.choices.get_submaps_shallow():
             if selection.has_addr(k):
                 weight += subtrace.project(selection.get_subselection(k))

--- a/src/genjax/_src/generative_functions/static/static_transforms.py
+++ b/src/genjax/_src/generative_functions/static/static_transforms.py
@@ -17,6 +17,7 @@ import itertools
 from dataclasses import dataclass
 
 import jax
+import jax.numpy as jnp
 import jax.tree_util as jtu
 
 from genjax._src.core.datatypes.generative import (
@@ -246,7 +247,7 @@ class StaticLanguageHandler(StatefulHandler):
 @dataclass
 class SimulateHandler(StaticLanguageHandler):
     key: PRNGKey
-    score: FloatArray = 0.0
+    score: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
     address_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
     address_choices: Trie = Pytree.field(default_factory=Trie)
     cache_state: Trie = Pytree.field(default_factory=Trie)
@@ -307,8 +308,8 @@ def simulate_transform(source_fn):
 class ImportanceHandler(StaticLanguageHandler):
     key: PRNGKey
     constraints: ChoiceMap
-    score: FloatArray = 0.0
-    weight: FloatArray = 0.0
+    score: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
+    weight: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
     address_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
     address_choices: Trie = Pytree.field(default_factory=Trie)
     cache_state: Trie = Pytree.field(default_factory=Trie)
@@ -383,8 +384,8 @@ class UpdateHandler(StaticLanguageHandler):
     previous_trace: Trace
     constraints: ChoiceMap
     address_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
-    score: FloatArray = 0.0
-    weight: FloatArray = 0.0
+    score: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
+    weight: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
     address_choices: Trie = Pytree.field(default_factory=Trie)
     discard_choices: Trie = Pytree.field(default_factory=Trie)
     cache_state: Trie = Pytree.field(default_factory=Trie)
@@ -491,7 +492,7 @@ def update_transform(source_fn):
 @dataclass
 class AssessHandler(StaticLanguageHandler):
     constraints: ChoiceMap
-    score: FloatArray = 0.0
+    score: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
     address_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
     cache_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
 


### PR DESCRIPTION
Without this change, `assess` fails with a type error for a static generative function with no choices (because it returns a float instead of a JAX array).

This change (without the new tests) was original merged into main as https://github.com/probcomp/genjax/pull/920 .  But it looks like the change got lost in a merge somewhere -- so the tests in this PR fail right now in both nightly and main with errors like:
```
____________________________________________________________ TestAssess.test_assess_with_no_choices _____________________________________________________________
[gw0] linux -- Python 3.11.6 /home/jburnim_google_com/genjax/.nox/tests/bin/python

self = <test_static_language.TestAssess object at 0x7fad5817af50>

    def test_assess_with_no_choices(self):
        @genjax.static
        def empty(x):
            return jnp.square(x - 3.0)

        key = jax.random.PRNGKey(314159)
        key, sub_key = jax.random.split(key)
        tr = jax.jit(empty.simulate)(sub_key, (jnp.ones(4),))
        jitted = jax.jit(empty.assess)
        chm = tr.get_choices().strip()
>       (score, retval) = jitted(chm, (jnp.ones(4),))

tests/generative_functions/test_static_language.py:125:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

__beartype_func = <function StaticGenerativeFunction.assess at 0x7fad5888b7e0>
__beartype_conf = BeartypeConf(claw_is_pep526=True, is_color=False, is_debug=False, is_pep484_tower=False, strategy=<BeartypeStrategy.O1: 2>, warning_cls_on_decorator_exception=None)
__beartype_get_violation = <function get_beartype_violation at 0x7fad6e748900>
__beartype_object_94598457647856 = <class 'genjax._src.core.datatypes.generative.Choice'>
__beartype_object_94598441068512 = <class 'jaxtyping.Float[Array, '...']'>
args = (StaticGenerativeFunction(source=<function empty>), HierarchicalChoiceMap(trie=Trie(inner={})), (Traced<ShapedArray(float32[4])>with<DynamicJaxprTrace(level=1/0)>,))
kwargs = {}, __beartype_args_len = 3, __beartype_pith_0 = (0.0, Traced<ShapedArray(float32[4])>with<DynamicJaxprTrace(level=1/0)>)

>   ???
E   beartype.roar.BeartypeCallHintReturnViolation: Method genjax._src.generative_functions.static.static_gen_fn.StaticGenerativeFunction.assess() return (0.0, Traced<ShapedArray(float32[4])>with<DynamicJaxprTrace(level=1/0)>) violates type hint tuple[jaxtyping.Float[Array, '...'], typing.Any] under non-default configuration BeartypeConf(claw_is_pep526=True, is_color=False, is_debug=False, is_pep484_tower=False, strategy=<BeartypeStrategy.O1: 2>, warning_cls_on_decorator_exception=None), as tuple index 0 item float 0.0 not instance of <protocol "jaxtyping.Float[Array, '...']">.
E   --------------------
E   For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

<@beartype(genjax._src.generative_functions.static.static_gen_fn.StaticGenerativeFunction.assess) at 0x7fad5888b7e0>:65: BeartypeCallHintReturnViolation
```

