### PR TITLE
Fix dimap extra tupling (GEN-338)

### DIFF
--- a/src/genjax/_src/generative_functions/combinators/dimap.py
+++ b/src/genjax/_src/generative_functions/combinators/dimap.py
@@ -147,8 +147,8 @@ class DimapCombinator(GenerativeFunction):
         tr, w, inner_retdiff, bwd_problem = self.inner.update(
             key, inner_trace, GenericProblem(inner_argdiffs, update_problem)
         )
-        inner_retval_primals = Diff.tree_primal((inner_retdiff,))
-        inner_retval_tangents = Diff.tree_tangent((inner_retdiff,))
+        inner_retval_primals = Diff.tree_primal(inner_retdiff)
+        inner_retval_tangents = Diff.tree_tangent(inner_retdiff)
 
         def closed_mapping(args, retval):
             return self.retval_mapping(args, retval)
@@ -158,6 +158,7 @@ class DimapCombinator(GenerativeFunction):
             (primals, inner_retval_primals),
             (tangents, inner_retval_tangents),
         )
+
         retval_primal = Diff.tree_primal(retval_diff)
         return (
             DimapTrace(self, tr, primals, retval_primal),

--- a/tests/generative_functions/test_dimap_combinator.py
+++ b/tests/generative_functions/test_dimap_combinator.py
@@ -1,4 +1,3 @@
-
 # Copyright 2024 MIT Probabilistic Computing Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +19,6 @@ from genjax import ChoiceMapBuilder as C
 
 class TestDimapCombinator:
     def test_dimap_update_retval(self):
-
         # Define pre- and post-processing functions
         def pre_process(x, y):
             return (x + 1, y * 2)
@@ -38,13 +36,17 @@ class TestDimapCombinator:
 
         # Use the dimap model
         key = jax.random.PRNGKey(0)
-        trace = dimap_model.simulate(key, (2.0, 3.0))  
-        trace.get_retval()
-        updated_tr, updated_w, _, _ = trace.update(key, C['z'].set(-2.0))
-        assert 4.0 == updated_tr.get_retval(), "updating 'z' should run through `post_process` before returning"
+        trace = dimap_model.simulate(key, (2.0, 3.0))
+        assert (
+            20.333187 == trace.get_retval()
+        ), "initial retval is a square of random draw"
 
-        tr, w = dimap_model.importance(key, updated_tr.get_sample(), (2.0, 3.0))
-        assert tr.get_retval() == updated_tr.get_retval()
+        updated_tr, _, _, _ = trace.update(key, C["z"].set(-2.0))
+        assert (
+            4.0 == updated_tr.get_retval()
+        ), "updating 'z' should run through `post_process` before returning"
 
-        # TODO what can I say about the weight??
-        # assert w == updated_w
+        tr, _ = dimap_model.importance(key, updated_tr.get_sample(), (1.0, 2.0))
+        assert (
+            tr.get_retval() == updated_tr.get_retval()
+        ), "importance shouldn't update the retval"

--- a/tests/generative_functions/test_dimap_combinator.py
+++ b/tests/generative_functions/test_dimap_combinator.py
@@ -1,0 +1,50 @@
+
+# Copyright 2024 MIT Probabilistic Computing Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import genjax
+import jax
+from genjax import ChoiceMapBuilder as C
+
+
+class TestDimapCombinator:
+    def test_dimap_update_retval(self):
+
+        # Define pre- and post-processing functions
+        def pre_process(x, y):
+            return (x + 1, y * 2)
+
+        def post_process(args, retval):
+            return retval**2
+
+        @genjax.gen
+        def model(x, y):
+            return genjax.normal(x, y) @ "z"
+
+        dimap_model = model.dimap(
+            pre=pre_process, post=post_process, info="Square of normal"
+        )
+
+        # Use the dimap model
+        key = jax.random.PRNGKey(0)
+        trace = dimap_model.simulate(key, (2.0, 3.0))  
+        trace.get_retval()
+        updated_tr, updated_w, _, _ = trace.update(key, C['z'].set(-2.0))
+        assert 4.0 == updated_tr.get_retval(), "updating 'z' should run through `post_process` before returning"
+
+        tr, w = dimap_model.importance(key, updated_tr.get_sample(), (2.0, 3.0))
+        assert tr.get_retval() == updated_tr.get_retval()
+
+        # TODO what can I say about the weight??
+        # assert w == updated_w

--- a/tests/generative_functions/test_dimap_combinator.py
+++ b/tests/generative_functions/test_dimap_combinator.py
@@ -23,8 +23,11 @@ class TestDimapCombinator:
         def pre_process(x, y):
             return (x + 1, y * 2)
 
-        def post_process(args, retval):
-            return retval**2
+        def post_process(_, retval):
+            return retval + 2
+
+        def invert_post(x):
+            return x - 2
 
         @genjax.gen
         def model(x, y):
@@ -38,15 +41,31 @@ class TestDimapCombinator:
         key = jax.random.PRNGKey(0)
         trace = dimap_model.simulate(key, (2.0, 3.0))
         assert (
-            20.333187 == trace.get_retval()
+            -2.5092335 == trace.get_retval()
         ), "initial retval is a square of random draw"
+
+        assert (
+            genjax.normal.logpdf(
+                invert_post(trace.get_retval()), *pre_process(2.0, 3.0)
+            )
+            == trace.get_score()
+        ), "final score sees pre-processing but not post-processing (note the inverse). This is only true here because we are returning the sampled value."
 
         updated_tr, _, _, _ = trace.update(key, C["z"].set(-2.0))
         assert (
-            4.0 == updated_tr.get_retval()
-        ), "updating 'z' should run through `post_process` before returning"
+            0.0 == updated_tr.get_retval()
+        ), "updated 'z' must hit `post_process` before returning"
 
-        tr, _ = dimap_model.importance(key, updated_tr.get_sample(), (1.0, 2.0))
+        importance_tr, _ = dimap_model.importance(
+            key, updated_tr.get_sample(), (1.0, 2.0)
+        )
         assert (
-            tr.get_retval() == updated_tr.get_retval()
+            importance_tr.get_retval() == updated_tr.get_retval()
         ), "importance shouldn't update the retval"
+
+        assert (
+            genjax.normal.logpdf(
+                invert_post(importance_tr.get_retval()), *pre_process(1.0, 2.0)
+            )
+            == importance_tr.get_score()
+        ), "with importance trace, final score sees pre-processing but not post-processing."


### PR DESCRIPTION
This PR removes an extra level of tupling in the dimap combinator's `update` implementation. This fixes #1169 's failing test as well.

I added tests of the returned trace's score and retval. I don't remember/know how the score relates to the weight, but getting a weight test into here would probably be a good idea.