### PR TITLE
Fix workflow caching

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: ${{ runner.os }}-nox
 
       - name: Generate coverage report
-        run: nox -s coverage
+        run: nox -r -s coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,7 @@ jobs:
           restore-keys: ${{ runner.os }}-nox
 
       - name: Run Docs Build
-        run: nox -s docs-build
+        run: nox -r -s docs-build
 
       - name: Deploy to GH Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -49,4 +49,4 @@ jobs:
           restore-keys: ${{ runner.os }}-nox
 
       - name: Run Docs Build
-        run: nox -s mkdocs
+        run: nox -r -s mkdocs


### PR DESCRIPTION
These workflows weren't reusing the cached nox environment. This PR adds the `-r` flag to fix that.