### PR TITLE
Fix argument order repeat_combinator.py

### DIFF
--- a/src/genjax/_src/generative_functions/combinators/vector/repeat_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/repeat_combinator.py
@@ -125,6 +125,6 @@ class RepeatCombinator(
 
 def repeat_combinator(*, repeats) -> Callable[[Callable], JAXGenerativeFunction]:
     def decorator(f) -> JAXGenerativeFunction:
-        return RepeatCombinator(repeats, f)
+        return RepeatCombinator(f, repeats)
 
     return decorator


### PR DESCRIPTION
`RepeatCombinator` expects:
1. `inner`: JAXGenerativeFunction
2. `repeats`: Int = Pytree.static()

However `map_combinator` returns `RepeatCombinator(repeats, f)`.

I fixed that to `RepeatCombinator(f, repeats)`.