### PR TITLE
Support masks in ChoiceMapBuilder

### DIFF
--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -54,7 +54,8 @@ register_exclusion(__file__)
 #################
 
 StaticAddressComponent = String
-DynamicAddressComponent = Int | IntArray
+MaskAddressComponent = Bool | BoolArray
+DynamicAddressComponent = Int | IntArray | MaskAddressComponent
 AddressComponent = StaticAddressComponent | DynamicAddressComponent
 Address = Tuple[()] | Tuple[AddressComponent, ...]
 StaticAddress = Tuple[()] | Tuple[StaticAddressComponent, ...]
@@ -444,6 +445,8 @@ class _ChoiceMapBuilder(Pytree):
         for comp in reversed(addr):
             if isinstance(comp, ExtendedStaticAddressComponent):
                 new = ChoiceMap.str(comp, new)
+            elif isinstance(comp, MaskAddressComponent):
+                new = ChoiceMap.maybe(comp, new)
             else:
                 new = ChoiceMap.idx(comp, new)
         return new

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -15,6 +15,7 @@
 
 from genjax import ChoiceMapBuilder as C
 from genjax import SelectionBuilder as S
+import jax.numpy as jnp
 
 
 class TestChoiceMap:
@@ -26,6 +27,10 @@ class TestChoiceMap:
     def test_address_map(self):
         chm = C.a(("x",), 3.0)
         assert chm["x"] == 3.0
+
+    def test_mask_map(self):
+        chm = C.a(("x", jnp.array(True)), 3.0)
+        assert chm["x"].value == 3.0
 
 
 class TestSelections:


### PR DESCRIPTION
I don't know if this is a good idea or a correct way to approach this. I just wanted to use a ChoiceMapBuilder for a `genjax.mask` and this seemed a good way to do it.