### PR TITLE
Docs for ScanCombinator, decorator, methods

### DIFF
--- a/docs/library/combinators.md
+++ b/docs/library/combinators.md
@@ -1,8 +1,45 @@
 # Combinators: structured patterns of composition
 
-While the programmatic `StaticGenerativeFunction` language is powerful, its restrictions can be limiting. Combinators are a way to express common patterns of composition in a more concise way, and to gain access to effects which are common in JAX (like `jax.vmap`) for generative computations.
+While the programmatic [`genjax.StaticGenerativeFunction`][] language is powerful, its restrictions can be limiting. Combinators are a way to express common patterns of composition in a more concise way, and to gain access to effects which are common in JAX (like `jax.vmap`) for generative computations.
 
-Each of the combinators below is implemented as a decorator. `GenerativeFunction` instances make each combinator available as a method with the same name.
+Each of the combinators below is implemented as a method on [`genjax.GenerativeFunction`][] and as a standalone decorator.
+
+You should strongly prefer the method form. Here's an example of the `vmap` combinator created by the [`genjax.GenerativeFunction.vmap`][] method:
+
+Here is the `vmap` combinator used as a method. `square_many` below accepts an array and returns an array:
+
+```python exec="yes" html="true" source="material-block" session="combinators"
+import jax, genjax
+
+@genjax.gen
+def square(x):
+    return x * x
+
+square_many = square.vmap()
+```
+
+Here is `square_many` defined with [`genjax.vmap`][], the decorator version of the `vmap` method:
+
+```python exec="yes" html="true" source="material-block" session="combinators"
+@genjax.vmap()
+@genjax.gen
+def square_many_decorator(x):
+    return x * x
+```
+
+!!! warning
+    We do _not_ recommend this style, since the original building block generative function won't be available by itself. Please prefer using the combinator methods, or the transformation style shown below.
+
+If you insist on using the decorator form, you can preserve the original function like this:
+
+```python exec="yes" html="true" source="material-block" session="combinators"
+@genjax.gen
+def square(x):
+    return x * x
+
+# Use the decorator as a transformation:
+square_many_better = genjax.vmap()(square)
+```
 
 ## `vmap`-like Combinators
 

--- a/docs/library/combinators.md
+++ b/docs/library/combinators.md
@@ -1,0 +1,31 @@
+# Combinators: structured patterns of composition
+
+While the programmatic `StaticGenerativeFunction` language is powerful, its restrictions can be limiting. Combinators are a way to express common patterns of composition in a more concise way, and to gain access to effects which are common in JAX (like `jax.vmap`) for generative computations.
+
+Each of the combinators below is implemented as a decorator. `GenerativeFunction` instances make each combinator available as a method with the same name.
+
+## `vmap`-like Combinators
+
+::: genjax.vmap
+::: genjax.repeat
+
+## `scan`-like Combinators
+
+::: genjax.scan
+
+## Control Flow Combinators
+
+::: genjax.or_else
+::: genjax.switch
+
+## Various Transformations
+
+::: genjax.map_addresses
+::: genjax.dimap
+::: genjax.map
+::: genjax.contramap
+
+## The Rest
+
+::: genjax.mask
+::: genjax.mix

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
   - Library reference:
       - Core: library/core.md
       - Generative functions: library/generative_functions.md
+      - Combinators: library/combinators.md
       - Inference: library/inference.md
     # - ADEV: library/adev.md
   - For developers:

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -557,7 +557,7 @@ class GenerativeFunction(Pytree):
             print(tr.render_html())
             ```
 
-            Another example, using the same model, composed into [`genjax.repeat`](generative_functions.md#genjax.repeat) - which creates a new generative function, which has the same interface:
+            Another example, using the same model, composed into [`genjax.repeat`](combinators.md#genjax.repeat) - which creates a new generative function, which has the same interface:
             ```python exec="yes" html="true" source="material-block" session="core"
             @genjax.gen
             def model():
