### PR TITLE
Remove note about adding probcomp-caliban project, fix poetry instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ pip install genjax --extra-index-url https://us-west1-python.pkg.dev/probcomp-ca
 If you're using Poetry:
 
 ```bash
+poetry self update && poetry self add keyrings.google-artifactregistry-auth
 poetry source add --priority=explicit gcp https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/simple/
 poetry add genjax --source gcp
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ GenJAX is currently private. To configure your machine to access the package:
 - Ask @sritchie to add you to the `probcomp-caliban` project on Google Cloud.
 - [Install the Google Cloud command line tools](https://cloud.google.com/sdk/docs/install).
 - Follow the instructions on the [installation page](https://cloud.google.com/sdk/docs/install)
-- run `gcloud init` as described [in this guide](https://cloud.google.com/sdk/docs/initializing) and configure the tool with the `probcomp-caliban` project ID.
+- run `gcloud init` as described [in this guide](https://cloud.google.com/sdk/docs/initializing).
 
 To install GenJAX using `pip`:
 


### PR DESCRIPTION
It turns out that this isn't possible if you only have artifact registry permissions, according to @wsphillips (thanks for giving this a runthrough!)

This PR:

- removes the unnecessary instruction
- adds a missing line necessary for a successful poetry install