### PR TITLE
Export Address and AddressComponent from genjax._src.core.generative (GEN-315)

### DIFF
--- a/src/genjax/core/generative.py
+++ b/src/genjax/core/generative.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from genjax._src.core.generative import (
+    Address,
+    AddressComponent,
     Argdiffs,
     Arguments,
     ChoiceMap,
@@ -41,6 +43,8 @@ from genjax._src.core.generative import (
 )
 
 __all__ = [
+    "Address",
+    "AddressComponent",
     "Argdiffs",
     "Arguments",
     "ChoiceMap",


### PR DESCRIPTION
These appear in public signatures and should be exported.