### PR TITLE
Migrate genjax repo static site to private site (GEN-184)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Render and Publish Docs
 on:
   push:
     branches:
-      - main
+      - huebert/private-site
 
 env:
   POETRY_EXPERIMENTAL_SYSTEM_GIT_CLIENT: true
@@ -56,8 +56,18 @@ jobs:
       - name: Run Docs Build
         run: nox -r -s docs-build
 
-      - name: Deploy to GH Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Authenticate with Google Cloud
+        uses: 'google-github-actions/auth@v2.1.3'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
+          project_id: 'probcomp-caliban'
+          workload_identity_provider: 'projects/110275315150/locations/global/workloadIdentityPools/gen-website-private-publishers/providers/github'
+          service_account: 'gen-website-private-admin@probcomp-caliban.iam.gserviceaccount.com'
+          audience: '//iam.googleapis.com/projects/110275315150/locations/global/workloadIdentityPools/gen-website-private-publishers/providers/github'
+
+      - name: Deploy to Google Cloud Storage
+        run: | 
+          WEBSITE_DIR='./site'
+          PARENT_DOMAIN='gen.dev'
+          SUBDOMAIN=${{github.event.repository.name}}
+          BUCKET_PATH="gs://gen-website-private/$PARENT_DOMAIN/$SUBDOMAIN"
+          gcloud storage rsync --recursive --delete-unmatched-destination-objects --cache-control 'public, max-age=60' $WEBSITE_DIR $BUCKET_PATH

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Render and Publish Docs
 on:
   push:
     branches:
-      - huebert/private-site
+      - main
 
 env:
   POETRY_EXPERIMENTAL_SYSTEM_GIT_CLIENT: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,18 +56,13 @@ jobs:
       - name: Run Docs Build
         run: nox -r -s docs-build
 
-      - name: Authenticate with Google Cloud
-        uses: 'google-github-actions/auth@v2.1.3'
+      - name: Create website artifact
+        uses: actions/upload-artifact@v4
         with:
-          project_id: 'probcomp-caliban'
-          workload_identity_provider: 'projects/110275315150/locations/global/workloadIdentityPools/gen-website-private-publishers/providers/github'
-          service_account: 'gen-website-private-admin@probcomp-caliban.iam.gserviceaccount.com'
-          audience: '//iam.googleapis.com/projects/110275315150/locations/global/workloadIdentityPools/gen-website-private-publishers/providers/github'
-
-      - name: Deploy to Google Cloud Storage
-        run: | 
-          WEBSITE_DIR='./site'
-          PARENT_DOMAIN='gen.dev'
-          SUBDOMAIN=${{github.event.repository.name}}
-          BUCKET_PATH="gs://gen-website-private/$PARENT_DOMAIN/$SUBDOMAIN"
-          gcloud storage rsync --recursive --delete-unmatched-destination-objects --cache-control 'public, max-age=60' $WEBSITE_DIR $BUCKET_PATH
+          name: website
+          path: ./site
+  publish:
+    needs: build-deploy
+    uses: probcomp/gen-website-private/.github/workflows/publish_private_website.yml@main
+    with:
+      artifact: website


### PR DESCRIPTION
This should publish the docs site to genjax.gen.dev, behind a password wall.

The action has been written & tested in the [gen-website-private](https://github.com/probcomp/gen-website-private) repo. (I didn't test it here yet b/c actions on non-main branches are not set up to receive the required context/permissions.)