### PR TITLE
Change "Open in Colab" to point to colab enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ On a Linux machine with a GPU, run the following command:
 pip install jax[cuda12]==0.4.28
 ```
 
-### Quick example [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1aEFpmpgh43B0tk-V0dXT-hple0LWPmQT?usp=sharing)
+### Quick example [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://console.cloud.google.com/vertex-ai/colab/notebooks?project=probcomp-caliban&activeNb=projects%2Fprobcomp-caliban%2Flocations%2Fus-west1%2Frepositories%2F09be0f8e-ccfd-4d34-a029-fed94d455c48)
 
 
 The following code snippet defines a generative function called `beta_bernoulli` that


### PR DESCRIPTION
Inside Colab Enterprise, we can grant access to all users in genjax-users@chi-fro.org. In the externally available version of colab we have to do this for each notebook individually.