### PR TITLE
Repeat combinator fixes #1035

### DIFF
--- a/src/genjax/_src/generative_functions/combinators/vector/repeat_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/repeat_combinator.py
@@ -19,8 +19,8 @@ import jax.numpy as jnp
 
 from genjax._src.core.datatypes.generative import (
     Choice,
-    JAXGenerativeFunction,
     GenerativeFunction,
+    JAXGenerativeFunction,
     Selection,
     Trace,
 )

--- a/src/genjax/_src/generative_functions/combinators/vector/repeat_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/vector/repeat_combinator.py
@@ -20,6 +20,7 @@ import jax.numpy as jnp
 from genjax._src.core.datatypes.generative import (
     Choice,
     JAXGenerativeFunction,
+    GenerativeFunction,
     Selection,
     Trace,
 )
@@ -40,6 +41,7 @@ from genjax._src.generative_functions.static.static_gen_fn import SupportsCallee
 
 
 class RepeatTrace(Trace):
+    gen_fn: GenerativeFunction
     inner_trace: Trace
     args: Tuple
 
@@ -54,6 +56,9 @@ class RepeatTrace(Trace):
 
     def get_retval(self):
         return self.inner_trace.get_retval()
+
+    def get_gen_fn(self):
+        return self.gen_fn
 
     @typecheck
     def project(self, selection: Selection):
@@ -81,7 +86,7 @@ class RepeatCombinator(
             self.inner.simulate,
             in_axes=(0, None),
         )(sub_keys, args)
-        return RepeatTrace(repeated_inner_tr, args)
+        return RepeatTrace(self, repeated_inner_tr, args)
 
     @dispatch
     def importance(
@@ -95,7 +100,7 @@ class RepeatCombinator(
             self.inner.importance,
             in_axes=(0, None),
         )(sub_keys, choice, args)
-        return RepeatTrace(repeated_inner_tr, args), jnp.sum(w)
+        return RepeatTrace(self, repeated_inner_tr, args), jnp.sum(w)
 
     @typecheck
     def update(
@@ -125,6 +130,6 @@ class RepeatCombinator(
 
 def repeat_combinator(*, repeats) -> Callable[[Callable], JAXGenerativeFunction]:
     def decorator(f) -> JAXGenerativeFunction:
-        return RepeatCombinator(repeats, f)
+        return RepeatCombinator(f, repeats)
 
     return decorator


### PR DESCRIPTION
Closes #1035:

`RepeatCombinator` expects:

1. `inner`: JAXGenerativeFunction
2. `repeats`: Int = Pytree.static()
However `map_combinator` returns `RepeatCombinator(repeats, f)`. I fixed that to `RepeatCombinator(f, repeats)`.

Furthermore `RepeatTrace` didn't have a `gen_fn` field and no getter either. 

I fixed those here:
https://github.com/probcomp/genjax/compare/nightly...mkl-repeat-combinator