### PR TITLE
Fix pyright errors, ArrayLike => Array

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
 
+      - run: poetry self update && poetry self add keyrings.google-artifactregistry-auth
+
       - run: poetry install --with dev --all-extras
 
       - uses: jakebailey/pyright-action@v1

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -145,7 +145,7 @@ def static_check_supports_grad(v):
 
 
 @typecheck
-def static_check_shape_dtype_equivalence(vs: List[ArrayLike]) -> Bool:
+def static_check_shape_dtype_equivalence(vs: List[Array]) -> Bool:
     shape_dtypes = [(v.shape, v.dtype) for v in vs]
     num_unique = set(shape_dtypes)
     return len(num_unique) == 1


### PR DESCRIPTION
This PR fixes these pyright errors:

```
/Users/sritchie/code/python/genjax/src/genjax/_src/core/typing.py
  /Users/sritchie/code/python/genjax/src/genjax/_src/core/typing.py:149:24 - error: Cannot access member "shape" for type "bool"
    Member "shape" is unknown (reportAttributeAccessIssue)
  /Users/sritchie/code/python/genjax/src/genjax/_src/core/typing.py:149:24 - error: Cannot access member "shape" for type "int"
    Member "shape" is unknown (reportAttributeAccessIssue)
  /Users/sritchie/code/python/genjax/src/genjax/_src/core/typing.py:149:24 - error: Cannot access member "shape" for type "float"
    Member "shape" is unknown (reportAttributeAccessIssue)
  /Users/sritchie/code/python/genjax/src/genjax/_src/core/typing.py:149:24 - error: Cannot access member "shape" for type "complex"
    Member "shape" is unknown (reportAttributeAccessIssue)
  /Users/sritchie/code/python/genjax/src/genjax/_src/core/typing.py:149:33 - error: Cannot access member "dtype" for type "bool"
    Member "dtype" is unknown (reportAttributeAccessIssue)
  /Users/sritchie/code/python/genjax/src/genjax/_src/core/typing.py:149:33 - error: Cannot access member "dtype" for type "int"
    Member "dtype" is unknown (reportAttributeAccessIssue)
  /Users/sritchie/code/python/genjax/src/genjax/_src/core/typing.py:149:33 - error: Cannot access member "dtype" for type "float"
    Member "dtype" is unknown (reportAttributeAccessIssue)
  /Users/sritchie/code/python/genjax/src/genjax/_src/core/typing.py:149:33 - error: Cannot access member "dtype" for type "complex"
    Member "dtype" is unknown (reportAttributeAccessIssue)
```