### PR TITLE
fixes to ScanCombinator._update

### DIFF
--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -355,7 +355,7 @@ class ScanCombinator(GenerativeFunction):
 
         def _update(carry, scanned_over):
             key, idx, carried_value = carry
-            (subtrace, *scanned_in) = scanned_over
+            subtrace, scanned_in = scanned_over
             key = jax.random.fold_in(key, idx)
             subproblem = self._get_subproblem(problem, idx)
             (

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -344,7 +344,9 @@ class ScanCombinator(GenerativeFunction):
                     subproblem,
                 ),
             )
-            (carry_retdiff, scanned_out_retdiff) = kernel_retdiff
+            (carry_retdiff, scanned_out_retdiff) = Diff.tree_diff_unknown_change(
+                kernel_retdiff
+            )
             score = new_subtrace.get_score()
             return (carry_retdiff, score), (
                 new_subtrace,

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -337,6 +337,6 @@ class TestScanUpdate:
         tr = model.simulate(jax.random.PRNGKey(0), (jnp.array(1.0),))
         u, w, _, _ = tr.update(jax.random.PRNGKey(1), C["steps", 1, "b"].set(99.0))
         assert jnp.allclose(
-            u.get_choices()["steps", ..., "b"], jnp.array([2.0, 99.0, 7.0])
+            u.get_choices()["steps", ..., "b"], jnp.array([2.0, 99.0, 7.0]), atol=0.1
         )
         assert w < -100.0

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -21,6 +21,7 @@ from genjax import ChoiceMapBuilder as C
 from genjax import Diff
 from genjax import SelectionBuilder as S
 from genjax import UpdateProblemBuilder as U
+from genjax.typing import FloatArray
 
 
 @genjax.iterate(n=10)
@@ -324,7 +325,7 @@ class TestScanUpdate:
     def test_scan_update(self, key):
         @pz.pytree_dataclass
         class A(genjax.Pytree):
-            x: genjax.typing.FloatArray
+            x: FloatArray
 
         @genjax.gen
         def step(b, a):

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -334,8 +334,9 @@ class TestScanUpdate:
         def model(k):
             return step.scan(n=3)(k, A(jnp.array([1.0, 2.0, 3.0]))) @ "steps"
 
-        tr = model.simulate(jax.random.PRNGKey(0), (jnp.array(1.0),))
-        u, w, _, _ = tr.update(jax.random.PRNGKey(1), C["steps", 1, "b"].set(99.0))
+        k1, k2 = jax.random.split(key)
+        tr = model.simulate(k1, (jnp.array(1.0),))
+        u, w, _, _ = tr.update(k2, C["steps", 1, "b"].set(99.0))
         assert jnp.allclose(
             u.get_choices()["steps", ..., "b"], jnp.array([2.0, 99.0, 7.0]), atol=0.1
         )


### PR DESCRIPTION
This is a fix to GEN-339: 

- removes an extra layer of array being applied to a scanned function argument during update calculations
- equalizes the Diff type of scan input and output to UknownChange in both cases
