### PR TITLE
Fix docs build

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -60,11 +60,12 @@ def install_jaxlib(session):
 
 
 @session(python=python_version)
-def prepare(session, *extras):
-    extra_acc = []
-    for extra in extras:
-        extra_acc += ["--with", extra]
-    print(extras)
+def prepare(session, *with_strs):
+    with_pairs = []
+
+    for s in with_strs:
+        with_pairs += ["--with", s]
+
     session.run(
         "poetry",
         "self",
@@ -73,7 +74,7 @@ def prepare(session, *extras):
         external=True,
     )
     session.run_always(
-        "poetry", "install", "--with", "dev", *extra_acc, "--all-extras", external=True
+        "poetry", "install", "--with", "dev", *with_pairs, "--all-extras", external=True
     )
     install_jaxlib(session)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,7 +60,11 @@ def install_jaxlib(session):
 
 
 @session(python=python_version)
-def prepare(session):
+def prepare(session, *extras):
+    extra_acc = []
+    for extra in extras:
+        extra_acc += ["--with", extra]
+    print(extras)
     session.run(
         "poetry",
         "self",
@@ -69,7 +73,7 @@ def prepare(session):
         external=True,
     )
     session.run_always(
-        "poetry", "install", "--with", "dev", "--all-extras", external=True
+        "poetry", "install", "--with", "dev", *extra_acc, "--all-extras", external=True
     )
     install_jaxlib(session)
 
@@ -185,14 +189,7 @@ def build(session):
 @session(name="mkdocs", python=python_version)
 def mkdocs(session: Session) -> None:
     """Run the mkdocs-only portion of the docs build."""
-    prepare(session)
-    session.run_always(
-        "poetry",
-        "install",
-        "--with",
-        "docs",
-        external=True,
-    )
+    prepare(session, "docs")
     build_dir = Path("site")
     if build_dir.exists():
         shutil.rmtree(build_dir)


### PR DESCRIPTION
I must have updated Poetry, and the latest version deletes my custom `pip install jax[cpu]` when the `poetry install` command runs in `mkdocs`. 

This PR augments `prepare` with the ability to take strings that we'll pass along to `poetry install` via `--with`.