@@ -865,7 +865,7 @@ class GenerativeFunction(Pytree):
         """
         Returns a [`GenerativeFunction`][genjax.GenerativeFunction] that samples from `self` `n` times, returning a vector of `n` results and nesting traced values under an index.
 
-        This combinator is useful for creating multiple samples from the same generative model in a batched manner.
+        This combinator is useful for creating multiple samples from `self` in a batched manner.
 
         Args:
             n: The number of times to sample from the generative function.
@@ -877,17 +877,103 @@ class GenerativeFunction(Pytree):
 
         return genjax.repeat(n=n)(self)
 
-    def scan(self, /, *, n: Int) -> "GenerativeFunction":
+    def scan(
+        self,
+        /,
+        *,
+        n: Optional[Int] = None,
+        reverse: bool = False,
+        unroll: int | bool = 1,
+    ) -> "GenerativeFunction":
+        """
+        When called on a [`genjax.GenerativeFunction`][] of type `(c, a) -> (c, b)`, returns a new [`genjax.GenerativeFunction`][] of type `(c, [a]) -> (c, [b])` where
+
+        - `c` is a loop-carried value, which must hold a fixed shape and dtype across all iterations
+        - `a` may be a primitive, an array type or a pytree (container) type with array leaves
+        - `b` may be a primitive, an array type or a pytree (container) type with array leaves.
+
+        All traced values are nested under an index.
+
+        For any array type specifier `t`, `[t]` represents the type with an additional leading axis, and if `t` is a pytree (container) type with array leaves then `[t]` represents the type with the same pytree structure and corresponding leaves each with an additional leading axis.
+
+        When the type of `xs` (denoted `[a]` above) is an array type or None, and the type of `ys` (denoted `[b]` above) is an array type, the semantics of the returned [`genjax.GenerativeFunction`][] are given roughly by this Python implementation:
+
+        ```python
+        def scan(f, init, xs, length=None):
+            if xs is None:
+                xs = [None] * length
+            carry = init
+            ys = []
+            for x in xs:
+                carry, y = f(carry, x)
+                ys.append(y)
+            return carry, np.stack(ys)
+        ```
+
+        Unlike that Python version, both `xs` and `ys` may be arbitrary pytree values, and so multiple arrays can be scanned over at once and produce multiple output arrays. `None` is actually a special case of this, as it represents an empty pytree.
+
+        The loop-carried value `c` must hold a fixed shape and dtype across all iterations (and not just be consistent up to NumPy rank/shape broadcasting and dtype promotion rules, for example). In other words, the type `c` in the type signature above represents an array with a fixed shape and dtype (or a nested tuple/list/dict container data structure with a fixed structure and arrays with fixed shape and dtype at the leaves).
+
+        Args:
+            n: optional integer specifying the number of loop iterations, which (if supplied) must agree with the sizes of leading axes of the arrays in `xs`. If supplied then the returned generative function can take `None` in place of `xs`, as seen in the Python example above.
+
+            reverse: optional boolean specifying whether to run the scan iteration forward (the default) or in reverse, equivalent to reversing the leading axes of the arrays in both `xs` and in `ys`.
+
+            unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many scan iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
+
+        Examples:
+            Scan for 1000 iterations with no array input:
+            ```python exec="yes" html="true" source="material-block" session="scan"
+            import jax
+            import genjax
+
+
+            @genjax.gen
+            def random_walk(prev, _):
+                x = genjax.normal(prev, 1.0) @ "x"
+                return x, None
+
+
+            scan_fn = random_walk.scan(n=1000)
+            init = 0.5
+            key = jax.random.PRNGKey(314159)
+
+            tr = jax.jit(scan_fn.simulate)(key, (init, None))
+            print(tr.render_html())
+            ```
+
+            Scan across an input array:
+            ```python exec="yes" html="true" source="material-block" session="scan"
+            import jax.numpy as jnp
+
+
+            @genjax.gen
+            def add_and_square(sum, x):
+                new_sum = sum + x
+                return new_sum, sum * sum
+
+
+            # notice no `n` parameter supplied:
+            scan_fn = add_and_square.scan()
+            init = 0.0
+            xs = jnp.ones(10)
+
+            tr = jax.jit(scan_fn.simulate)(key, (init, xs))
+
+            # The retval has the final carry and an array of all `sum*sum` returned.
+            print(tr.render_html())
+            ```
+        """
         import genjax
 
-        return genjax.scan(n=n)(self)
+        return genjax.scan(n=n, reverse=reverse, unroll=unroll)(self)
 
-    def mask(self) -> "GenerativeFunction":
+    def mask(self, /) -> "GenerativeFunction":
         import genjax
 
         return genjax.mask(self)
 
-    def or_else(self, gen_fn: "GenerativeFunction") -> "GenerativeFunction":
+    def or_else(self, gen_fn: "GenerativeFunction", /) -> "GenerativeFunction":
         """
         Returns a [`GenerativeFunction`][genjax.GenerativeFunction] that accepts
 
