### PR TITLE
Fix "missing import" pyright errors

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1
 
-    - run: poetry install
+    - run: poetry install --with dev --all-extras
 
     - uses: jakebailey/pyright-action@v1
       with:


### PR DESCRIPTION
This PR fixes our missing import pyright errors by installing a full dev environment before running pyright.