### PR TITLE
Change typechecking mode to standard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ exclude = [
 defineConstant = { DEBUG = true }
 reportMissingImports = true
 reportMissingTypeStubs = false
+typeCheckingMode = "standard"
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
This allows the `basedpyright` extension to work correctly without editor config.