### PR TITLE
ci(actions/docs): add id-token write permission

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ env:
 permissions:
   contents: write
   pages: write
+  id-token: write
 
 jobs:
   build-deploy:


### PR DESCRIPTION
This may fix the docs action deploy step.