### PR TITLE
Add codecov.yml to stop failing PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 3%


### PR DESCRIPTION
This PR will stop the `x` from appearing when we don't have 100% code coverage in PRs.