### PR TITLE
Clean up easy pyright errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,6 @@ repos:
         types_or: [ python, pyi, jupyter ]
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.370
+    rev: v1.1.371
     hooks:
     - id: pyright

--- a/src/genjax/_src/adev/primitives.py
+++ b/src/genjax/_src/adev/primitives.py
@@ -26,6 +26,7 @@ from genjax._src.adev.core import (
 )
 from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
+    Any,
     Callable,
     PRNGKey,
     Tuple,
@@ -47,8 +48,8 @@ def zero(v):
 
 @Pytree.dataclass
 class REINFORCE(ADEVPrimitive):
-    sample_function: Callable = Pytree.static()
-    differentiable_logpdf: Callable = Pytree.static()
+    sample_function: Callable[..., Any] = Pytree.static()
+    differentiable_logpdf: Callable[..., Any] = Pytree.static()
 
     def sample(self, key, *args):
         return self.sample_function(key, *args)
@@ -126,7 +127,8 @@ flip_enum = FlipEnum()
 
 @Pytree.dataclass
 class FlipMVD(ADEVPrimitive):
-    def sample(self, key, p):
+    def sample(self, key, *args):
+        p = args[0]
         return 1 == tfd.Bernoulli(probs=p).sample(seed=key)
 
     def jvp_estimate(

--- a/src/genjax/_src/checkify.py
+++ b/src/genjax/_src/checkify.py
@@ -28,6 +28,6 @@ def do_checkify():
 
 
 @typecheck
-def optional_check(check: Callable):
+def optional_check(check: Callable[[], None]):
     if _GLOBAL_CHECKIFY_HANDLER:
         check()

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -1409,8 +1409,8 @@ class GenerativeFunction(Pytree):
         self,
         /,
         *,
-        pre: Callable,
-        post: Callable,
+        pre: Callable[..., Any],
+        post: Callable[..., Any],
         info: Optional[String] = None,
     ) -> "GenerativeFunction":
         """
@@ -1462,7 +1462,7 @@ class GenerativeFunction(Pytree):
         return genjax.dimap(pre=pre, post=post, info=info)(self)
 
     def map(
-        self, f: Callable, *, info: Optional[String] = None
+        self, f: Callable[..., Any], *, info: Optional[String] = None
     ) -> "GenerativeFunction":
         """
         Specialized version of [`genjax.dimap`][] where only the post-processing function is applied.
