### PR TITLE
Prepend initial accumulator in accumulate, iterate (GEN-346)

### DIFF
--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -1011,7 +1011,7 @@ class GenerativeFunction(Pytree):
         When called on a [`genjax.GenerativeFunction`][] of type `(c, a) -> c`, returns a new [`genjax.GenerativeFunction`][] of type `(c, [a]) -> [c]` where
 
         - `c` is a loop-carried value, which must hold a fixed shape and dtype across all iterations
-        - `[c]` is an array of all loop-carried values seen during iteration (excluding the first)
+        - `[c]` is an array of all loop-carried values seen during iteration (including the first)
         - `a` may be a primitive, an array type or a pytree (container) type with array leaves
 
         All traced values are nested under an index.
@@ -1023,7 +1023,7 @@ class GenerativeFunction(Pytree):
         ```python
         def accumulate(f, init, xs):
             carry = init
-            carries = []
+            carries = [init]
             for x in xs:
                 carry = f(carry, x)
                 carries.append(carry)
@@ -1129,7 +1129,7 @@ class GenerativeFunction(Pytree):
         When called on a [`genjax.GenerativeFunction`][] of type `a -> a`, returns a new [`genjax.GenerativeFunction`][] of type `a -> [a]` where
 
         - `a` is a loop-carried value, which must hold a fixed shape and dtype across all iterations
-        - `[a]` is an array of all `f(a)`, `f(f(a))` etc. values seen during iteration (excluding tjhe initial `a`)
+        - `[a]` is an array of all `a`, `f(a)`, `f(f(a))` etc. values seen during iteration.
 
         All traced values are nested under an index.
 
@@ -1138,7 +1138,7 @@ class GenerativeFunction(Pytree):
         ```python
         def iterate(f, n, init):
             input = init
-            seen = []
+            seen = [init]
             for _ in range(n):
                 input = f(input)
                 seen.append(input)
@@ -1321,10 +1321,10 @@ class GenerativeFunction(Pytree):
 
     def switch(self, *branches: "GenerativeFunction") -> "GenerativeFunction":
         """
-        Given `n` [`genjax.GenerativeFunction`][] inputs, returns a decorator that takes a [`genjax.GenerativeFunction`][] `f` and returns a new [`genjax.GenerativeFunction`][] that accepts `n+2` arguments:
+        Given `n` [`genjax.GenerativeFunction`][] inputs, returns a new [`genjax.GenerativeFunction`][] that accepts `n+2` arguments:
 
-        - an index in the range `[0, n]`
-        - a tuple of arguments for `f` and each of the input generative functions (`n+1` total tuples)
+        - an index in the range $[0, n+1)$
+        - a tuple of arguments for `self` and each of the input generative functions (`n+1` total tuples)
 
         and executes the generative function at the supplied index with its provided arguments.
 

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -655,10 +655,10 @@ def prepend_initial_acc(args, ret):
     init_acc = args[0]
     xs = ret[1]
 
-    def concat_with_init(init, arr):
-        return jnp.concatenate([jnp.array([init]), arr])
+    def cat(init, arr):
+        return jnp.concatenate([jnp.array(init)[jnp.newaxis], arr])
 
-    return jax.tree.map(concat_with_init, init_acc, xs)
+    return jax.tree.map(cat, init_acc, xs)
 
 
 @typecheck

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -634,6 +634,33 @@ def scan(
     return decorator
 
 
+def prepend_initial_acc(args, ret):
+    """
+    Prepends the initial accumulator value to the array of accumulated values.
+
+    This function is used in the context of scan operations to include the initial
+    accumulator state in the output, effectively providing a complete history of
+    the accumulator's values throughout the scan.
+
+    Args:
+        args: A tuple containing the initial arguments to the scan operation. The first element is expected to be the initial accumulator value.
+        ret: A tuple containing the final accumulator value and an array of intermediate accumulator values from the scan operation.
+
+    Returns:
+        A tree structure where each leaf is an array with the initial accumulator value prepended to the corresponding array of intermediate values.
+
+    Note:
+        This function uses JAX's tree mapping to handle nested structures in the accumulator, allowing it to work with complex accumulator types.
+    """
+    init_acc, _ = args
+    xs = ret[1]
+
+    def concat_with_init(init, arr):
+        return jnp.concatenate([jnp.array([init]), arr])
+
+    return jax.tree.map(concat_with_init, init_acc, xs)
+
+
 @typecheck
 def accumulate(
     *, reverse: bool = False, unroll: int | bool = 1
@@ -642,7 +669,7 @@ def accumulate(
     Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type `(c, a) -> c` and returns a new [`genjax.GenerativeFunction`][] of type `(c, [a]) -> [c]` where
 
     - `c` is a loop-carried value, which must hold a fixed shape and dtype across all iterations
-    - `[c]` is an array of all loop-carried values seen during iteration (excluding the first)
+    - `[c]` is an array of all loop-carried values seen during iteration (including the first)
     - `a` may be a primitive, an array type or a pytree (container) type with array leaves
 
     All traced values are nested under an index.
@@ -654,7 +681,7 @@ def accumulate(
     ```python
     def accumulate(f, init, xs):
         carry = init
-        carries = []
+        carries = [init]
         for x in xs:
             carry = f(carry, x)
             carries.append(carry)
@@ -694,11 +721,11 @@ def accumulate(
         ```
     """
 
