### PR TITLE
Fix dimap args / retval mapping issue (GEN-345)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,9 +109,13 @@ exclude = [
     "**/__pycache__",
 ]
 defineConstant = { DEBUG = true }
+typeCheckingMode = "standard"
+reportMatchNotExhaustive = true
 reportMissingImports = true
 reportMissingTypeStubs = false
-typeCheckingMode = "standard"
+analyzeUnannotatedFunctions = true
+strictParameterNoneValue = true
+deprecateTypingAliases = true
 
 [tool.ruff]
 exclude = [

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -38,7 +38,6 @@ from genjax._src.core.typing import (
     Is,
     List,
     Optional,
-    ParamSpec,
     PRNGKey,
     String,
     Tuple,
@@ -53,8 +52,7 @@ register_exclusion(__file__)
 if TYPE_CHECKING:
     import genjax
 
-_P = ParamSpec("_P")
-_T = TypeVar("_T")
+_C = TypeVar("_C", bound=Callable)
 
 #####################################
 # Special generative function types #
@@ -528,7 +526,7 @@ class GenerativeFunction(Pytree):
         return jtu.tree_map(lambda v: jnp.zeros(v.shape, dtype=v.dtype), data_shape)
 
     @classmethod
-    def gfi_boundary(cls, c: Callable[_P, _T]) -> Callable[_P, _T]:
+    def gfi_boundary(cls, c: _C) -> _C:
         return gfi_boundary(c)
 
     @abstractmethod

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -53,6 +53,9 @@ if TYPE_CHECKING:
     import genjax
 
 _C = TypeVar("_C", bound=Callable)
+ArgTuple = TypeVar("ArgTuple", bound=tuple)
+R = TypeVar("R")
+S = TypeVar("S")
 
 #####################################
 # Special generative function types #
@@ -1407,9 +1410,9 @@ class GenerativeFunction(Pytree):
         self,
         /,
         *,
-        pre: Callable[..., Any],
-        post: Callable[..., Any],
-        info: Optional[String] = None,
+        pre: Callable[..., ArgTuple],
+        post: Callable[[ArgTuple, R], S],
+        info: String | None = None,
     ) -> "GenerativeFunction":
         """
         Returns a new [`genjax.GenerativeFunction`][] and applies pre- and post-processing functions to its arguments and return value.
@@ -1460,7 +1463,7 @@ class GenerativeFunction(Pytree):
         return genjax.dimap(pre=pre, post=post, info=info)(self)
 
     def map(
-        self, f: Callable[..., Any], *, info: Optional[String] = None
+        self, f: Callable[[R], S], *, info: String | None = None
     ) -> "GenerativeFunction":
         """
         Specialized version of [`genjax.dimap`][] where only the post-processing function is applied.
@@ -1501,7 +1504,7 @@ class GenerativeFunction(Pytree):
         return genjax.map(f=f, info=info)(self)
 
     def contramap(
-        self, f: Callable[..., Any], *, info: Optional[String] = None
+        self, f: Callable[..., ArgTuple], *, info: String | None = None
     ) -> "GenerativeFunction":
         """
         Specialized version of [`genjax.GenerativeFunction.dimap`][] where only the pre-processing function is applied.

--- a/src/genjax/_src/core/traceback_util.py
+++ b/src/genjax/_src/core/traceback_util.py
@@ -20,8 +20,8 @@ _T = TypeVar("_T")
 
 
 # register_exclusion = traceback_util.register_exclusion
-def register_exclusion(v):
-    return v
+def register_exclusion(_)-> None:
+    return None
 
 
 def gfi_boundary(c: Callable[_P, _T]) -> Callable[_P, _T]:

--- a/src/genjax/_src/core/traceback_util.py
+++ b/src/genjax/_src/core/traceback_util.py
@@ -13,16 +13,15 @@
 # limitations under the License.
 
 import jax._src.traceback_util as traceback_util
-from beartype.typing import Callable, ParamSpec, TypeVar
+from beartype.typing import Callable, TypeVar
 
-_P = ParamSpec("_P")
-_T = TypeVar("_T")
+_C = TypeVar("_C", bound=Callable)
 
 
 # register_exclusion = traceback_util.register_exclusion
-def register_exclusion(_)-> None:
+def register_exclusion(_) -> None:
     return None
 
 
-def gfi_boundary(c: Callable[_P, _T]) -> Callable[_P, _T]:
+def gfi_boundary(c: _C) -> _C:
     return traceback_util.api_boundary(c)

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -73,8 +73,6 @@ ScalarBool = Annotated[Bool | BoolArray, ScalarShaped]
 Generic = btyping.Generic
 TypeVar = btyping.TypeVar
 ParamSpec = btyping.ParamSpec
-TypeVarTuple = btyping.TypeVarTuple
-Unpack = btyping.Unpack
 
 ########################################
 # Static typechecking from annotations #

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -73,6 +73,8 @@ ScalarBool = Annotated[Bool | BoolArray, ScalarShaped]
 Generic = btyping.Generic
 TypeVar = btyping.TypeVar
 ParamSpec = btyping.ParamSpec
+TypeVarTuple = btyping.TypeVarTuple
+Unpack = btyping.Unpack
 
 ########################################
 # Static typechecking from annotations #

--- a/src/genjax/_src/generative_functions/combinators/dimap.py
+++ b/src/genjax/_src/generative_functions/combinators/dimap.py
@@ -35,24 +35,24 @@ from genjax._src.core.typing import (
     PRNGKey,
     String,
     TypeVar,
-    TypeVarTuple,
-    Unpack,
     typecheck,
 )
 
 register_exclusion(__file__)
 
+ArgTuple = TypeVar("ArgTuple", bound=tuple)
 R = TypeVar("R")
-T = TypeVarTuple("T")
+S = TypeVar("S")
+
 
 @Pytree.dataclass
-class DimapTrace(Trace, Generic[R, Unpack[T]]):
-    gen_fn: GenerativeFunction
+class DimapTrace(Trace, Generic[ArgTuple, S]):
+    gen_fn: "DimapCombinator"
     inner: Trace
-    args: tuple[*T]
-    retval: R
+    args: ArgTuple
+    retval: S
 
-    def get_args(self) -> tuple[*T]:
+    def get_args(self) -> ArgTuple:
         return self.args
 
     def get_gen_fn(self) -> GenerativeFunction:
@@ -61,7 +61,7 @@ class DimapTrace(Trace, Generic[R, Unpack[T]]):
     def get_sample(self) -> Sample:
         return self.inner.get_sample()
 
-    def get_retval(self) -> R:
+    def get_retval(self) -> S:
         return self.retval
 
     def get_score(self) -> Score:
@@ -69,7 +69,7 @@ class DimapTrace(Trace, Generic[R, Unpack[T]]):
 
 
 @Pytree.dataclass
-class DimapCombinator(GenerativeFunction, Generic[Unpack[T]]):
+class DimapCombinator(GenerativeFunction, Generic[ArgTuple, R, S]):
     """
     A combinator that transforms both the arguments and return values of a [`genjax.GenerativeFunction`][].
 
@@ -110,8 +110,8 @@ class DimapCombinator(GenerativeFunction, Generic[Unpack[T]]):
     """
 
     inner: GenerativeFunction
-    argument_mapping: Callable[[*T], tuple[*U]] = Pytree.static()
-    retval_mapping: Callable[..., Any] = Pytree.static()
+    argument_mapping: Callable[[tuple], ArgTuple] = Pytree.static()
+    retval_mapping: Callable[[ArgTuple, R], S] = Pytree.static()
     info: String | None = Pytree.static(default=None)
 
     @GenerativeFunction.gfi_boundary
@@ -125,7 +125,7 @@ class DimapCombinator(GenerativeFunction, Generic[Unpack[T]]):
         tr = self.inner.simulate(key, inner_args)
         inner_retval = tr.get_retval()
         retval = self.retval_mapping(inner_args, inner_retval)
-        return DimapTrace(self, tr, args, retval)
+        return DimapTrace[tuple, S](self, tr, args, retval)
 
     @typecheck
     def update_change_target(
@@ -136,26 +136,32 @@ class DimapCombinator(GenerativeFunction, Generic[Unpack[T]]):
         argdiffs: Argdiffs,
     ) -> tuple[Trace, Weight, Retdiff, UpdateProblem]:
         assert isinstance(trace, EmptyTrace | DimapTrace)
+
         primals = Diff.tree_primal(argdiffs)
         tangents = Diff.tree_tangent(argdiffs)
+
         inner_argdiffs = incremental(self.argument_mapping)(
             None,
             primals,
             tangents,
         )
+
         match trace:
             case DimapTrace():
                 inner_trace = trace.inner
             case EmptyTrace():
                 inner_trace = EmptyTrace(self.inner)
+
         tr, w, inner_retdiff, bwd_problem = self.inner.update(
             key, inner_trace, GenericProblem(inner_argdiffs, update_problem)
         )
+
         inner_retval_primals = Diff.tree_primal(inner_retdiff)
         inner_retval_tangents = Diff.tree_tangent(inner_retdiff)
 
-        def closed_mapping(args, retval):
-            return self.retval_mapping(args, retval)
+        def closed_mapping(args: tuple, retval: R) -> S:
+            xformed_args = self.argument_mapping(*args)
+            return self.retval_mapping(xformed_args, retval)
 
         retval_diff = incremental(closed_mapping)(
             None,
@@ -165,7 +171,7 @@ class DimapCombinator(GenerativeFunction, Generic[Unpack[T]]):
 
         retval_primal = Diff.tree_primal(retval_diff)
         return (
-            DimapTrace(self, tr, primals, retval_primal),
+            DimapTrace[tuple, S](self, tr, primals, retval_primal),
             w,
             retval_diff,
             bwd_problem,
@@ -194,7 +200,7 @@ class DimapCombinator(GenerativeFunction, Generic[Unpack[T]]):
     ) -> tuple[Score, Any]:
         inner_args = self.argument_mapping(*args)
         w, inner_retval = self.inner.assess(sample, inner_args)
-        retval = self.retval_mapping(args, inner_retval)
+        retval = self.retval_mapping(inner_args, inner_retval)
         return w, retval
 
 
@@ -205,8 +211,8 @@ class DimapCombinator(GenerativeFunction, Generic[Unpack[T]]):
 
 def dimap(
     *,
-    pre: Callable[..., Any] = lambda *args: args,
-    post: Callable[..., Any] = lambda _args, retval: retval,
+    pre: Callable[..., ArgTuple] = lambda *args: args,
+    post: Callable[[ArgTuple, R], S] = lambda _, retval: retval,
     info: String | None = None,
 ) -> Callable[[GenerativeFunction], GenerativeFunction]:
     """
@@ -253,13 +259,13 @@ def dimap(
     """
 
     def decorator(f) -> GenerativeFunction:
-        return DimapCombinator(f, pre, post, info)
+        return DimapCombinator[ArgTuple, R, S](f, pre, post, info)
 
     return decorator
 
 
 def map(
-    f: Callable[..., Any],
+    f: Callable[[R], S],
     *,
     info: String | None = None,
 ) -> Callable[[GenerativeFunction], GenerativeFunction]:
@@ -299,11 +305,15 @@ def map(
         print(trace.render_html())
         ```
     """
-    return dimap(pre=lambda *args: args, post=lambda _, ret: f(ret), info=info)
+
+    def post(_, x: R) -> S:
+        return f(x)
+
+    return dimap(pre=lambda *args: args, post=post, info=info)
 
 
 def contramap(
-    f: Callable[..., Any],
+    f: Callable[..., ArgTuple],
     *,
     info: String | None = None,
 ) -> Callable[[GenerativeFunction], GenerativeFunction]:

--- a/tests/generative_functions/test_dimap_combinator.py
+++ b/tests/generative_functions/test_dimap_combinator.py
@@ -21,16 +21,17 @@ class TestDimapCombinator:
     def test_dimap_update_retval(self):
         # Define pre- and post-processing functions
         def pre_process(x, y):
-            return (x + 1, y * 2)
+            return (x + 1, y * 2, y * 3)
 
-        def post_process(_, retval):
+        def post_process(args, retval):
+            assert len(args) == 3, "post_process has to receive transformed args."
             return retval + 2
 
         def invert_post(x):
             return x - 2
 
         @genjax.gen
-        def model(x, y):
+        def model(x, y, _):
             return genjax.normal(x, y) @ "z"
 
         dimap_model = model.dimap(

--- a/tests/generative_functions/test_dimap_combinator.py
+++ b/tests/generative_functions/test_dimap_combinator.py
@@ -45,6 +45,10 @@ class TestDimapCombinator:
             -2.5092335 == trace.get_retval()
         ), "initial retval is a square of random draw"
 
+        assert (trace.get_score(), trace.get_retval()) == dimap_model.assess(
+            trace.get_sample(), (2.0, 3.0)
+        ), "assess with the same args returns score, retval"
+
         assert (
             genjax.normal.logpdf(
                 invert_post(trace.get_retval()), *pre_process(2.0, 3.0)


### PR DESCRIPTION
This PR:

- adds generic types to `DimapTrace`, `DimapCombinator` and all of the methods that create these types
- fixes two bugs exposed by the typing where the args failed to be transformed before being passed to `retval_mapping`
- adds tests that back up this behavior
- fixes up some `Callable` type bounds