@@ -1503,7 +1503,7 @@ class GenerativeFunction(Pytree):
         return genjax.map(f=f, info=info)(self)
 
     def contramap(
-        self, f: Callable, *, info: Optional[String] = None
+        self, f: Callable[..., Any], *, info: Optional[String] = None
     ) -> "GenerativeFunction":
         """
         Specialized version of [`genjax.GenerativeFunction.dimap`][] where only the pre-processing function is applied.
@@ -1582,7 +1582,7 @@ class GenerativeFunction(Pytree):
 # C.f. above.
 # This stack will not interact with JAX tracers at all
 # so it's safe, and will be resolved at JAX tracing time.
-GLOBAL_TRACE_OP_HANDLER_STACK: List[Callable] = []
+GLOBAL_TRACE_OP_HANDLER_STACK: List[Callable[..., Any]] = []
 
 
 def handle_off_trace_stack(addr, gen_fn: GenerativeFunction, args):

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -368,7 +368,7 @@ class Trace(Pytree):
     @typecheck
     def get_choices(self) -> "genjax.ChoiceMap":
         """Version of [`genjax.Trace.get_sample`][] for traces where the sample is an instance of [`genjax.ChoiceMap`][]."""
-        return self.get_sample()
+        return self.get_sample()  # type: ignore
 
     @abstractmethod
     def get_gen_fn(self) -> "GenerativeFunction":

--- a/src/genjax/_src/core/interpreters/forward.py
+++ b/src/genjax/_src/core/interpreters/forward.py
@@ -27,7 +27,7 @@ from jax.interpreters import partial_eval as pe
 from genjax._src.core.interpreters.staging import stage
 from genjax._src.core.pytree import Pytree
 from genjax._src.core.traceback_util import register_exclusion
-from genjax._src.core.typing import Bool, Callable, List, Union, Value, typecheck
+from genjax._src.core.typing import Any, Bool, Callable, List, Union, Value, typecheck
 
 register_exclusion(__file__)
 

--- a/src/genjax/_src/core/interpreters/forward.py
+++ b/src/genjax/_src/core/interpreters/forward.py
@@ -249,7 +249,7 @@ class ForwardInterpreter(Pytree):
 
 
 @typecheck
-def forward(f: Callable):
+def forward(f: Callable[..., Any]):
     @functools.wraps(f)
     @typecheck
     def wrapped(stateful_handler: StatefulHandler, *args):

--- a/src/genjax/_src/core/interpreters/incremental.py
+++ b/src/genjax/_src/core/interpreters/incremental.py
@@ -245,7 +245,7 @@ def default_propagation_rule(prim, *args, **_params):
 
 @Pytree.dataclass
 class IncrementalInterpreter(Pytree):
-    custom_rules: dict[jc.Primitive, Callable] = Pytree.static(default_factory=dict)
+    custom_rules: dict[jc.Primitive, Callable[..., Any]] = Pytree.static(default_factory=dict)
 
     def _eval_jaxpr_forward(
         self,
@@ -301,7 +301,7 @@ class IncrementalInterpreter(Pytree):
 
 
 @typecheck
-def incremental(f: Callable):
+def incremental(f: Callable[..., Any]):
     @functools.wraps(f)
     @typecheck
     def wrapped(

--- a/src/genjax/_src/core/interpreters/incremental.py
+++ b/src/genjax/_src/core/interpreters/incremental.py
@@ -245,7 +245,9 @@ def default_propagation_rule(prim, *args, **_params):
 
 @Pytree.dataclass
 class IncrementalInterpreter(Pytree):
-    custom_rules: dict[jc.Primitive, Callable[..., Any]] = Pytree.static(default_factory=dict)
+    custom_rules: dict[jc.Primitive, Callable[..., Any]] = Pytree.static(
+        default_factory=dict
+    )
 
     def _eval_jaxpr_forward(
         self,

--- a/src/genjax/_src/core/interpreters/time_travel.py
+++ b/src/genjax/_src/core/interpreters/time_travel.py
@@ -47,10 +47,10 @@ record_p = InitialStylePrimitive("record_p")
 
 @Pytree.dataclass
 class FrameRecording(Pytree):
-    f: Callable
+    f: Callable[..., Any]
     args: Tuple
     local_retval: Any
-    cont: Callable
+    cont: Callable[..., Any]
 
 
 @Pytree.dataclass
@@ -61,7 +61,7 @@ class RecordPoint(Pytree):
     def default_call(self, *args):
         return self.callable(*args)
 
-    def handle(self, cont: Callable, *args):
+    def handle(self, cont: Callable[..., Any], *args):
         @Pytree.partial()
         def _cont(*args):
             final_ret, _ = cont(self.callable(*args))
@@ -85,7 +85,7 @@ class RecordPoint(Pytree):
 
 @typecheck
 def rec(
-    callable: Callable,
+    callable: Callable[..., Any],
     debug_tag: Optional[String] = None,
 ):
     if not isinstance(callable, Closure):
@@ -273,7 +273,7 @@ class TimeTravelingDebugger(Pytree):
 
 
 @typecheck
-def _record(source: Callable):
+def _record(source: Callable[..., Any]):
     def inner(*args) -> Tuple[Any, TimeTravelingDebugger]:
         retval, next = time_travel(source)(*args)
         sequence = []
@@ -291,7 +291,7 @@ def _record(source: Callable):
 
 
 @typecheck
-def time_machine(source: Callable):
+def time_machine(source: Callable[..., Any]):
     def instrumented(*args):
         return tag(rec(source, "_enter")(*args), "exit")
 

--- a/src/genjax/_src/core/pytree.py
+++ b/src/genjax/_src/core/pytree.py
@@ -490,7 +490,7 @@ class Closure(Pytree):
     """
 
     dyn_args: Tuple
-    fn: Callable = Pytree.static()
+    fn: Callable[..., Any] = Pytree.static()
 
     def __call__(self, *args, **kwargs):
         return self.fn(*self.dyn_args, *args, **kwargs)

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -130,7 +130,7 @@ Examples:
 #################
 
 
