### PR TITLE
make gfi_boundary preserve types (GEN-313, GEN-336)

### DIFF
--- a/notebooks/cookbook/basics/generative_fun.ipynb
+++ b/notebooks/cookbook/basics/generative_fun.ipynb
@@ -23,7 +23,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following is a simple  of a beta-bernoulli process. We use the @gen decorator to create generative functions."
+    "The following is a simple  of a beta-bernoulli process. We use the `@gen` decorator to create generative functions."
    ]
   },
   {

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -49,8 +49,8 @@ from genjax._src.core.typing import (
 
 register_exclusion(__file__)
 
-P = ParamSpec("P")
-T = TypeVar("T")
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
 
 #####################################
 # Special generative function types #
@@ -526,7 +526,7 @@ class GenerativeFunction(Pytree):
         return jtu.tree_map(lambda v: jnp.zeros(v.shape, dtype=v.dtype), data_shape)
 
     @classmethod
-    def gfi_boundary(cls, c: Callable[P, T]) -> Callable[P, T]:
+    def gfi_boundary(cls, c: Callable[_P, _T]) -> Callable[_P, _T]:
         return gfi_boundary(c)
 
     @abstractmethod

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -320,7 +320,7 @@ class Trace(Pytree):
     def get_score(self) -> Score:
         """Return the [`Score`][genjax.core.Score] of the `Trace`.
 
-        The score must satisfy a particular mathematical specification: it's either an exact density evaluation of $P$ (the distribution over samples) for the sample returned by `Trace.get_sample`, or _a sample from an estimator_ (a density estimate) if the generative function contains _untraced randomness_.
+        The score must satisfy a particular mathematical specification: it's either an exact density evaluation of $P$ (the distribution over samples) for the sample returned by [`genjax.Trace.get_sample`][], or _a sample from an estimator_ (a density estimate) if the generative function contains _untraced randomness_.
 
         Let $s$ be the score, $t$ the sample, and $a$ the arguments: when the generative function contains no _untraced randomness_, the score (in logspace) is given by:
 
@@ -370,7 +370,7 @@ class Trace(Pytree):
     # TODO: deprecated.
     @typecheck
     def get_choices(self) -> "genjax.ChoiceMap":
-        """Version of [`Trace.get_sample`][] for traces where the sample is an instance of [`ChoiceMap`][genjax.core.ChoiceMap]."""
+        """Version of [`genjax.Trace.get_sample`][] for traces where the sample is an instance of [`genjax.ChoiceMap`][]."""
         return self.get_sample()
 
     @abstractmethod
@@ -547,7 +547,7 @@ class GenerativeFunction(Pytree):
 
         The [`Trace`][genjax.core.Trace] returned by `simulate` implements its own interface.
 
-        It is responsible for storing the arguments of the invocation ([`Trace.get_args`](core.md#genjax.core.Trace.get_args)), the return value of the generative function ([`Trace.get_retval`](core.md#genjax.core.Trace.get_retval)), the identity of the generative function which produced the trace ([`Trace.get_gen_fn`](core.md#genjax.core.Trace.get_gen_fn)), the sample of traced random choices produced during the invocation ([`Trace.get_sample`](core.md#genjax.core.Trace.get_sample)) and _the score_ of the sample ([`Trace.get_score`](core.md#genjax.core.Trace.get_score)).
+        It is responsible for storing the arguments of the invocation ([`genjax.Trace.get_args`][]), the return value of the generative function ([`genjax.Trace.get_retval`][]), the identity of the generative function which produced the trace ([`genjax.Trace.get_gen_fn`][]), the sample of traced random choices produced during the invocation ([`genjax.Trace.get_sample`][]) and _the score_ of the sample ([`genjax.Trace.get_score`][]).
 
         Examples:
             ```python exec="yes" html="true" source="material-block" session="core"

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
@@ -48,6 +49,10 @@ from genjax._src.core.typing import (
 )
 
 register_exclusion(__file__)
+
+# Import `genjax` so static typecheckers can see the circular reference to "genjax.ChoiceMap" below.
+if TYPE_CHECKING:
+    import genjax
 
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
@@ -364,7 +369,7 @@ class Trace(Pytree):
 
     # TODO: deprecated.
     @typecheck
-    def get_choices(self) -> "ChoiceMap":
+    def get_choices(self) -> "genjax.ChoiceMap":
         """Version of [`Trace.get_sample`][] for traces where the sample is an instance of [`ChoiceMap`][genjax.core.ChoiceMap]."""
         return self.get_sample()
 

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -527,7 +527,7 @@ class GenerativeFunction(Pytree):
         return jtu.tree_map(lambda v: jnp.zeros(v.shape, dtype=v.dtype), data_shape)
 
     @classmethod
-    def gfi_boundary(_cls, c: Callable[P, T]) -> Callable[P, T]:
+    def gfi_boundary(cls, c: Callable[P, T]) -> Callable[P, T]:
         return gfi_boundary(c)
 
     @abstractmethod

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -19,7 +19,6 @@ import jax.numpy as jnp
 import jax.tree_util as jtu
 from penzai.core import formatting_util
 
-from genjax._src.core.generative.choice_map import ChoiceMap
 from genjax._src.core.interpreters.incremental import Diff
 from genjax._src.core.interpreters.staging import get_trace_shape, staged_and
 from genjax._src.core.pytree import Pytree
@@ -38,26 +37,22 @@ from genjax._src.core.typing import (
     Is,
     List,
     Optional,
-    ParamSpec,
     PRNGKey,
     ScalarFloat,
     String,
     Tuple,
-    TypeVar,
     static_check_is_concrete,
     typecheck,
 )
 
 register_exclusion(__file__)
 
-P = ParamSpec("P")
-T = TypeVar("T")
-
 #####################################
 # Special generative function types #
 #####################################
 
 Weight = ScalarFloat
+
 """
 A _weight_ is a density ratio which often occurs in the context of proper weighting for [`Target`][genjax.inference.Target] distributions, or in Gen's [`update`][genjax.core.GenerativeFunction.update] interface, whose mathematical content is described in [`update`][genjax.core.GenerativeFunction.update].
 
@@ -364,9 +359,7 @@ class Trace(Pytree):
         """Return the [`Sample`][genjax.core.Sample] sampled from the distribution over samples by the generative function during the invocation which created the [`Trace`][genjax.core.Trace]."""
 
     # TODO: deprecated.
-    @typecheck
-    def get_choices(self) -> ChoiceMap:
-        """Version of [`Trace.get_sample`][] for traces where the sample is an instance of [`ChoiceMap][genjax.core.ChoiceMap]."""
+    def get_choices(self) -> Sample:
         return self.get_sample()
 
     @abstractmethod
@@ -527,7 +520,7 @@ class GenerativeFunction(Pytree):
         return jtu.tree_map(lambda v: jnp.zeros(v.shape, dtype=v.dtype), data_shape)
 
     @classmethod
-    def gfi_boundary(cls, c: Callable[P, T]) -> Callable[P, T]:
+    def gfi_boundary(cls, c: Callable) -> Callable:
         return gfi_boundary(c)
 
     @abstractmethod

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -19,6 +19,7 @@ import jax.numpy as jnp
 import jax.tree_util as jtu
 from penzai.core import formatting_util
 
+from genjax._src.core.generative.choice_map import ChoiceMap
 from genjax._src.core.interpreters.incremental import Diff
 from genjax._src.core.interpreters.staging import get_trace_shape, staged_and
 from genjax._src.core.pytree import Pytree
@@ -37,22 +38,26 @@ from genjax._src.core.typing import (
     Is,
     List,
     Optional,
+    ParamSpec,
     PRNGKey,
     ScalarFloat,
     String,
     Tuple,
+    TypeVar,
     static_check_is_concrete,
     typecheck,
 )
 
 register_exclusion(__file__)
 
+P = ParamSpec("P")
+T = TypeVar("T")
+
 #####################################
 # Special generative function types #
 #####################################
 
 Weight = ScalarFloat
-
 """
 A _weight_ is a density ratio which often occurs in the context of proper weighting for [`Target`][genjax.inference.Target] distributions, or in Gen's [`update`][genjax.core.GenerativeFunction.update] interface, whose mathematical content is described in [`update`][genjax.core.GenerativeFunction.update].
 
@@ -359,7 +364,9 @@ class Trace(Pytree):
         """Return the [`Sample`][genjax.core.Sample] sampled from the distribution over samples by the generative function during the invocation which created the [`Trace`][genjax.core.Trace]."""
 
     # TODO: deprecated.
-    def get_choices(self) -> Sample:
+    @typecheck
+    def get_choices(self) -> ChoiceMap:
+        """Version of [`Trace.get_sample`][] for traces where the sample is an instance of [`ChoiceMap][genjax.core.ChoiceMap]."""
         return self.get_sample()
 
     @abstractmethod
@@ -520,7 +527,7 @@ class GenerativeFunction(Pytree):
         return jtu.tree_map(lambda v: jnp.zeros(v.shape, dtype=v.dtype), data_shape)
 
     @classmethod
-    def gfi_boundary(cls, c: Callable) -> Callable:
+    def gfi_boundary(_cls, c: Callable[P, T]) -> Callable[P, T]:
         return gfi_boundary(c)
 
     @abstractmethod

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -37,22 +37,26 @@ from genjax._src.core.typing import (
     Is,
     List,
     Optional,
+    ParamSpec,
     PRNGKey,
     ScalarFloat,
     String,
     Tuple,
+    TypeVar,
     static_check_is_concrete,
     typecheck,
 )
 
 register_exclusion(__file__)
 
+P = ParamSpec("P")
+T = TypeVar("T")
+
 #####################################
 # Special generative function types #
 #####################################
 
 Weight = ScalarFloat
-
 """
 A _weight_ is a density ratio which often occurs in the context of proper weighting for [`Target`][genjax.inference.Target] distributions, or in Gen's [`update`][genjax.core.GenerativeFunction.update] interface, whose mathematical content is described in [`update`][genjax.core.GenerativeFunction.update].
 
@@ -359,7 +363,9 @@ class Trace(Pytree):
         """Return the [`Sample`][genjax.core.Sample] sampled from the distribution over samples by the generative function during the invocation which created the [`Trace`][genjax.core.Trace]."""
 
     # TODO: deprecated.
-    def get_choices(self) -> Sample:
+    @typecheck
+    def get_choices(self) -> "ChoiceMap":
+        """Version of [`Trace.get_sample`][] for traces where the sample is an instance of [`ChoiceMap`][genjax.core.ChoiceMap]."""
         return self.get_sample()
 
     @abstractmethod
@@ -520,7 +526,7 @@ class GenerativeFunction(Pytree):
         return jtu.tree_map(lambda v: jnp.zeros(v.shape, dtype=v.dtype), data_shape)
 
     @classmethod
-    def gfi_boundary(cls, c: Callable) -> Callable:
+    def gfi_boundary(cls, c: Callable[P, T]) -> Callable[P, T]:
         return gfi_boundary(c)
 
     @abstractmethod

--- a/src/genjax/_src/core/traceback_util.py
+++ b/src/genjax/_src/core/traceback_util.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import jax._src.traceback_util as traceback_util
-
 from beartype.typing import Callable, ParamSpec, TypeVar
 
 P = ParamSpec("P")

--- a/src/genjax/_src/core/traceback_util.py
+++ b/src/genjax/_src/core/traceback_util.py
@@ -14,7 +14,7 @@
 
 import jax._src.traceback_util as traceback_util
 
-from genjax._src.core.typing import Callable, ParamSpec, TypeVar
+from beartype.typing import Callable, ParamSpec, TypeVar
 
 P = ParamSpec("P")
 T = TypeVar("T")

--- a/src/genjax/_src/core/traceback_util.py
+++ b/src/genjax/_src/core/traceback_util.py
@@ -14,11 +14,16 @@
 
 import jax._src.traceback_util as traceback_util
 
+from genjax._src.core.typing import Callable, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
 
 # register_exclusion = traceback_util.register_exclusion
 def register_exclusion(v):
     return v
 
 
-def gfi_boundary(c):
+def gfi_boundary(c: Callable[P, T]) -> Callable[P, T]:
     return traceback_util.api_boundary(c)

--- a/src/genjax/_src/core/traceback_util.py
+++ b/src/genjax/_src/core/traceback_util.py
@@ -15,8 +15,8 @@
 import jax._src.traceback_util as traceback_util
 from beartype.typing import Callable, ParamSpec, TypeVar
 
-P = ParamSpec("P")
-T = TypeVar("T")
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
 
 
 # register_exclusion = traceback_util.register_exclusion
@@ -24,5 +24,5 @@ def register_exclusion(v):
     return v
 
 
-def gfi_boundary(c: Callable[P, T]) -> Callable[P, T]:
+def gfi_boundary(c: Callable[_P, _T]) -> Callable[_P, _T]:
     return traceback_util.api_boundary(c)

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -178,6 +178,7 @@ __all__ = [
     "IntArray",
     "Is",
     "List",
+    "ParamSpec",
     "PRNGKey",
     "ScalarBool",
     "ScalarFloat",

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -73,6 +73,7 @@ ScalarFloat = Annotated[Float | FloatArray, ScalarShaped]
 
 Generic = btyping.Generic
 TypeVar = btyping.TypeVar
+ParamSpec = btyping.ParamSpec
 
 ########################################
 # Static typechecking from annotations #

--- a/src/genjax/_src/inference/sp.py
+++ b/src/genjax/_src/inference/sp.py
@@ -43,7 +43,7 @@ from genjax._src.generative_functions.distributions.distribution import Distribu
 @Pytree.dataclass
 class Target(Pytree):
     """
-    A `Target` represents an unnormalized target distribution induced by conditioning a generative function on a [`Constraint`](core.md#genjax.core.Constraint).
+    A `Target` represents an unnormalized target distribution induced by conditioning a generative function on a [`genjax.Constraint`][].
 
     Targets are created by providing a generative function, arguments to the generative function, and a constraint.
 


### PR DESCRIPTION
This PR:

- Makes `ChoiceMap` the return type of `get_choices` (with a `@typecheck` annotation so this will fail at runtime if `get_sample` returns something different)
- modifies `gfi_boundary` to preserve the input and output args of the wrapped method, so the IDE can see proper types