### PR TITLE
Update URLs to GenJAX website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Here is a list of important resources for contributors:
 
 [apache 2.0 license]: https://opensource.org/licenses/Apache-2.0
 [source code]: https://github.com/probcomp/genjax
-[documentation]: https://probcomp.github.io/genjax
+[documentation]: https://genjax.gen.dev
 [issue tracker]: https://github.com/probcomp/genjax/issues
 
 ## How to report a bug

--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@
 
 | **Documentation** |          **Build status**          |
 | :---------------: | :--------------------------------: |
-| [![](https://img.shields.io/badge/docs-stable-blue.svg?style=flat-square)](https://probcomp.github.io/genjax/) [![](https://img.shields.io/badge/jupyter-%23FA0F00.svg?style=flat-square&logo=jupyter&logoColor=white)][cookbook] | [![][main_build_action_badge]][main_build_status_url] |
+| [![](https://img.shields.io/badge/docs-stable-blue.svg?style=flat-square)](https://genjax.gen.dev/) [![](https://img.shields.io/badge/jupyter-%23FA0F00.svg?style=flat-square&logo=jupyter&logoColor=white)][cookbook] | [![][main_build_action_badge]][main_build_status_url] |
 
 </div>
 
 ## 🔎 What is GenJAX?
 
-Gen is a multi-paradigm (generative, differentiable, incremental) language for probabilistic programming focused on [**generative functions**: computational objects which represent probability measures over structured sample spaces](https://probcomp.github.io/genjax/cookbook/active/intro.html#generative-functions).
+Gen is a multi-paradigm (generative, differentiable, incremental) language for probabilistic programming focused on [**generative functions**: computational objects which represent probability measures over structured sample spaces](https://genjax.gen.dev/cookbook/active/intro.html#generative-functions).
 
 GenJAX is an implementation of Gen on top of [JAX](https://github.com/google/jax) - exposing the ability to programmatically construct and manipulate generative functions, as well as [JIT compile + auto-batch inference computations using generative functions onto GPU devices](https://jax.readthedocs.io/en/latest/jax-101/02-jitting.html).
 
 <div align="center">
-<a href="https://probcomp.github.io/genjax/cookbook/">Jump into the notebooks!</a>
+<a href="https://genjax.gen.dev/cookbook/">Jump into the notebooks!</a>
 <br>
 <br>
 </div>
@@ -168,7 +168,7 @@ Created and maintained by the <a href="http://probcomp.csail.mit.edu/">MIT Proba
 
 [actions]: https://github.com/probcomp/genjax/actions
 [adev]: https://arxiv.org/abs/2212.06386
-[cookbook]: https://probcomp.github.io/genjax/cookbook/
+[cookbook]: https://genjax.gen.dev/cookbook/
 [coverage_badge]: https://github.com/probcomp/genjax/coverage.svg
 [effect_handling_interp]: https://colab.research.google.com/drive/1HGs59anVC2AOsmt7C4v8yD6v8gZSJGm6#scrollTo=ukjVJ2Ls_6Q3
 [equinox]: https://github.com/patrick-kidger/equinox

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,7 @@ Here is a list of important resources for contributors:
 
 [apache 2.0 license]: https://opensource.org/licenses/Apache-2.0
 [source code]: https://github.com/probcomp/genjax
-[documentation]: https://probcomp.github.io/genjax
+[documentation]: https://genjax.gen.dev
 [issue tracker]: https://github.com/probcomp/genjax/issues
 
 ## How to report a bug

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 site_name: GenJAX
-site_url: https://probcomp.github.io/genjax/
+site_url: https://genjax.gen.dev/
 repo_url: https://github.com/probcomp/genjax
 repo_name: probcomp/genjax
 edit_uri: edit/main/docs/

--- a/notebooks/index.ipynb
+++ b/notebooks/index.ipynb
@@ -14,7 +14,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is a recipe book for _getting started with GenJAX_. It is **not** an exhaustive reference on the concepts and implementation of GenJAX ([you can find that in the documentation](https://probcomp.github.io/genjax/library/core.html))"
+    "This is a recipe book for _getting started with GenJAX_. It is **not** an exhaustive reference on the concepts and implementation of GenJAX ([you can find that in the documentation](https://genjax.gen.dev/library/core.html))"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license = "Apache 2.0"
 readme = "README.md"
 homepage = "https://github.com/probcomp/genjax"
 repository = "https://github.com/probcomp/genjax"
-documentation = "https://probcomp.github.io/genjax/"
+documentation = "https://genjax.gen.dev/"
 keywords = [
   "artificial-intelligence",
   "probabilistic-programming",


### PR DESCRIPTION
The official GenJAX website has been moved to https://genjax.gen.dev/. However, many places in our documentations still points to https://probcomp.github.io/genjax, which currently leads to the 404 page.

As a simple fix, I replaced all occurrences of `"probcomp.github.io/genjax"` with `"genjax.gen.dev"` in the current GenJAX repo.

## Test Plan

I've manually clicked into each of the new URLs and verified that all of them are valid :).