-def static_check_is_array(v):
+def static_check_is_array(v: Any) -> Bool:
     return (
         isinstance(v, jnp.ndarray)
         or isinstance(v, np.ndarray)
@@ -138,11 +138,11 @@ def static_check_is_array(v):
     )
 
 
-def static_check_is_concrete(x):
+def static_check_is_concrete(x: Any) -> Bool:
     return not isinstance(x, jc.Tracer)
 
 
-def static_check_bool(x):
+def static_check_bool(x: Any) -> Bool:
     return static_check_is_concrete(x) and isinstance(x, Bool)
 
 

--- a/src/genjax/_src/generative_functions/combinators/dimap.py
+++ b/src/genjax/_src/generative_functions/combinators/dimap.py
@@ -106,8 +106,8 @@ class DimapCombinator(GenerativeFunction):
     """
 
     inner: GenerativeFunction
-    argument_mapping: Callable = Pytree.static()
-    retval_mapping: Callable = Pytree.static()
+    argument_mapping: Callable[..., Any] = Pytree.static()
+    retval_mapping: Callable[..., Any] = Pytree.static()
     info: Optional[String] = Pytree.static(default=None)
 
     @GenerativeFunction.gfi_boundary
@@ -201,8 +201,8 @@ class DimapCombinator(GenerativeFunction):
 
 def dimap(
     *,
-    pre: Callable = lambda *args: args,
-    post: Callable = lambda _args, retval: retval,
+    pre: Callable[..., Any] = lambda *args: args,
+    post: Callable[..., Any] = lambda _args, retval: retval,
     info: Optional[String] = None,
 ) -> Callable[[GenerativeFunction], GenerativeFunction]:
     """
@@ -255,7 +255,7 @@ def dimap(
 
 
 def map(
-    f: Callable,
+    f: Callable[..., Any],
     *,
     info: Optional[String] = None,
 ) -> Callable[[GenerativeFunction], GenerativeFunction]:
@@ -299,7 +299,7 @@ def map(
 
 
 def contramap(
-    f: Callable,
+    f: Callable[..., Any],
     *,
     info: Optional[String] = None,
 ) -> Callable[[GenerativeFunction], GenerativeFunction]:

--- a/src/genjax/_src/generative_functions/distributions/distribution.py
+++ b/src/genjax/_src/generative_functions/distributions/distribution.py
@@ -216,7 +216,7 @@ class Distribution(GenerativeFunction):
         trace: Trace,
         argdiffs: Argdiffs,
     ) -> Tuple[Trace, Weight, Retdiff, UpdateProblem]:
-        sample = trace.get_sample()
+        sample = trace.get_choices()
         primals = Diff.tree_primal(argdiffs)
         new_score, _ = self.assess(sample, primals)
         new_trace = DistributionTrace(self, primals, sample.get_value(), new_score)
@@ -234,7 +234,7 @@ class Distribution(GenerativeFunction):
         constraint: MaskedConstraint,
         argdiffs: Argdiffs,
     ) -> Tuple[Trace, Weight, Retdiff, UpdateProblem]:
-        old_sample = trace.get_sample()
+        old_sample = trace.get_choices()
 
         def update_branch(key, trace, constraint, argdiffs):
             tr, w, rd, _ = self.update(key, trace, GenericProblem(argdiffs, constraint))
@@ -245,7 +245,7 @@ class Distribution(GenerativeFunction):
                 MaskedProblem(True, old_sample),
             )
 
-        def do_nothing_branch(key, trace, constraint, argdiffs):
+        def do_nothing_branch(key, trace, _, argdiffs):
             tr, w, _, _ = self.update(
                 key, trace, GenericProblem(argdiffs, EmptyProblem())
             )
@@ -276,7 +276,7 @@ class Distribution(GenerativeFunction):
         primals = Diff.tree_primal(argdiffs)
         match constraint:
             case EmptyConstraint():
-                old_sample = trace.get_sample()
+                old_sample = trace.get_choices()
                 old_retval = trace.get_retval()
                 new_score, _ = self.assess(old_sample, primals)
                 new_trace = DistributionTrace(
@@ -316,7 +316,7 @@ class Distribution(GenerativeFunction):
                         discard,
                     )
                 elif static_check_is_concrete(check):
