### PR TITLE
Add Colab link, update install instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/access.md
+++ b/.github/ISSUE_TEMPLATE/access.md
@@ -1,0 +1,13 @@
+---
+name: GenJAX-Users Access
+about: Request access to the GenJAX-Users group
+title: "[ACCESS]"
+assignees: sritchie
+
+---
+
+**Why are you requesting GenJAX access?**
+
+Let us know how you're affiliated with GenJAX.
+
+**What's an email address associated with a Google account?**

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@
 
 </div>
 
-
-
 ## 🔎 What is GenJAX?
 
 Gen is a multi-paradigm (generative, differentiable, incremental) language for probabilistic programming focused on [**generative functions**: computational objects which represent probability measures over structured sample spaces](https://probcomp.github.io/genjax/cookbook/active/intro.html#generative-functions).
@@ -41,12 +39,13 @@ GenJAX is an implementation of Gen on top of [JAX](https://github.com/google/jax
 
 ## Quickstart
 
-GenJAX is currently private. To configure your machine to access the package:
-
-- Ask @sritchie to add you to the `probcomp-caliban` project on Google Cloud.
-- [Install the Google Cloud command line tools](https://cloud.google.com/sdk/docs/install).
-- Follow the instructions on the [installation page](https://cloud.google.com/sdk/docs/install)
-- run `gcloud init` as described [in this guide](https://cloud.google.com/sdk/docs/initializing).
+> [!IMPORTANT] 
+> GenJAX is currently private. To configure your machine to access the package,
+> - [file a ticket requesting access to the GenJAX-Users
+> group](https://github.com/probcomp/genjax/issues/new?assignees=sritchie&projects=&template=access.md&title=%5BACCESS%5D)
+> - [install the Google Cloud command line tools](https://cloud.google.com/sdk/docs/install)
+> - follow the instructions on the [installation page](https://cloud.google.com/sdk/docs/install)
+> - run `gcloud init` as described [in this guide](https://cloud.google.com/sdk/docs/initializing).
 
 To install GenJAX using `pip`:
 
@@ -77,7 +76,8 @@ On a Linux machine with a GPU, run the following command:
 pip install jax[cuda12]==0.4.28
 ```
 
-### Quick example
+### Quick example [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1aEFpmpgh43B0tk-V0dXT-hple0LWPmQT?usp=sharing)
+
 
 The following code snippet defines a generative function called `beta_bernoulli` that
 


### PR DESCRIPTION
This PR:

- Adds a new Issue template that folks can use to request access to genjax-users@chi-fro.org (this will open a linear issue assigned to @sritchie )
- updates the README instructions for installation, pointing users to this new issue template.
- Adds an "open in Colab" link to the colab version of the quick start example (@femtomc , you have editor access to edit this example)

Only people on genjax-users@chi-fro.org will be able to view the Colab and install the releases.

We'll have to add these instructions somewhere else too, probably on Notion, since how else would anyone read them from the private repo??