### PR TITLE
Add note about application-default login vs login

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ GenJAX is an implementation of Gen on top of [JAX](https://github.com/google/jax
 > group](https://github.com/probcomp/genjax/issues/new?assignees=sritchie&projects=&template=access.md&title=%5BACCESS%5D)
 > - [install the Google Cloud command line tools](https://cloud.google.com/sdk/docs/install)
 > - follow the instructions on the [installation page](https://cloud.google.com/sdk/docs/install)
-> - run `gcloud init` as described [in this guide](https://cloud.google.com/sdk/docs/initializing).
+> - run `gcloud auth application-default login` as described [in this guide](https://cloud.google.com/sdk/docs/initializing).
 
 To install GenJAX using `pip`:
 


### PR DESCRIPTION
The first place that `keyrings.google-artifactregistry-auth` looks to give a user access to the Artifact Registry is the "application default" credentials.

On a compute VM, logging in via `gcloud init` makes you specify way too much stuff, and `gcloud auth login` won't override the default compute VM service account. The new way in the README works locally and also on a compute VM.