-                    value_chm = trace.get_sample()
+                    value_chm = trace.get_choices()
                     v = value_chm.get_value()
                     fwd = self.estimate_logpdf(key, v, *primals)
                     bwd = trace.get_score()
@@ -342,7 +342,7 @@ class Distribution(GenerativeFunction):
                     masked_value: Mask = v
                     flag = masked_value.flag
                     new_value = masked_value.value
-                    old_value = trace.get_sample().get_value()
+                    old_value = trace.get_choices().get_value()
 
                     new_value, w, score = jax.lax.cond(
                         flag,

--- a/src/genjax/_src/generative_functions/distributions/distribution.py
+++ b/src/genjax/_src/generative_functions/distributions/distribution.py
@@ -579,8 +579,8 @@ class ExactDensityFromCallables(ExactDensity):
 
 @typecheck
 def exact_density(
-    sample: Callable,
-    logpdf: Callable,
+    sample: Callable[..., Any],
+    logpdf: Callable[..., Any],
 ):
     if not isinstance(sample, Closure):
         sample = Pytree.partial()(sample)

--- a/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
+++ b/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
@@ -15,13 +15,13 @@
 
 from tensorflow_probability.substrates import jax as tfp
 
-from genjax._src.core.typing import Callable
+from genjax._src.core.typing import Any, Callable
 from genjax._src.generative_functions.distributions.distribution import exact_density
 
 tfd = tfp.distributions
 
 
-def tfp_distribution(dist: Callable):
+def tfp_distribution(dist: Callable[..., Any]):
     def sampler(key, *args, **kwargs):
         d = dist(*args, **kwargs)
         return d.sample(seed=key)

--- a/src/genjax/_src/generative_functions/interpreted.py
+++ b/src/genjax/_src/generative_functions/interpreted.py
@@ -90,7 +90,7 @@ class Handler(object):
 # A primitive used in our language to denote invoking another generative function.
 # Its behavior depends on the handler which is at the top of the stack
 # when the primitive is invoked.
-def trace(addr: Any, gen_fn: GenerativeFunction) -> Callable:
+def trace(addr: Any, gen_fn: GenerativeFunction) -> Callable[..., Any]:
     """Invoke a generative function, binding its generative semantics with the current
     caller.
 
@@ -290,7 +290,7 @@ def handler_trace_with_interpreted(
     return trace(addr, gen_fn)(args)
 
 
-# Our generative function type - simply wraps a `source: Callable`
+# Our generative function type - simply wraps a `source: Callable[..., Any]`
 # which can invoke our `trace` primitive.
 @Pytree.dataclass
 class InterpretedGenerativeFunction(GenerativeFunction):
@@ -331,7 +331,7 @@ class InterpretedGenerativeFunction(GenerativeFunction):
     ```
     """
 
-    source: Callable = Pytree.static()
+    source: Callable[..., Any] = Pytree.static()
 
     @GenerativeFunction.gfi_boundary
     @typecheck

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -623,7 +623,7 @@ class StaticGenerativeFunction(GenerativeFunction):
 
 
 @typecheck
-def gen(f: Callable) -> StaticGenerativeFunction:
+def gen(f: Callable[..., Any]) -> StaticGenerativeFunction:
     if isinstance(f, Closure):
         return StaticGenerativeFunction(f)
     else:

--- a/src/genjax/_src/inference/smc.py
+++ b/src/genjax/_src/inference/smc.py
@@ -601,7 +601,7 @@ class SMCP3Move(SMCMove):
 
 @Pytree.dataclass
 class DirectOverload(SMCMove):
-    impl: Callable
+    impl: Callable[..., Any]
 
     @typecheck
     def weight_correction(

--- a/src/genjax/_src/inference/sp.py
+++ b/src/genjax/_src/inference/sp.py
@@ -236,7 +236,7 @@ class Marginal(SampleDistribution):
     ) -> Tuple[FloatArray, Sample]:
         key, sub_key = jax.random.split(key)
         tr = self.gen_fn.simulate(sub_key, args)
-        choices: ChoiceMap = tr.get_sample()
+        choices: ChoiceMap = tr.get_choices()
         latent_choices = choices.filter(self.selection)
         key, sub_key = jax.random.split(key)
         bwd_problem = ~self.selection

--- a/src/genjax/_src/inference/vi.py
+++ b/src/genjax/_src/inference/vi.py
@@ -64,7 +64,7 @@ tfd = tfp.distributions
 @typecheck
 def adev_distribution(
     adev_primitive: ADEVPrimitive,
-    differentiable_logpdf: Callable,
+    differentiable_logpdf: Callable[..., Any],
 ) -> ExactDensity:
     """
     Return an [`ExactDensity`][genjax.ExactDensity] distribution whose sampler invokes an ADEV sampling primitive, with a provided differentiable log density function.

--- a/tests/generative_functions/test_dimap_combinator.py
+++ b/tests/generative_functions/test_dimap_combinator.py
@@ -57,7 +57,7 @@ class TestDimapCombinator:
         ), "updated 'z' must hit `post_process` before returning"
 
         importance_tr, _ = dimap_model.importance(
-            key, updated_tr.get_sample(), (1.0, 2.0)
+            key, updated_tr.get_choices(), (1.0, 2.0)
         )
         assert (
             importance_tr.get_retval() == updated_tr.get_retval()

--- a/tests/generative_functions/test_distributions.py
+++ b/tests/generative_functions/test_distributions.py
@@ -44,7 +44,7 @@ class TestDistributions:
             MaskedConstraint(True, C.v(1.0)),
             (0.0, 1.0),
         )
-        v = tr.get_sample().get_value()
+        v = tr.get_choices().get_value()
         assert v == 1.0
         assert w == genjax.normal.assess(C.v(v), (0.0, 1.0))[0]
 
@@ -54,7 +54,7 @@ class TestDistributions:
             MaskedConstraint(False, C.v(1.0)),
             (0.0, 1.0),
         )
-        v = tr.get_sample().get_value()
+        v = tr.get_choices().get_value()
         assert v != 1.0
         assert w == 0.0
 
@@ -67,9 +67,9 @@ class TestDistributions:
         (new_tr, w, _, _) = genjax.normal.update(
             sub_key, tr, U.g((Diff(0.0, NoChange), Diff(1.0, NoChange)), C.n())
         )
-        assert new_tr.get_sample().get_value() == tr.get_sample().get_value()
+        assert new_tr.get_choices().get_value() == tr.get_choices().get_value()
         assert (
-            new_tr.get_score() == genjax.normal.assess(tr.get_sample(), (0.0, 1.0))[0]
+            new_tr.get_score() == genjax.normal.assess(tr.get_choices(), (0.0, 1.0))[0]
         )
         assert w == 0.0
 
@@ -83,12 +83,12 @@ class TestDistributions:
                 C.v(1.0),
             ),
         )
-        assert new_tr.get_sample().get_value() == 1.0
+        assert new_tr.get_choices().get_value() == 1.0
         assert new_tr.get_score() == genjax.normal.assess(C.v(1.0), (0.0, 1.0))[0]
         assert (
             w
             == genjax.normal.assess(C.v(1.0), (0.0, 1.0))[0]
-            - genjax.normal.assess(tr.get_sample(), (0.0, 1.0))[0]
+            - genjax.normal.assess(tr.get_choices(), (0.0, 1.0))[0]
         )
 
         # No constraint, change to arguments.
@@ -98,14 +98,14 @@ class TestDistributions:
             tr,
             U.g((Diff(1.0, UnknownChange), Diff(1.0, NoChange)), C.n()),
         )
-        assert new_tr.get_sample().get_value() == tr.get_sample().get_value()
+        assert new_tr.get_choices().get_value() == tr.get_choices().get_value()
         assert (
-            new_tr.get_score() == genjax.normal.assess(tr.get_sample(), (1.0, 1.0))[0]
+            new_tr.get_score() == genjax.normal.assess(tr.get_choices(), (1.0, 1.0))[0]
         )
         assert (
             w
-            == genjax.normal.assess(tr.get_sample(), (1.0, 1.0))[0]
-            - genjax.normal.assess(tr.get_sample(), (0.0, 1.0))[0]
+            == genjax.normal.assess(tr.get_choices(), (1.0, 1.0))[0]
+            - genjax.normal.assess(tr.get_choices(), (0.0, 1.0))[0]
         )
 
         # Constraint, change to arguments.
@@ -118,12 +118,12 @@ class TestDistributions:
                 C.v(1.0),
             ),
         )
-        assert new_tr.get_sample().get_value() == 1.0
+        assert new_tr.get_choices().get_value() == 1.0
         assert new_tr.get_score() == genjax.normal.assess(C.v(1.0), (1.0, 2.0))[0]
         assert (
             w
             == genjax.normal.assess(C.v(1.0), (1.0, 2.0))[0]
-            - genjax.normal.assess(tr.get_sample(), (0.0, 1.0))[0]
+            - genjax.normal.assess(tr.get_choices(), (0.0, 1.0))[0]
         )
 
         # Constraint is masked (True), no change to arguments.
@@ -136,12 +136,12 @@ class TestDistributions:
                 MaskedConstraint(True, C.v(1.0)),
             ),
         )
-        assert new_tr.get_sample().get_value() == 1.0
+        assert new_tr.get_choices().get_value() == 1.0
         assert new_tr.get_score() == genjax.normal.assess(C.v(1.0), (0.0, 1.0))[0]
         assert (
             w
             == genjax.normal.assess(C.v(1.0), (0.0, 1.0))[0]
-            - genjax.normal.assess(tr.get_sample(), (0.0, 1.0))[0]
+            - genjax.normal.assess(tr.get_choices(), (0.0, 1.0))[0]
         )
 
         # Constraint is masked (True), change to arguments.
@@ -154,12 +154,12 @@ class TestDistributions:
                 MaskedConstraint(True, C.v(1.0)),
             ),
         )
-        assert new_tr.get_sample().get_value() == 1.0
+        assert new_tr.get_choices().get_value() == 1.0
         assert new_tr.get_score() == genjax.normal.assess(C.v(1.0), (1.0, 1.0))[0]
         assert (
             w
             == genjax.normal.assess(C.v(1.0), (1.0, 1.0))[0]
-            - genjax.normal.assess(tr.get_sample(), (0.0, 1.0))[0]
+            - genjax.normal.assess(tr.get_choices(), (0.0, 1.0))[0]
         )
 
         # Constraint is masked (False), no change to arguments.
@@ -172,9 +172,9 @@ class TestDistributions:
                 MaskedConstraint(False, C.v(1.0)),
             ),
         )
-        assert new_tr.get_sample().get_value() == tr.get_sample().get_value()
+        assert new_tr.get_choices().get_value() == tr.get_choices().get_value()
         assert (
-            new_tr.get_score() == genjax.normal.assess(tr.get_sample(), (0.0, 1.0))[0]
+            new_tr.get_score() == genjax.normal.assess(tr.get_choices(), (0.0, 1.0))[0]
         )
         assert w == 0.0
 
@@ -188,12 +188,12 @@ class TestDistributions:
                 MaskedConstraint(False, C.v(1.0)),
             ),
         )
-        assert new_tr.get_sample().get_value() == tr.get_sample().get_value()
+        assert new_tr.get_choices().get_value() == tr.get_choices().get_value()
         assert (
-            new_tr.get_score() == genjax.normal.assess(tr.get_sample(), (1.0, 1.0))[0]
+            new_tr.get_score() == genjax.normal.assess(tr.get_choices(), (1.0, 1.0))[0]
         )
         assert (
             w
-            == genjax.normal.assess(tr.get_sample(), (1.0, 1.0))[0]
-            - genjax.normal.assess(tr.get_sample(), (0.0, 1.0))[0]
+            == genjax.normal.assess(tr.get_choices(), (1.0, 1.0))[0]
+            - genjax.normal.assess(tr.get_choices(), (0.0, 1.0))[0]
         )

--- a/tests/generative_functions/test_repeat_combinator.py
+++ b/tests/generative_functions/test_repeat_combinator.py
@@ -26,7 +26,7 @@ class TestRepeatCombinator:
 
         key = PRNGKey(314)
         tr, w = model.repeat(n=10).importance(key, C[1, "x"].set(3.0), ())
-        assert normal.assess(C.v(tr.get_sample()[1, "x"]), (0.0, 1.0))[0] == w
+        assert normal.assess(C.v(tr.get_choices()[1, "x"]), (0.0, 1.0))[0] == w
 
     def test_repeat_matches_vmap(self):
         @gen

--- a/tests/generative_functions/test_static_gen_fn.py
+++ b/tests/generative_functions/test_static_gen_fn.py
@@ -254,8 +254,8 @@ class TestStaticGenFnImportance:
             key, choice.get_submap("y2"), (0.0, 1.0)
         )
         test_score = score_1 + score_2
-        assert choice["y1"] == out.get_sample()["y1"]
-        assert choice["y2"] == out.get_sample()["y2"]
+        assert choice["y1"] == out.get_choices()["y1"]
+        assert choice["y2"] == out.get_choices()["y2"]
         assert out.get_score() == pytest.approx(test_score, 0.01)
 
     def test_importance_weight_correctness(self):
@@ -269,8 +269,8 @@ class TestStaticGenFnImportance:
         key = jax.random.PRNGKey(314159)
         choice = C["y1"].set(0.5).at["y2"].set(0.5)
         (tr, w) = simple_normal.importance(key, choice, ())
-        y1 = tr.get_sample()["y1"]
-        y2 = tr.get_sample()["y2"]
+        y1 = tr.get_choices()["y1"]
+        y2 = tr.get_choices()["y2"]
         assert y1 == 0.5
         assert y2 == 0.5
         (_, score_1) = genjax.normal.importance(
@@ -286,7 +286,7 @@ class TestStaticGenFnImportance:
         # Partial constraints.
         choice = C["y2"].set(0.5)
         (tr, w) = simple_normal.importance(key, choice, ())
-        tr_chm = tr.get_sample()
+        tr_chm = tr.get_choices()
         y1 = tr_chm.get_submap("y1")
         y2 = tr_chm.get_submap("y2")
         assert tr_chm["y2"] == 0.5
@@ -299,7 +299,7 @@ class TestStaticGenFnImportance:
         # No constraints.
         choice = C.n()
         (tr, w) = simple_normal.importance(key, choice, ())
-        tr_chm = tr.get_sample()
+        tr_chm = tr.get_choices()
         y1 = tr_chm.get_submap("y1")
         y2 = tr_chm.get_submap("y2")
         score_1, _ = genjax.normal.assess(y1, (0.0, 1.0))

--- a/tests/generative_functions/test_switch_combinator.py
+++ b/tests/generative_functions/test_switch_combinator.py
@@ -222,7 +222,7 @@ class TestSwitchCombinator:
         keys = jax.random.split(jax.random.PRNGKey(17), 3)
         # Just select 0 in all branches for simplicity:
         tr = jax.vmap(s.simulate, in_axes=(0, None))(keys, (0, (), ()))
-        y = tr.get_sample()["y"]
+        y = tr.get_choices()["y"]
         y = y.unmask()
         assert y.shape == (3,)
 

--- a/tests/generative_functions/test_vmap_combinator.py
+++ b/tests/generative_functions/test_vmap_combinator.py
@@ -72,7 +72,7 @@ class TestVmapCombinator:
         chm = jax.vmap(lambda idx, v: C[idx, "z"].set(v))(jnp.arange(3), zv)
         (tr, _) = kernel.importance(sub_key, chm, (map_over,))
         for i in range(0, 3):
-            v = tr.get_sample()[i, "z"]
+            v = tr.get_choices()[i, "z"]
             v = v.unmask()
             assert v == zv[i]
 


### PR DESCRIPTION
This PR:

- upgrades pyright in the pre-commit hook to the latest version (1.1.371)
- Changes all bare uses of `Callable` to `Callable[..., Any]`... this is not ideal, but we can do another pass knocking out any unfounded use of `Any` in the codebase
- Changes `get_sample` calls to `get_choices` where the caller is assuming that the return value is a choicemap. I know that @femtomc wants to deprecate `get_choices` calls, but the types at play make it clear that we're not ready for this yet.

I want to get to a place where pyright failing for a PR is a notable event, not something we ignore.

Locally, this takes me from 173 errors in pre-commit to 124 errors.