### PR TITLE
Fixes GEN-312 (score should be FloatArray)

### DIFF
--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -40,7 +40,6 @@ from genjax._src.core.typing import (
     Optional,
     ParamSpec,
     PRNGKey,
-    ScalarFloat,
     String,
     Tuple,
     TypeVar,
@@ -61,19 +60,17 @@ _T = TypeVar("_T")
 # Special generative function types #
 #####################################
 
-Weight = ScalarFloat
+Weight = FloatArray
 """
 A _weight_ is a density ratio which often occurs in the context of proper weighting for [`Target`][genjax.inference.Target] distributions, or in Gen's [`update`][genjax.core.GenerativeFunction.update] interface, whose mathematical content is described in [`update`][genjax.core.GenerativeFunction.update].
 
 The type `Weight` does not enforce any meaningful mathematical invariants, but is used to denote the type of weights in GenJAX, to improve readability and parsing of interface specifications / expectations.
 """
-Score = ScalarFloat
+Score = FloatArray
 """
 A _score_ is a density ratio, described fully in [`simulate`][genjax.core.GenerativeFunction.simulate].
 
 The type `Score` does not enforce any meaningful mathematical invariants, but is used to denote the type of scores in the GenJAX system, to improve readability and parsing of interface specifications.
-
-Under type checking, the type `Score` enforces that the value must be a scalar floating point number.
 """
 
 Arguments = Tuple
@@ -176,7 +173,7 @@ class UpdateProblemBuilder(Pytree):
 
     @classmethod
     def maybe(cls, flag: Bool | BoolArray, problem: "UpdateProblem"):
-        return MaskedProblem.maybe_empty(flag, problem)
+        return MaskedProblem.maybe_empty(jnp.array(flag), problem)
 
     @classmethod
     def g(cls, argdiffs: Argdiffs, subproblem: "UpdateProblem") -> "UpdateProblem":
@@ -440,7 +437,7 @@ class EmptyTrace(Trace):
         return EmptyTraceRetval()
 
     def get_score(self) -> Score:
-        return 0.0
+        return jnp.array(0.0)
 
     def get_sample(self) -> Sample:
         return EmptySample()
@@ -1610,7 +1607,7 @@ def push_trace_overload_stack(handler, fn):
 
 @Pytree.dataclass
 class IgnoreKwargs(GenerativeFunction):
-    wrapped: "GenerativeFunction"
+    wrapped: GenerativeFunction
 
     def handle_kwargs(self) -> "GenerativeFunction":
         raise NotImplementedError
@@ -1708,9 +1705,9 @@ class GenerativeFunctionClosure(GenerativeFunction):
         self,
         key: PRNGKey,
         trace: Trace,
-        problem: UpdateProblem,
+        update_problem: UpdateProblem,
     ) -> Tuple[Trace, Weight, Retdiff, UpdateProblem]:
-        match problem:
+        match update_problem:
             case GenericProblem(argdiffs, subproblem):
                 full_argdiffs = (*self.args, *argdiffs)
                 if self.kwargs:

--- a/src/genjax/_src/core/interpreters/incremental.py
+++ b/src/genjax/_src/core/interpreters/incremental.py
@@ -28,7 +28,6 @@ By default, `genjax` provides two types of `ChangeTangent`:
 
 # TODO: Think about when tangents don't share the same Pytree shape as primals.
 
-import abc
 import functools
 
 import jax.core as jc
@@ -40,6 +39,7 @@ from genjax._src.core.interpreters.staging import stage
 from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
     Any,
+    Bool,
     Callable,
     IntArray,
     List,
