### PR TITLE
Fix docs-serve command, add docs-build-serve

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -139,9 +139,17 @@ nox -r -s docs-build
 This command will use `mkdocs` to build the static site, and then use `quarto`
 to render the notebooks into the static site directory.
 
-Pushing the resulting changes to the `main` branch will trigger a CI job to
-deploy to the GitHub Pages branch `gh-pages`, from which the documentation is
-hosted.
+To view the generated site, run:
+
+```bash
+nox -r -s docs-serve
+```
+
+or to run both commands in sequence:
+
+```bash
+nox -r -s docs-build-serve
+```
 
 ## Granting someone access to GenJAX's Artifact Registry
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,6 +61,13 @@ def install_jaxlib(session):
 
 @session(python=python_version)
 def prepare(session):
+    session.run(
+        "poetry",
+        "self",
+        "add",
+        "keyrings.google-artifactregistry-auth",
+        external=True,
+    )
     session.run_always(
         "poetry", "install", "--with", "dev", "--all-extras", external=True
     )
@@ -203,11 +210,24 @@ def docs_build(session: Session) -> None:
 
 @session(name="docs-serve", python=python_version)
 def docs_serve(session: Session) -> None:
-    """Build the documentation."""
-    session.run_always(
-        "poetry", "install", "--with", "docs", "--with", "dev", external=True
+    """Serve the already-built documentation."""
+    session.run(
+        "python",
+        "-m",
+        "http.server",
+        "8080",
+        "--bind",
+        "127.0.0.1",
+        "--directory",
+        "site",
     )
-    session.run("poetry", "run", "mkdocs", "serve")
+
+
+@session(name="docs-build-serve", python=python_version)
+def docs_build_serve(session: Session) -> None:
+    """Build and serve the documentation site."""
+    docs_build(session)
+    docs_serve(session)
 
 
 @session(name="notebooks-serve", python=python_version)


### PR DESCRIPTION
This PR:

- updates the docs-serve command to ONLY serve already-built docs. (Before this change `docs-serve` would rebuild the docs and prevent the user from previewing the quarto build)
- adds a `docs-build-serve` command that builds and then serves
- installs the `keyrings.google-artifactregistry-auth` plugin, in prep for #1120 .