### PR TITLE
fix in_axes typing, bug with _static_check_broadcastable

### DIFF
--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -31,6 +31,7 @@ from genjax._src.core.typing import (
     Callable,
     Dict,
     FloatArray,
+    InAxes,
     Int,
     IntArray,
     Is,
@@ -41,7 +42,6 @@ from genjax._src.core.typing import (
     static_check_is_concrete,
     typecheck,
 )
-from genjax._src.generative_functions.combinators.vmap_combinator import InAxes
 
 register_exclusion(__file__)
 

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -41,6 +41,7 @@ from genjax._src.core.typing import (
     static_check_is_concrete,
     typecheck,
 )
+from genjax._src.generative_functions.combinators.vmap_combinator import InAxes
 
 register_exclusion(__file__)
 
@@ -684,7 +685,7 @@ class GenerativeFunction(Pytree):
     def vmap(
         self,
         *args,
-        in_axes=0,
+        in_axes: InAxes = 0,
     ) -> "GenerativeFunction":
         from genjax import vmap_combinator
 

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -48,6 +48,8 @@ List = btyping.List
 Optional = btyping.Optional
 Type = btyping.Type
 
+# JAX Type alias.
+InAxes = int | None | Sequence[Any]
 
 # Types of Python literals.
 Int = int

--- a/src/genjax/_src/generative_functions/combinators/vmap_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap_combinator.py
@@ -44,11 +44,15 @@ from genjax._src.core.typing import (
     FloatArray,
     Optional,
     PRNGKey,
+    Sequence,
     Tuple,
     typecheck,
 )
 
 register_exclusion(__file__)
+
+# JAX Type alias.
+InAxes = int | None | Sequence[Any]
 
 
 @Pytree.dataclass
@@ -132,7 +136,7 @@ class VmapCombinator(GenerativeFunction):
     The source generative function.
     """
 
-    in_axes: Tuple = Pytree.static()
+    in_axes: InAxes = Pytree.static()
     """
     The axes specified, it should be a tuple which matches (or prefixes) the `Pytree` type of the argument tuple for the underlying `gen_fn`.
     """
@@ -146,10 +150,12 @@ class VmapCombinator(GenerativeFunction):
     def _static_check_broadcastable(self, args):
         # Argument broadcast semantics must be fully specified
         # in `in_axes`.
-        if not len(args) == len(self.in_axes):
-            raise Exception(
-                f"VmapCombinator requires that length of the provided in_axes kwarg match the number of arguments provided to the invocation.\nA mismatch occured with len(args) = {len(args)} and len(self.in_axes) = {len(self.in_axes)}"
-            )
+        if self.in_axes is not None:
+            axes_length = 1 if isinstance(self.in_axes, int) else len(self.in_axes)
+            if not len(args) == axes_length:
+                raise Exception(
+                    f"VmapCombinator requires that length of the provided in_axes kwarg match the number of arguments provided to the invocation.\nA mismatch occured with len(args) = {len(args)} and len(self.in_axes) = {axes_length}"
+                )
 
     def _static_broadcast_dim_length(self, args):
         def find_axis_size(axis, x):
@@ -314,7 +320,7 @@ def vmap_combinator(
     gen_fn: Optional[GenerativeFunctionClosure] = None,
     /,
     *,
-    in_axes: Tuple,
+    in_axes: InAxes,
 ) -> Callable | VmapCombinator:
     def decorator(gen_fn) -> VmapCombinator:
         return VmapCombinator(gen_fn, in_axes)

--- a/src/genjax/_src/generative_functions/combinators/vmap_combinator.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap_combinator.py
@@ -42,17 +42,14 @@ from genjax._src.core.typing import (
     Any,
     Callable,
     FloatArray,
+    InAxes,
     Optional,
     PRNGKey,
-    Sequence,
     Tuple,
     typecheck,
 )
 
 register_exclusion(__file__)
-
-# JAX Type alias.
-InAxes = int | None | Sequence[Any]
 
 
 @Pytree.dataclass


### PR DESCRIPTION
This PR:

- changes the `in_axes` type across the library to match JAX's type declaration
- handles the `int` and `None` cases in `_static_check_broadcastable`