@@ -60,9 +60,8 @@ from genjax._src.core.typing import (
 
 
 class ChangeTangent(Pytree):
-    @abc.abstractmethod
-    def should_flatten(self):
-        pass
+    def should_flatten(self) -> Bool:
+        return False
 
     def widen(self):
         return UnknownChange
@@ -78,8 +77,7 @@ class ChangeTangent(Pytree):
 
 @Pytree.dataclass
 class _UnknownChange(ChangeTangent):
-    def should_flatten(self):
-        return False
+    pass
 
 
 UnknownChange = _UnknownChange()
@@ -87,8 +85,7 @@ UnknownChange = _UnknownChange()
 
 @Pytree.dataclass
 class _NoChange(ChangeTangent):
-    def should_flatten(self):
-        return False
+    pass
 
 
 NoChange = _NoChange()

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -65,7 +65,6 @@ Value = Any
 
 ScalarShaped = Is[lambda arr: jnp.array(arr, copy=False).shape == ()]
 ScalarBool = Annotated[Bool | BoolArray, ScalarShaped]
-ScalarFloat = Annotated[Float | FloatArray, ScalarShaped]
 
 ############
 # Generics #
@@ -181,7 +180,6 @@ __all__ = [
     "ParamSpec",
     "PRNGKey",
     "ScalarBool",
-    "ScalarFloat",
     "ScalarShaped",
     "Sequence",
     "Tuple",

--- a/src/genjax/_src/inference/smc.py
+++ b/src/genjax/_src/inference/smc.py
@@ -596,7 +596,7 @@ class SMCP3Move(SMCMove):
         K_aux: Sample,
         K_aux_score: FloatArray,
     ) -> FloatArray:
-        pass
+        return jnp.array(0.0)
 
 
 @Pytree.dataclass

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -126,7 +126,7 @@ class TestIterate:
     def test_inc_tupled(self, key):
         """Baseline test demonstrating `inc_tupled`."""
         result = inc_tupled.simulate(key, ((0, 2),)).get_retval()
-        assert jnp.array_equal(result, (2, 2))
+        assert jnp.array_equal(result, jnp.array((2, 2)))
 
     def test_iterate_tupled(self, key):
         """
@@ -134,9 +134,7 @@ class TestIterate:
         from invocation to invocation.
         """
         result = inc_tupled.iterate(n=4).simulate(key, ((0, 2),)).get_retval()
-        assert jnp.array_equal(
-            result, (jnp.array([0, 2, 4, 6, 8]), jnp.array([2, 2, 2, 2, 2]))
-        )
+        assert jnp.array_equal(result, jnp.array([[0, 2, 4, 6, 8], [2, 2, 2, 2, 2]]))
 
     def test_iterate_final_tupled(self, key):
         """
@@ -145,7 +143,7 @@ class TestIterate:
         `iterate_final`.
         """
         result = inc_tupled.iterate_final(n=10).simulate(key, ((0, 2),)).get_retval()
-        assert jnp.array_equal(result, (20, 2))
+        assert jnp.array_equal(result, jnp.array((20, 2)))
 
     def test_iterate_array(self, key):
         """
@@ -249,7 +247,7 @@ class TestAccumulateReduceMethods:
     def test_add_tupled(self, key):
         """Baseline test demonstrating `add_tupled`."""
         result = add_tupled.simulate(key, ((0, 2), 10)).get_retval()
-        assert jnp.array_equal(result, (12, 2))
+        assert jnp.array_equal(result, jnp.array((12, 2)))
 
     def test_accumulate_tupled(self, key):
         """
@@ -258,9 +256,7 @@ class TestAccumulateReduceMethods:
         result = (
             add_tupled.accumulate().simulate(key, ((0, 2), jnp.ones(4))).get_retval()
         )
-        assert jnp.array_equal(
-            result, (jnp.array([0, 3, 6, 9, 12]), jnp.array([2, 2, 2, 2, 2]))
-        )
+        assert jnp.array_equal(result, jnp.array([[0, 3, 6, 9, 12], [2, 2, 2, 2, 2]]))
         jax.numpy.hstack
 
     def test_reduce_tupled(self, key):
@@ -268,7 +264,7 @@ class TestAccumulateReduceMethods:
         `reduce` on function with tupled carry state works correctly.
         """
         result = add_tupled.reduce().simulate(key, ((0, 2), jnp.ones(10))).get_retval()
-        assert jnp.array_equal(result, (30, 2))
+        assert jnp.array_equal(result, jnp.array((30, 2)))
 
     def test_accumulate_array(self, key):
         """


### PR DESCRIPTION
We take the opportunity to clean up a few low-hanging Pyright errors as well.