### PR TITLE
docs: add keyring dependency for poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ pip install genjax --extra-index-url https://us-west1-python.pkg.dev/probcomp-ca
 If you're using Poetry:
 
 ```bash
+poetry self add keyring keyrings.google-artifactregistry-auth
 poetry source add --priority=explicit gcp https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/simple/
 poetry add genjax --source gcp
 ```


### PR DESCRIPTION
For Poetry, we need to install keyring to use gcloud credentials to access the artifact repository (just like with pip).