@@ -970,14 +1056,14 @@ class GenerativeFunction(Pytree):
     ) -> "GenerativeFunction":
         import genjax
 
-        return genjax.map(f=f, info=info)
+        return genjax.map(f=f, info=info)(self)
 
     def contramap(
         self, f: Callable, *, info: Optional[String] = None
     ) -> "GenerativeFunction":
         import genjax
 
-        return genjax.contramap(f=f, info=info)
+        return genjax.contramap(f=f, info=info)(self)
 
     #####################
     # GenSP / inference #

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -125,11 +125,11 @@ class ScanCombinator(GenerativeFunction):
     - `a` may be a primitive, an array type or a pytree (container) type with array leaves
     - `b` may be a primitive, an array type or a pytree (container) type with array leaves.
 
-    All traced values are nested under an index.
+    The values traced by each call to the original generative function will be nested under an integer index that matches the loop iteration index that generated it.
 
     For any array type specifier `t`, `[t]` represents the type with an additional leading axis, and if `t` is a pytree (container) type with array leaves then `[t]` represents the type with the same pytree structure and corresponding leaves each with an additional leading axis.
 
-    When the type of `xs` (denoted `[a]` above) is an array type or None, and the type of `ys` (denoted `[b]` above) is an array type, the semantics of the returned [`genjax.GenerativeFunction`][] are given roughly by this Python implementation:
+    When the type of `xs` in the snippet below (denoted `[a]` above) is an array type or None, and the type of `ys` in the snippet below (denoted `[b]` above) is an array type, the semantics of the returned [`genjax.GenerativeFunction`][] are given roughly by this Python implementation:
 
     ```python
     def scan(f, init, xs, length=None):
@@ -150,7 +150,7 @@ class ScanCombinator(GenerativeFunction):
     Attributes:
         kernel_gen_fn: a generative function to be scanned of type `(c, a) -> (c, b)`, meaning that `f` accepts two arguments where the first is a value of the loop carry and the second is a slice of `xs` along its leading axis, and that `f` returns a pair where the first element represents a new value for the loop carry and the second represents a slice of the output.
 
-        length: optional integer specifying the number of loop iterations, which (if supplied) must agree with the sizes of leading axes of the arrays in `xs`. If supplied then the returned generative function can take `None` in place of `xs`, as seen in the Python example above.
+        length: optional integer specifying the number of loop iterations, which (if supplied) must agree with the sizes of leading axes of the arrays in the returned function's second argument. If supplied then the returned generative function can take `None` as its second argument.
 
         reverse: optional boolean specifying whether to run the scan iteration forward (the default) or in reverse, equivalent to reversing the leading axes of the arrays in both `xs` and in `ys`.
 
@@ -165,7 +165,7 @@ class ScanCombinator(GenerativeFunction):
 
         # A kernel_gen_fn generative function.
         @genjax.gen
-        def random_walk(prev, _):
+        def random_walk_step(prev, _):
             x = genjax.normal(prev, 1.0) @ "x"
             return x, None
 
@@ -173,9 +173,9 @@ class ScanCombinator(GenerativeFunction):
         init = 0.5
         key = jax.random.PRNGKey(314159)
 
-        scan_gen_fned_random_walk = random_walk.scan(n=1000)
+        random_walk = random_walk_step.scan(n=1000)
 
-        tr = jax.jit(scan_gen_fned_random_walk.simulate)(key, (init, None))
+        tr = jax.jit(random_walk.simulate)(key, (init, None))
         print(tr.render_html())
         ```
 