-    def decorator(f):
+    def decorator(f: GenerativeFunction):
         return (
             f.map(lambda ret: (ret, ret))
             .scan(reverse=reverse, unroll=unroll)
-            .map(lambda ret: ret[1])
+            .dimap(pre=lambda *args: args, post=prepend_initial_acc)
         )
 
     return decorator
@@ -779,7 +806,7 @@ def iterate(
     Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type `a -> a` and returns a new [`genjax.GenerativeFunction`][] of type `a -> [a]` where
 
     - `a` is a loop-carried value, which must hold a fixed shape and dtype across all iterations
-    - `[a]` is an array of all `f(a)`, `f(f(a))` etc. values seen during iteration (excluding tjhe initial `a`)
+    - `[a]` is an array of all `a`, `f(a)`, `f(f(a))` etc. values seen during iteration.
 
     All traced values are nested under an index.
 
@@ -788,7 +815,7 @@ def iterate(
     ```python
     def iterate(f, n, init):
         input = init
-        seen = []
+        seen = [init]
         for _ in range(n):
             input = f(input)
             seen.append(input)
@@ -830,7 +857,7 @@ def iterate(
         return (
             f.dimap(pre=lambda *args: args[:-1], post=lambda _, ret: (ret, ret))
             .scan(n=n, unroll=unroll)
-            .dimap(pre=lambda *args: (*args, None), post=lambda _, ret: ret[1])
+            .dimap(pre=lambda *args: (*args, None), post=prepend_initial_acc)
         )
 
     return decorator

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -652,7 +652,7 @@ def prepend_initial_acc(args, ret):
     Note:
         This function uses JAX's tree mapping to handle nested structures in the accumulator, allowing it to work with complex accumulator types.
     """
-    init_acc, _ = args
+    init_acc = args[0]
     xs = ret[1]
 
     def concat_with_init(init, arr):

--- a/src/genjax/_src/generative_functions/combinators/switch.py
+++ b/src/genjax/_src/generative_functions/combinators/switch.py
@@ -694,17 +694,17 @@ def switch(
     *gen_fns: GenerativeFunction,
 ) -> GenerativeFunction:
     """
-    Given `n` [`genjax.GenerativeFunction`][] inputs, returns a decorator that takes a [`genjax.GenerativeFunction`][] `f` and returns a new [`genjax.GenerativeFunction`][] that accepts `n+2` arguments:
+    Given `n` [`genjax.GenerativeFunction`][] inputs, returns a [`genjax.GenerativeFunction`][] that accepts `n+1` arguments:
 
-    - an index in the range `[0, n]`
-    - a tuple of arguments for `f` and each of the input generative functions (`n+1` total tuples)
+    - an index in the range $[0, n)$
+    - a tuple of arguments for each of the input generative functions (`n` total tuples)
 
     and executes the generative function at the supplied index with its provided arguments.
 
     If `index` is out of bounds, `index` is clamped to within bounds.
 
     Args:
-        gen_fns: generative functions that the `SwitchCombinator` will select from when given an index of 1 or greater.
+        gen_fns: generative functions that the `SwitchCombinator` will select from.
 
     Returns:
 

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -108,7 +108,7 @@ class TestIterate:
         the initial value).
         """
         result = inc.iterate(n=4).simulate(key, (0,)).get_retval()
-        assert jnp.array_equal(result, jnp.array([1, 2, 3, 4]))
+        assert jnp.array_equal(result, jnp.array([0, 1, 2, 3, 4]))
 
     def test_iterate_final(self, key):
         """
@@ -131,7 +131,7 @@ class TestIterate:
         """
         result = inc_tupled.iterate(n=4).simulate(key, ((0, 2),)).get_retval()
         assert jnp.array_equal(
-            result, (jnp.array([2, 4, 6, 8]), jnp.array([2, 2, 2, 2]))
+            result, (jnp.array([0, 2, 4, 6, 8]), jnp.array([2, 2, 2, 2, 2]))
         )
 
     def test_iterate_final_tupled(self, key):
@@ -166,19 +166,19 @@ class TestScanFoldMethods:
         result = add.simulate(key, (0, 2)).get_retval()
         assert result == 2
 
-    def test_scan(self, key):
+    def test_accumulate(self, key):
         """
-        `scan` on a generative function of signature `(accumulator, v) -> accumulator` returns a generative function that
+        `accumulate` on a generative function of signature `(accumulator, v) -> accumulator` returns a generative function that
 
         - takes `(accumulator, jnp.array(v)) -> accumulator`
         - and returns an array of each intermediate accumulator value seen (not including the initial value).
         """
         result = add.accumulate().simulate(key, (0, jnp.ones(4))).get_retval()
-        assert jnp.array_equal(result, jnp.array([1, 2, 3, 4]))
+        assert jnp.array_equal(result, jnp.array([0, 1, 2, 3, 4]))
 
-    def test_fold(self, key):
+    def test_reduce(self, key):
         """
-        `fold` on a generative function of signature `(accumulator, v) -> accumulator` returns a generative function that
+        `reduce` on a generative function of signature `(accumulator, v) -> accumulator` returns a generative function that
 
         - takes `(accumulator, jnp.array(v)) -> accumulator`
         - and returns the final `accumulator` produces by folding in each element of `jnp.array(v)`.
@@ -192,20 +192,21 @@ class TestScanFoldMethods:
         result = add_tupled.simulate(key, ((0, 2), 10)).get_retval()
         assert jnp.array_equal(result, (12, 2))
 
-    def test_scan_tupled(self, key):
+    def test_accumulate_tupled(self, key):
         """
-        `scan` on function with tupled carry state works correctly.
+        `accumulate` on function with tupled carry state works correctly.
         """
         result = (
             add_tupled.accumulate().simulate(key, ((0, 2), jnp.ones(4))).get_retval()
         )
         assert jnp.array_equal(
-            result, (jnp.array([3, 6, 9, 12]), jnp.array([2, 2, 2, 2]))
+            result, (jnp.array([0, 3, 6, 9, 12]), jnp.array([2, 2, 2, 2, 2]))
         )
+        jax.numpy.hstack
 
-    def test_fold_tupled(self, key):
+    def test_reduce_tupled(self, key):
         """
-        `fold` on function with tupled carry state works correctly.
+        `reduce` on function with tupled carry state works correctly.
         """
         result = add_tupled.reduce().simulate(key, ((0, 2), jnp.ones(10))).get_retval()
         assert jnp.array_equal(result, (30, 2))


### PR DESCRIPTION
This PR modifies the `iterate` and `accumulate` combinators to attach the initial accumulator at the front of the array returned by these generative functions.

`jax.lax.scan` does NOT do this because the type signature of `(s -> a -> (s, b)) -> s -> [a] -> (s, [b])` doesn't allow it. (The accumulated type here is `b`, not `s`).

BUT in `iterate` and `accumulate`, `s == b`, and returning the initial accumulator matches the behavior of these functions everywhere they appear (in Clojure, Python, Haskell, Scala etc.).

Thanks to @littleredcomputer for suggesting this and @arijitnoobstar for noting that this would be useful for him as well.

The PR also fixes some docs typos.