### PR TITLE
Fix scan combinator docs

### DIFF
--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -131,9 +131,9 @@ class ScanCombinator(GenerativeFunction):
 
         # A kernel_gen_fn generative function.
         @genjax.gen
-        def random_walk(prev):
+        def random_walk(prev, _):
             x = genjax.normal(prev, 1.0) @ "x"
-            return x
+            return x, None
 
 
         # You can apply the Scan combinator directly like this:
@@ -143,7 +143,7 @@ class ScanCombinator(GenerativeFunction):
         # You can also use the decorator when declaring the function:
         @genjax.scan(n=1000)
         @genjax.gen
-        def random_walk(prev, xs):
+        def random_walk(prev, _):
             x = genjax.normal(prev, 1.0) @ "x"
             return x, None
 


### PR DESCRIPTION
This PR fixes the invalid first version of `random_walk` in the `ScanCombinator` docstring, closing #1171 . Thanks to @derifatives for noticing this!