@@ -553,11 +553,11 @@ def scan(
     - `a` may be a primitive, an array type or a pytree (container) type with array leaves
     - `b` may be a primitive, an array type or a pytree (container) type with array leaves.
 
-    All traced values are nested under an index.
+    The values traced by each call to the original generative function will be nested under an integer index that matches the loop iteration index that generated it.
 
     For any array type specifier `t`, `[t]` represents the type with an additional leading axis, and if `t` is a pytree (container) type with array leaves then `[t]` represents the type with the same pytree structure and corresponding leaves each with an additional leading axis.
 
-    When the type of `xs` (denoted `[a]` above) is an array type or None, and the type of `ys` (denoted `[b]` above) is an array type, the semantics of the returned [`genjax.GenerativeFunction`][] are given roughly by this Python implementation:
+    When the type of `xs` in the snippet below (denoted `[a]` above) is an array type or None, and the type of `ys` in the snippet below (denoted `[b]` above) is an array type, the semantics of the returned [`genjax.GenerativeFunction`][] are given roughly by this Python implementation:
 
     ```python
     def scan(f, init, xs, length=None):
@@ -576,7 +576,7 @@ def scan(
     The loop-carried value `c` must hold a fixed shape and dtype across all iterations (and not just be consistent up to NumPy rank/shape broadcasting and dtype promotion rules, for example). In other words, the type `c` in the type signature above represents an array with a fixed shape and dtype (or a nested tuple/list/dict container data structure with a fixed structure and arrays with fixed shape and dtype at the leaves).
 
     Args:
-        n: optional integer specifying the number of loop iterations, which (if supplied) must agree with the sizes of leading axes of the arrays in `xs`. If supplied then the returned generative function can take `None` in place of `xs`, as seen in the Python example above.
+        n: optional integer specifying the number of loop iterations, which (if supplied) must agree with the sizes of leading axes of the arrays in the returned function's second argument. If supplied then the returned generative function can take `None` as its second argument.
 
         reverse: optional boolean specifying whether to run the scan iteration forward (the default) or in reverse, equivalent to reversing the leading axes of the arrays in both `xs` and in `ys`.
 
@@ -610,7 +610,7 @@ def scan(
 
         @genjax.scan()
         @genjax.gen
-        def add_and_square(sum, x):
+        def add_and_square_all(sum, x):
             new_sum = sum + x
             return new_sum, sum * sum
 
@@ -618,7 +618,7 @@ def scan(
         init = 0.0
         xs = jnp.ones(10)
 
-        tr = jax.jit(add_and_square.simulate)(key, (init, xs))
+        tr = jax.jit(add_and_square_all.simulate)(key, (init, xs))
 
         # The retval has the final carry and an array of all `sum*sum` returned.
         print(tr.render_html())

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -41,6 +41,7 @@ from genjax._src.core.typing import (
     FloatArray,
     Int,
     IntArray,
+    Optional,
     PRNGKey,
     Tuple,
     typecheck,
@@ -66,7 +67,7 @@ class ScanTrace(Trace):
     def get_sample(self):
         return jax.vmap(
             lambda idx, subtrace: ChoiceMap.idx(idx, subtrace.get_sample()),
-        )(jnp.arange(self.scan_gen_fn.max_length), self.inner)
+        )(jnp.arange(self.scan_gen_fn.length), self.inner)
 
     def get_gen_fn(self):
         return self.scan_gen_fn
@@ -117,14 +118,47 @@ class CheckerboardProblem(UpdateProblem):
 
 @Pytree.dataclass
 class ScanCombinator(GenerativeFunction):
-    """> `ScanCombinator` accepts a kernel_gen_fn generative function, as well as a static
-    maximum unroll length, and provides a scan-like pattern of generative computation.
+    """
+    `ScanCombinator` wraps a `kernel_gen_fn` [`genjax.GenerativeFunction`][] of type `(c, a) -> (c, b)` in a new [`genjax.GenerativeFunction`][] of type `(c, [a]) -> (c, [b])`, where
 
-    !!! info "kernel_gen_fn generative functions"
-        A kernel_gen_fn generative function is one which accepts and returns the same signature of arguments. Under the hood, `ScanCombinator` is implemented using `jax.lax.scan` - which has the same requirements.
+    - `c` is a loop-carried value, which must hold a fixed shape and dtype across all iterations
+    - `a` may be a primitive, an array type or a pytree (container) type with array leaves
+    - `b` may be a primitive, an array type or a pytree (container) type with array leaves.
+
+    All traced values are nested under an index.
+
+    For any array type specifier `t`, `[t]` represents the type with an additional leading axis, and if `t` is a pytree (container) type with array leaves then `[t]` represents the type with the same pytree structure and corresponding leaves each with an additional leading axis.
+
+    When the type of `xs` (denoted `[a]` above) is an array type or None, and the type of `ys` (denoted `[b]` above) is an array type, the semantics of the returned [`genjax.GenerativeFunction`][] are given roughly by this Python implementation:
+
+    ```python
+    def scan(f, init, xs, length=None):
+        if xs is None:
+            xs = [None] * length
+        carry = init
+        ys = []
+        for x in xs:
+            carry, y = f(carry, x)
+            ys.append(y)
+        return carry, np.stack(ys)
+    ```
+
+    Unlike that Python version, both `xs` and `ys` may be arbitrary pytree values, and so multiple arrays can be scanned over at once and produce multiple output arrays. `None` is actually a special case of this, as it represents an empty pytree.
+
+    The loop-carried value `c` must hold a fixed shape and dtype across all iterations (and not just be consistent up to NumPy rank/shape broadcasting and dtype promotion rules, for example). In other words, the type `c` in the type signature above represents an array with a fixed shape and dtype (or a nested tuple/list/dict container data structure with a fixed structure and arrays with fixed shape and dtype at the leaves).
+
+    Attributes:
+        kernel_gen_fn: a generative function to be scanned of type `(c, a) -> (c, b)`, meaning that `f` accepts two arguments where the first is a value of the loop carry and the second is a slice of `xs` along its leading axis, and that `f` returns a pair where the first element represents a new value for the loop carry and the second represents a slice of the output.
+
+        length: optional integer specifying the number of loop iterations, which (if supplied) must agree with the sizes of leading axes of the arrays in `xs`. If supplied then the returned generative function can take `None` in place of `xs`, as seen in the Python example above.
+
+        reverse: optional boolean specifying whether to run the scan iteration forward (the default) or in reverse, equivalent to reversing the leading axes of the arrays in both `xs` and in `ys`.
+
+        unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many scan iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
 
     Examples:
-        ```python exec="yes" html="true" source="material-block" session="gen-fn"
+        Use the [`genjax.GenerativeFunction.scan`][] method:
+        ```python exec="yes" html="true" source="material-block" session="scan"
         import jax
         import genjax
 
@@ -136,11 +170,17 @@ class ScanCombinator(GenerativeFunction):
             return x, None
 
 
-        # You can apply the Scan combinator directly like this:
+        init = 0.5
+        key = jax.random.PRNGKey(314159)
+
         scan_gen_fned_random_walk = random_walk.scan(n=1000)
 
+        tr = jax.jit(scan_gen_fned_random_walk.simulate)(key, (init, None))
+        print(tr.render_html())
+        ```
 
-        # You can also use the decorator when declaring the function:
+        Or use the [`genjax.scan`][] decorator:
+        ```python exec="yes" html="true" source="material-block" session="scan"
         @genjax.scan(n=1000)
         @genjax.gen
         def random_walk(prev, _):
@@ -148,16 +188,17 @@ class ScanCombinator(GenerativeFunction):
             return x, None
 
 
-        init = 0.5
-        key = jax.random.PRNGKey(314159)
         tr = jax.jit(random_walk.simulate)(key, (init, None))
-
         print(tr.render_html())
         ```
     """
 
     kernel_gen_fn: GenerativeFunction
-    max_length: Int = Pytree.static()
+
+    # Only required for `None` carry inputs
+    length: Optional[Int] = Pytree.static()
+    reverse: bool = Pytree.static(default=False)
+    unroll: int | bool = Pytree.static(default=1)
 
     # To get the type of return value, just invoke
     # the scanned over source (with abstract tracer arguments).
@@ -172,7 +213,9 @@ class ScanCombinator(GenerativeFunction):
             _inner,
             carry,
             scanned_in,
-            length=self.max_length,
+            length=self.length,
+            reverse=self.reverse,
+            unroll=self.unroll,
         )
 
         return v, scanned_out
@@ -204,7 +247,9 @@ class ScanCombinator(GenerativeFunction):
             _inner,
             (key, 0, carry),
             scanned_in,
-            length=self.max_length,
+            length=self.length,
+            reverse=self.reverse,
+            unroll=self.unroll,
         )
 
         return ScanTrace(self, tr, args, (carried_out, scanned_out), jnp.sum(scores))
@@ -246,7 +291,9 @@ class ScanCombinator(GenerativeFunction):
             _importance,
             (key, 0, carry),
             scanned_in,
-            length=self.max_length,
+            length=self.length,
+            reverse=self.reverse,
+            unroll=self.unroll,
         )
         return (
             ScanTrace(self, tr, args, (carried_out, scanned_out), jnp.sum(scores)),
@@ -332,7 +379,9 @@ class ScanCombinator(GenerativeFunction):
             _update,
             (key, 0, carry_diff),
             (trace.inner, *scanned_in_diff),
-            length=self.max_length,
+            length=self.length,
+            reverse=self.reverse,
+            unroll=self.unroll,
         )
         carried_out, scanned_out = Diff.tree_primal((
             carried_out_diff,
@@ -478,7 +527,9 @@ class ScanCombinator(GenerativeFunction):
             _assess,
             (0, carry),
             scanned_in,
-            length=self.max_length,
+            length=self.length,
+            reverse=self.reverse,
+            unroll=self.unroll,
         )
         return (
             jnp.sum(scores),
@@ -486,14 +537,95 @@ class ScanCombinator(GenerativeFunction):
         )
 
 
-#############
-# Decorator #
-#############
+##############
+# Decorators #
+##############
 
 
 @typecheck
-def scan(*, n: Int) -> Callable[[GenerativeFunction], ScanCombinator]:
+def scan(
+    *, n: Optional[Int] = None, reverse: bool = False, unroll: int | bool = 1
+) -> Callable[[GenerativeFunction], ScanCombinator]:
+    """
+    Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type `(c, a) -> (c, b)`and returns a new [`genjax.GenerativeFunction`][] of type `(c, [a]) -> (c, [b])` where
+
+    - `c` is a loop-carried value, which must hold a fixed shape and dtype across all iterations
+    - `a` may be a primitive, an array type or a pytree (container) type with array leaves
+    - `b` may be a primitive, an array type or a pytree (container) type with array leaves.
+
+    All traced values are nested under an index.
+
+    For any array type specifier `t`, `[t]` represents the type with an additional leading axis, and if `t` is a pytree (container) type with array leaves then `[t]` represents the type with the same pytree structure and corresponding leaves each with an additional leading axis.
+
+    When the type of `xs` (denoted `[a]` above) is an array type or None, and the type of `ys` (denoted `[b]` above) is an array type, the semantics of the returned [`genjax.GenerativeFunction`][] are given roughly by this Python implementation:
+
+    ```python
+    def scan(f, init, xs, length=None):
+        if xs is None:
+            xs = [None] * length
+        carry = init
+        ys = []
+        for x in xs:
+            carry, y = f(carry, x)
+            ys.append(y)
+        return carry, np.stack(ys)
+    ```
+
+    Unlike that Python version, both `xs` and `ys` may be arbitrary pytree values, and so multiple arrays can be scanned over at once and produce multiple output arrays. `None` is actually a special case of this, as it represents an empty pytree.
+
+    The loop-carried value `c` must hold a fixed shape and dtype across all iterations (and not just be consistent up to NumPy rank/shape broadcasting and dtype promotion rules, for example). In other words, the type `c` in the type signature above represents an array with a fixed shape and dtype (or a nested tuple/list/dict container data structure with a fixed structure and arrays with fixed shape and dtype at the leaves).
+
+    Args:
+        n: optional integer specifying the number of loop iterations, which (if supplied) must agree with the sizes of leading axes of the arrays in `xs`. If supplied then the returned generative function can take `None` in place of `xs`, as seen in the Python example above.
+
+        reverse: optional boolean specifying whether to run the scan iteration forward (the default) or in reverse, equivalent to reversing the leading axes of the arrays in both `xs` and in `ys`.
+
+        unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many scan iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
+
+    Examples:
+        Scan for 1000 iterations with no array input:
+        ```python exec="yes" html="true" source="material-block" session="scan"
+        import jax
+        import genjax
+
+
+        @genjax.scan(n=1000)
+        @genjax.gen
+        def random_walk(prev, _):
+            x = genjax.normal(prev, 1.0) @ "x"
+            return x, None
+
+
+        init = 0.5
+        key = jax.random.PRNGKey(314159)
+
+        tr = jax.jit(random_walk.simulate)(key, (init, None))
+        print(tr.render_html())
+        ```
+
+        Scan across an input array:
+        ```python exec="yes" html="true" source="material-block" session="scan"
+        import jax.numpy as jnp
+
+
+        @genjax.scan()
+        @genjax.gen
+        def add_and_square(sum, x):
+            new_sum = sum + x
+            return new_sum, sum * sum
+
+
+        init = 0.0
+        xs = jnp.ones(10)
+
+        tr = jax.jit(add_and_square.simulate)(key, (init, xs))
+
+        # The retval has the final carry and an array of all `sum*sum` returned.
+        print(tr.render_html())
+        ```
+    """
+
     def decorator(f):
-        return ScanCombinator(f, n)
+        return ScanCombinator(f, length=n, reverse=reverse, unroll=unroll)
 
     return decorator


### PR DESCRIPTION
This PR:

- Beefs up documentation on `ScanCombinator`, the `genjax.scan` decorator and the `scan` method on `GenerativeFunction`
- renames `max_length` to `length` on `ScanCombinator`, and makes it optional (so that we don't have to specify this if we supply an array over which to scan)
- adds `reverse` and `unroll` arguments that we can pass through to `jax.lax.scan`, with defaults supplied