### PR TITLE
Fixing some problems in cookbooks after comments from Rif (GEN-388)

### DIFF
--- a/notebooks/cookbook/basics/debugging.ipynb
+++ b/notebooks/cookbook/basics/debugging.ipynb
@@ -55,10 +55,11 @@
     "\n",
     "\n",
     "non_jitted = beta_bernoulli_process.simulate\n",
-    "tr = non_jitted(key, (1.0,))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "tr = non_jitted(subkey, (1.0,))\n",
     "key, subkey = jax.random.split(key)\n",
     "jitted = jax.jit(beta_bernoulli_process.simulate)\n",
-    "tr = jitted(key, (1.0,))"
+    "tr = jitted(subkey, (1.0,))"
    ]
   },
   {
@@ -90,7 +91,7 @@
     "\n",
     "non_jitted = beta_bernoulli_process.simulate\n",
     "key, subkey = jax.random.split(key)\n",
-    "tr = non_jitted(key, (1.0,))\n",
+    "tr = non_jitted(subkey, (1.0,))\n",
     "```"
    ]
   }

--- a/notebooks/cookbook/basics/debugging.ipynb
+++ b/notebooks/cookbook/basics/debugging.ipynb
@@ -56,6 +56,7 @@
     "\n",
     "non_jitted = beta_bernoulli_process.simulate\n",
     "tr = non_jitted(key, (1.0,))\n",
+    "key, subkey = jax.random.split(key)\n",
     "jitted = jax.jit(beta_bernoulli_process.simulate)\n",
     "tr = jitted(key, (1.0,))"
    ]
@@ -88,6 +89,7 @@
     "\n",
     "\n",
     "non_jitted = beta_bernoulli_process.simulate\n",
+    "key, subkey = jax.random.split(key)\n",
     "tr = non_jitted(key, (1.0,))\n",
     "```"
    ]

--- a/notebooks/cookbook/basics/generative_fun.ipynb
+++ b/notebooks/cookbook/basics/generative_fun.ipynb
@@ -168,6 +168,7 @@
    "outputs": [],
    "source": [
     "fast_beta_bernoulli_process.simulate(key, (1.0,))\n",
+    "key, subkey = jax.random.split(key)\n",
     "jitted(key, (1.0,))"
    ]
   },
@@ -177,8 +178,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "key, subkey = jax.random.split(key)\n",
     "%timeit beta_bernoulli_process.simulate(key, (1.0,))\n",
+    "key, subkey = jax.random.split(key)\n",
     "%timeit fast_beta_bernoulli_process.simulate(key, (1.0,))\n",
+    "key, subkey = jax.random.split(key)\n",
     "%timeit jitted(key, (1.0,))"
    ]
   },
@@ -204,7 +208,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/cookbook/basics/generative_fun.ipynb
+++ b/notebooks/cookbook/basics/generative_fun.ipynb
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.PRNGKey(314159)"
+    "key = jax.random.PRNGKey(0)"
    ]
   },
   {
@@ -71,7 +71,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tr = beta_bernoulli_process.simulate(key, (1.0,))"
+    "key, subkey = jax.random.split(key)\n",
+    "tr = beta_bernoulli_process.simulate(subkey, (1.0,))"
    ]
   },
   {
@@ -142,34 +143,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can then compare the speed of the three functions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "key = jax.random.PRNGKey(314159)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To fairly compare we need to run the functions once to compile them"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fast_beta_bernoulli_process.simulate(key, (1.0,))\n",
-    "key, subkey = jax.random.split(key)\n",
-    "jitted(key, (1.0,))"
+    "We can then compare the speed of the three functions. \n",
+    "To fairly compare we need to run the functions once to compile them."
    ]
   },
   {
@@ -179,17 +154,24 @@
    "outputs": [],
    "source": [
     "key, subkey = jax.random.split(key)\n",
-    "%timeit beta_bernoulli_process.simulate(key, (1.0,))\n",
+    "fast_beta_bernoulli_process.simulate(subkey, (1.0,))\n",
     "key, subkey = jax.random.split(key)\n",
-    "%timeit fast_beta_bernoulli_process.simulate(key, (1.0,))\n",
-    "key, subkey = jax.random.split(key)\n",
-    "%timeit jitted(key, (1.0,))"
+    "jitted(subkey, (1.0,))"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
-   "source": []
+   "outputs": [],
+   "source": [
+    "key, subkey = jax.random.split(key)\n",
+    "%timeit beta_bernoulli_process.simulate(subkey, (1.0,))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "%timeit fast_beta_bernoulli_process.simulate(subkey, (1.0,))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "%timeit jitted(subkey, (1.0,))"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/cookbook/basics/methods_of_generative_fun.ipynb
+++ b/notebooks/cookbook/basics/methods_of_generative_fun.ipynb
@@ -283,7 +283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.PRNGKey(42)\n",
+    "key, subkey = jax.random.split(key)\n",
     "partial_chm = C[\"v\"].set(1)  # Creates a ChoiceMap of observations\n",
     "args = (0.5,)\n",
     "trace, weight = beta_bernoulli_process.importance(\n",
@@ -358,7 +358,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.PRNGKey(42)\n",
+    "key, subkey = jax.random.split(key)\n",
     "jitted = jit(beta_bernoulli_process.simulate)\n",
     "old_trace = jitted(key, (1.0,))\n",
     "constraint = C[\"v\"].set(1)"
@@ -453,6 +453,7 @@
    "source": [
     "jitted_update = jit(beta_bernoulli_process.update)\n",
     "\n",
+    "key, subkey = jax.random.split(key)\n",
     "new_trace, weight_diff, ret_diff, discard_choice = jitted_update(key, old_trace, update)"
    ]
   },
@@ -510,6 +511,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "key, subkey = jax.random.split(key)\n",
     "sample, score, retval = jit(beta_bernoulli_process.propose)(key, (0.5,))\n",
     "sample, score, retval"
    ]

--- a/notebooks/cookbook/basics/methods_of_generative_fun.ipynb
+++ b/notebooks/cookbook/basics/methods_of_generative_fun.ipynb
@@ -22,6 +22,7 @@
     "from genjax.incremental import Diff, NoChange, UnknownChange\n",
     "from jax import jit\n",
     "\n",
+    "key = jax.random.PRNGKey(0)\n",
     "pretty()\n",
     "\n",
     "\n",
@@ -46,8 +47,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.PRNGKey(0)\n",
-    "trace = jax.jit(beta_bernoulli_process.simulate)(key, (0.5,))"
+    "key, subkey = jax.random.split(key)\n",
+    "trace = jax.jit(beta_bernoulli_process.simulate)(subkey, (0.5,))"
    ]
   },
   {
@@ -287,7 +288,7 @@
     "partial_chm = C[\"v\"].set(1)  # Creates a ChoiceMap of observations\n",
     "args = (0.5,)\n",
     "trace, weight = beta_bernoulli_process.importance(\n",
-    "    key, partial_chm, args\n",
+    "    subkey, partial_chm, args\n",
     ")  # Runs importance sampling"
    ]
   },
@@ -360,7 +361,7 @@
    "source": [
     "key, subkey = jax.random.split(key)\n",
     "jitted = jit(beta_bernoulli_process.simulate)\n",
-    "old_trace = jitted(key, (1.0,))\n",
+    "old_trace = jitted(subkey, (1.0,))\n",
     "constraint = C[\"v\"].set(1)"
    ]
   },
@@ -454,7 +455,9 @@
     "jitted_update = jit(beta_bernoulli_process.update)\n",
     "\n",
     "key, subkey = jax.random.split(key)\n",
-    "new_trace, weight_diff, ret_diff, discard_choice = jitted_update(key, old_trace, update)"
+    "new_trace, weight_diff, ret_diff, discard_choice = jitted_update(\n",
+    "    subkey, old_trace, update\n",
+    ")"
    ]
   },
   {
@@ -512,7 +515,7 @@
    "outputs": [],
    "source": [
     "key, subkey = jax.random.split(key)\n",
-    "sample, score, retval = jit(beta_bernoulli_process.propose)(key, (0.5,))\n",
+    "sample, score, retval = jit(beta_bernoulli_process.propose)(subkey, (0.5,))\n",
     "sample, score, retval"
    ]
   },
@@ -568,16 +571,7 @@
    "outputs": [],
    "source": [
     "subtrace = trace.get_subtrace((\"p\",))\n",
-    "subtrace"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "subtrace.get_sample()"
+    "subtrace, subtrace.get_sample()"
    ]
   }
  ],

--- a/notebooks/cookbook/basics/methods_of_generative_fun.ipynb
+++ b/notebooks/cookbook/basics/methods_of_generative_fun.ipynb
@@ -327,7 +327,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also update a trace. This is for instance useful for performance optimizations in Metropolis-Hastings algorithms where often most of the trace doesn't change between time steps.\n",
+    "We can also update a trace. This is for instance useful as a performance optimization in Metropolis-Hastings algorithms where often most of the trace doesn't change between time steps.\n",
     "\n",
     "We first define a model for which changing the argument will force a change in the trace."
    ]
@@ -418,14 +418,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "arg_diff = (Diff(1.0, UnknownChange),)"
+    "arg_diff = (Diff(5.0, UnknownChange),)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We then we bundle together the arguments and the constraint as a `GenericProblem`, a simple instance of an `UpdateProblem`."
+    "Let's try to see what the system does when we use this last one.\n",
+    "We bundle together `arg_diff` and `constraint` as a `GenericProblem`, a simple instance of an `UpdateProblem`."
    ]
   },
   {
@@ -459,7 +460,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can compare the old and new values"
+    "We can compare the old and new values for the samples and notice that they have not changed."
    ]
   },
   {
@@ -468,7 +469,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "old_trace.get_sample()"
+    "old_trace.get_sample() == new_trace.get_sample()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also see that the weight has changed. In fact we can check that the following relation holds `new_weight` = `old_weight` + `weight_diff`."
    ]
   },
   {
@@ -477,10 +485,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Old value for p:\", old_trace.get_sample()[\"p\"])\n",
-    "print(\"New value for p:\", new_trace.get_sample()[\"p\"])\n",
-    "\n",
-    "weight_diff, ret_diff, discard_choice"
+    "weight_diff, old_trace.get_score() + weight_diff == new_trace.get_score()"
    ]
   },
   {

--- a/notebooks/cookbook/basics/saving_traces.ipynb
+++ b/notebooks/cookbook/basics/saving_traces.ipynb
@@ -26,6 +26,7 @@
     "from genjax import gen, pretty\n",
     "from genjax._src.core.serialization.msgpack import msgpack_serialize\n",
     "\n",
+    "key = jax.random.PRNGKey(0)\n",
     "pretty()"
    ]
   },
@@ -49,7 +50,6 @@
     "    return x + y\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(314159)\n",
     "args = (-2.1, jnp.array([1, 1, 0]))\n",
     "tr = model.simulate(key, args)\n",
     "tr.get_sample()"
@@ -131,7 +131,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/cookbook/basics/saving_traces.ipynb
+++ b/notebooks/cookbook/basics/saving_traces.ipynb
@@ -51,7 +51,8 @@
     "\n",
     "\n",
     "args = (-2.1, jnp.array([1, 1, 0]))\n",
-    "tr = model.simulate(key, args)\n",
+    "key, subkey = jax.random.split(key)\n",
+    "tr = model.simulate(subkey, args)\n",
     "tr.get_sample()"
    ]
   },

--- a/notebooks/cookbook/basics/some_oddities.ipynb
+++ b/notebooks/cookbook/basics/some_oddities.ipynb
@@ -61,20 +61,20 @@
     "# Second way of failing\n",
     "key, subkey = jax.random.split(key)\n",
     "try:\n",
-    "    f.simulate(key, [0.5])\n",
+    "    f.simulate(subkey, [0.5])\n",
     "except Exception as e:\n",
     "    print(e)\n",
     "\n",
     "# Third way of failing\n",
     "key, subkey = jax.random.split(key)\n",
     "try:\n",
-    "    f.simulate(key, (0.5))\n",
+    "    f.simulate(subkey, (0.5))\n",
     "except Exception as e:\n",
     "    print(e)\n",
     "\n",
     "# Correct way\n",
     "key, subkey = jax.random.split(key)\n",
-    "f.simulate(key, (0.5,)).get_retval()"
+    "f.simulate(subkey, (0.5,)).get_retval()"
    ]
   },
   {
@@ -151,7 +151,7 @@
     "arg = (0.3,)  # 0.3 is a valid probability\n",
     "keys = jax.random.split(subkey, 30)\n",
     "# simulate 30 times\n",
-    "jnp.array([h.simulate(key, arg).get_sample()[\"v\"] for key in keys])"
+    "jax.vmap(h.simulate, in_axes=(0, None))(keys, arg).get_sample()"
    ]
   },
   {
@@ -175,9 +175,9 @@
     "\n",
     "key, subkey = jax.random.split(key)\n",
     "arg = ([3.0, 1.0, 2.0],)  # lists of 3 logits\n",
-    "keys = jax.random.split(key, 30)\n",
+    "keys = jax.random.split(subkey, 30)\n",
     "# simulate 30 times\n",
-    "jnp.array([i.simulate(key, arg).get_sample()[\"v\"] for key in keys])"
+    "jax.vmap(i.simulate, in_axes=(0, None))(keys, arg).get_sample()"
    ]
   },
   {
@@ -437,7 +437,8 @@
     "key, subkey = jax.random.split(key)\n",
     "keys = jax.random.split(subkey, 20)\n",
     "jitted = jit(beta_bernoulli_process.simulate)\n",
-    "jnp.array([jitted(key, (0.5,)).get_sample()[\"v\"] for key in keys])"
+    "\n",
+    "jax.vmap(jitted, in_axes=(0, None))(keys, (0.5,)).get_sample()"
    ]
   },
   {
@@ -454,7 +455,7 @@
    "outputs": [],
    "source": [
     "key, subkey = jax.random.split(key)\n",
-    "x = random.uniform(key, (1000,), dtype=jnp.float64)\n",
+    "x = random.uniform(subkey, (1000,), dtype=jnp.float64)\n",
     "print(\"surprise surprise: \", x.dtype)"
    ]
   },
@@ -548,7 +549,7 @@
     "n_repeats = 100\n",
     "variance = jnp.eye(N)\n",
     "key, subkey = jax.random.split(key)\n",
-    "initial_state = jax.random.normal(key, (N,))\n",
+    "initial_state = jax.random.normal(subkey, (N,))\n",
     "\n",
     "\n",
     "@genjax.gen\n",
@@ -561,7 +562,8 @@
     "\n",
     "key, subkey = jax.random.split(key)\n",
     "jitted = jit(hmm.repeat(n=n_repeats).simulate)\n",
-    "trace = jitted(key, (initial_state, None))\n",
+    "trace = jitted(subkey, (initial_state, None))\n",
+    "key, subkey = jax.random.split(key)\n",
     "%timeit jitted(subkey, (initial_state, None))"
    ]
   },
@@ -592,7 +594,7 @@
     "\n",
     "key, subkey = jax.random.split(key)\n",
     "# About 4x slower on arm64 CPU and 40x on a Google Colab GPU\n",
-    "%timeit hmm_debatched(key, initial_state)"
+    "%timeit hmm_debatched(subkey, initial_state)"
    ]
   }
  ],

--- a/notebooks/cookbook/basics/some_oddities.ipynb
+++ b/notebooks/cookbook/basics/some_oddities.ipynb
@@ -107,7 +107,7 @@
     "arg = (3.0,)  # 3 is not a valid probability but a valid logit\n",
     "keys = jax.random.split(subkey, 30)\n",
     "# simulate 30 times\n",
-    "jnp.array([g.simulate(key, arg).get_sample()[\"v\"] for key in keys])"
+    "jax.vmap(g.simulate, in_axes=(0, None))(keys, arg).get_sample()"
    ]
   },
   {

--- a/notebooks/cookbook/basics/some_oddities.ipynb
+++ b/notebooks/cookbook/basics/some_oddities.ipynb
@@ -28,6 +28,7 @@
     "from genjax import beta, gen, pretty\n",
     "from jax import jit, random\n",
     "\n",
+    "key = jax.random.PRNGKey(0)\n",
     "pretty()"
    ]
   },
@@ -50,26 +51,29 @@
     "    return v\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(0)\n",
     "# First way of failing\n",
+    "key, subkey = jax.random.split(key)\n",
     "try:\n",
     "    f.simulate(key, 0.5)\n",
     "except Exception as e:\n",
     "    print(e)\n",
     "\n",
     "# Second way of failing\n",
+    "key, subkey = jax.random.split(key)\n",
     "try:\n",
     "    f.simulate(key, [0.5])\n",
     "except Exception as e:\n",
     "    print(e)\n",
     "\n",
     "# Third way of failing\n",
+    "key, subkey = jax.random.split(key)\n",
     "try:\n",
     "    f.simulate(key, (0.5))\n",
     "except Exception as e:\n",
     "    print(e)\n",
     "\n",
     "# Correct way\n",
+    "key, subkey = jax.random.split(key)\n",
     "f.simulate(key, (0.5,)).get_retval()"
    ]
   },
@@ -99,9 +103,9 @@
     "    return v\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(0)\n",
+    "key, subkey = jax.random.split(key)\n",
     "arg = (3.0,)  # 3 is not a valid probability but a valid logit\n",
-    "keys = jax.random.split(key, 30)\n",
+    "keys = jax.random.split(subkey, 30)\n",
     "# simulate 30 times\n",
     "jnp.array([g.simulate(key, arg).get_sample()[\"v\"] for key in keys])"
    ]
@@ -143,9 +147,9 @@
     "    return v\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(0)\n",
+    "key, subkey = jax.random.split(key)\n",
     "arg = (0.3,)  # 0.3 is a valid probability\n",
-    "keys = jax.random.split(key, 30)\n",
+    "keys = jax.random.split(subkey, 30)\n",
     "# simulate 30 times\n",
     "jnp.array([h.simulate(key, arg).get_sample()[\"v\"] for key in keys])"
    ]
@@ -169,7 +173,7 @@
     "    return v\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(0)\n",
+    "key, subkey = jax.random.split(key)\n",
     "arg = ([3.0, 1.0, 2.0],)  # lists of 3 logits\n",
     "keys = jax.random.split(key, 30)\n",
     "# simulate 30 times\n",
@@ -430,8 +434,8 @@
     "    return v\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(0)\n",
-    "keys = jax.random.split(key, 20)\n",
+    "key, subkey = jax.random.split(key)\n",
+    "keys = jax.random.split(subkey, 20)\n",
     "jitted = jit(beta_bernoulli_process.simulate)\n",
     "jnp.array([jitted(key, (0.5,)).get_sample()[\"v\"] for key in keys])"
    ]
@@ -449,7 +453,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = random.uniform(random.key(0), (1000,), dtype=jnp.float64)\n",
+    "key, subkey = jax.random.split(key)\n",
+    "x = random.uniform(key, (1000,), dtype=jnp.float64)\n",
     "print(\"surprise surprise: \", x.dtype)"
    ]
   },
@@ -542,7 +547,8 @@
     "N = 300\n",
     "n_repeats = 100\n",
     "variance = jnp.eye(N)\n",
-    "initial_state = jax.random.normal(jax.random.PRNGKey(0), (N,))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "initial_state = jax.random.normal(key, (N,))\n",
     "\n",
     "\n",
     "@genjax.gen\n",
@@ -553,7 +559,6 @@
     "\n",
     "hmm = hmm_step.scan(n=100)\n",
     "\n",
-    "key = jax.random.PRNGKey(0)\n",
     "key, subkey = jax.random.split(key)\n",
     "jitted = jit(hmm.repeat(n=n_repeats).simulate)\n",
     "trace = jitted(key, (initial_state, None))\n",
@@ -585,7 +590,7 @@
     "    return traces\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(0)\n",
+    "key, subkey = jax.random.split(key)\n",
     "# About 4x slower on arm64 CPU and 40x on a Google Colab GPU\n",
     "%timeit hmm_debatched(key, initial_state)"
    ]
@@ -607,7 +612,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/cookbook/expressivity/conditionals.ipynb
+++ b/notebooks/cookbook/expressivity/conditionals.ipynb
@@ -20,6 +20,7 @@
     "import jax.numpy as jnp\n",
     "from genjax import bernoulli, gen, normal, or_else, pretty, switch\n",
     "\n",
+    "key = jax.random.PRNGKey(0)\n",
     "pretty()"
    ]
   },
@@ -242,7 +243,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.PRNGKey(314159)\n",
     "jitted = jax.jit(cond_model.simulate)\n",
     "tr = jitted(key, (0.0,))\n",
     "tr.get_sample()"
@@ -276,6 +276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "key, subkey = jax.random.split(key)\n",
     "cond_model_v2.simulate(key, (0.0,))"
    ]
   },
@@ -305,9 +306,9 @@
     "    return cond\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(314159)\n",
+    "key, subkey = jax.random.split(key)\n",
     "tr1 = simple_cond_genjax.simulate(key, (0.3,))\n",
-    "tr2 = simple_cond_genjax.simulate(key, (-0.4,))\n",
+    "tr2 = simple_cond_genjax.simulate(subkey, (-0.4,))\n",
     "tr1.get_retval(), tr2.get_retval()"
    ]
   },
@@ -386,10 +387,12 @@
     "    return v\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(0)\n",
+    "key, subkey = jax.random.split(key)\n",
     "jitted = jax.jit(switch_model.simulate)\n",
     "tr1 = jitted(key, (0.0,))\n",
+    "key, subkey = jax.random.split(key)\n",
     "tr2 = jitted(key, (1.1,))\n",
+    "key, subkey = jax.random.split(key)\n",
     "tr3 = jitted(key, (2.2,))\n",
     "(\n",
     "    tr1.get_sample()[(\"s\", \"v1\")],\n",
@@ -421,6 +424,7 @@
     "\n",
     "\n",
     "jitted = switch_model_v2.simulate\n",
+    "key, subkey = jax.random.split(key)\n",
     "tr = jitted(key, (0.0,))\n",
     "tr.get_sample()[(\"switch\", \"v1\")]"
    ]

--- a/notebooks/cookbook/expressivity/conditionals.ipynb
+++ b/notebooks/cookbook/expressivity/conditionals.ipynb
@@ -244,7 +244,8 @@
    "outputs": [],
    "source": [
     "jitted = jax.jit(cond_model.simulate)\n",
-    "tr = jitted(key, (0.0,))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "tr = jitted(subkey, (0.0,))\n",
     "tr.get_sample()"
    ]
   },
@@ -277,7 +278,7 @@
    "outputs": [],
    "source": [
     "key, subkey = jax.random.split(key)\n",
-    "cond_model_v2.simulate(key, (0.0,))"
+    "cond_model_v2.simulate(subkey, (0.0,))"
    ]
   },
   {
@@ -307,7 +308,8 @@
     "\n",
     "\n",
     "key, subkey = jax.random.split(key)\n",
-    "tr1 = simple_cond_genjax.simulate(key, (0.3,))\n",
+    "tr1 = simple_cond_genjax.simulate(subkey, (0.3,))\n",
+    "key, subkey = jax.random.split(key)\n",
     "tr2 = simple_cond_genjax.simulate(subkey, (-0.4,))\n",
     "tr1.get_retval(), tr2.get_retval()"
    ]
@@ -389,11 +391,11 @@
     "\n",
     "key, subkey = jax.random.split(key)\n",
     "jitted = jax.jit(switch_model.simulate)\n",
-    "tr1 = jitted(key, (0.0,))\n",
+    "tr1 = jitted(subkey, (0.0,))\n",
     "key, subkey = jax.random.split(key)\n",
-    "tr2 = jitted(key, (1.1,))\n",
+    "tr2 = jitted(subkey, (1.1,))\n",
     "key, subkey = jax.random.split(key)\n",
-    "tr3 = jitted(key, (2.2,))\n",
+    "tr3 = jitted(subkey, (2.2,))\n",
     "(\n",
     "    tr1.get_sample()[(\"s\", \"v1\")],\n",
     "    tr2.get_sample()[(\"s\", \"v2\")],\n",
@@ -425,7 +427,7 @@
     "\n",
     "jitted = switch_model_v2.simulate\n",
     "key, subkey = jax.random.split(key)\n",
-    "tr = jitted(key, (0.0,))\n",
+    "tr = jitted(subkey, (0.0,))\n",
     "tr.get_sample()[(\"switch\", \"v1\")]"
    ]
   }

--- a/notebooks/cookbook/expressivity/custom_distribution.ipynb
+++ b/notebooks/cookbook/expressivity/custom_distribution.ipynb
@@ -126,7 +126,8 @@
     "\n",
     "probs = jnp.array([0.5, 0.5])\n",
     "key, subkey = jax.random.split(key)\n",
-    "model.simulate(key, (probs,))\n",
+    "model.simulate(subkey, (probs,))\n",
+    "key, subkey = jax.random.split(key)\n",
     "jit(model.simulate)(subkey, (probs,))"
    ]
   },
@@ -144,7 +145,7 @@
    "outputs": [],
    "source": [
     "key, subkey = jax.random.split(key)\n",
-    "jit(model.importance)(key, C[\"mix1\"].set(3.0), (probs,))"
+    "jit(model.importance)(subkey, C[\"mix1\"].set(3.0), (probs,))"
    ]
   }
  ],

--- a/notebooks/cookbook/expressivity/custom_distribution.ipynb
+++ b/notebooks/cookbook/expressivity/custom_distribution.ipynb
@@ -27,10 +27,10 @@
     "from genjax._src.generative_functions.distributions.distribution import Distribution\n",
     "from genjax.typing import Any, Float, Tuple\n",
     "from jax import jit\n",
-    "from jax.random import PRNGKey, split\n",
     "from tensorflow_probability.substrates import jax as tfp\n",
     "\n",
     "tfd = tfp.distributions\n",
+    "key = jax.random.PRNGKey(0)\n",
     "pretty()"
    ]
   },
@@ -53,7 +53,9 @@
     "    bias: Float = Pytree.static(default=0.0)\n",
     "\n",
     "    # For distributions that can compute their densities exactly, `random_weighted` should return a sample x and the reciprocal density 1/p(x).\n",
-    "    def random_weighted(self, key: PRNGKey, probs, means, vars) -> Tuple[Any, Weight]:\n",
+    "    def random_weighted(\n",
+    "        self, key: jax.random.PRNGKey, probs, means, vars\n",
+    "    ) -> Tuple[Any, Weight]:\n",
     "        # making sure that the inputs are jnp arrays for jax compatibility\n",
     "        probs = jnp.asarray(probs)\n",
     "        means = jnp.asarray(means)\n",
@@ -65,7 +67,7 @@
     "        normal = tfd.Normal(\n",
     "            loc=means[cat_index] + jnp.asarray(self.bias), scale=vars[cat_index]\n",
     "        )\n",
-    "        key, subkey = split(key)\n",
+    "        key, subkey = jax.random.split(key)\n",
     "        normal_sample = normal.sample(seed=subkey)\n",
     "\n",
     "        # calculating the reciprocal density\n",
@@ -84,7 +86,7 @@
     "        return normal_sample, weight_recip\n",
     "\n",
     "    # For distributions that can compute their densities exactly, `estimate_logpdf` should return the log density at x.\n",
-    "    def estimate_logpdf(self, key: PRNGKey, x, probs, means, vars) -> Weight:\n",
+    "    def estimate_logpdf(self, key: jax.random.PRNGKey, x, probs, means, vars) -> Weight:\n",
     "        zipped = jnp.stack([probs, means, vars], axis=1)\n",
     "        return jnp.log(\n",
     "            sum(\n",
@@ -111,7 +113,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = PRNGKey(0)\n",
     "# Create a particular instance of the distribution\n",
     "gauss_mix = GaussianMixture(0.0)\n",
     "\n",
@@ -124,8 +125,9 @@
     "\n",
     "\n",
     "probs = jnp.array([0.5, 0.5])\n",
+    "key, subkey = jax.random.split(key)\n",
     "model.simulate(key, (probs,))\n",
-    "jit(model.simulate)(key, (probs,))"
+    "jit(model.simulate)(subkey, (probs,))"
    ]
   },
   {
@@ -141,6 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "key, subkey = jax.random.split(key)\n",
     "jit(model.importance)(key, C[\"mix1\"].set(3.0), (probs,))"
    ]
   }

--- a/notebooks/cookbook/expressivity/iterating_computation.ipynb
+++ b/notebooks/cookbook/expressivity/iterating_computation.ipynb
@@ -25,6 +25,7 @@
     "import jax.numpy as jnp\n",
     "from genjax import bernoulli, gen, pretty\n",
     "\n",
+    "key = jax.random.PRNGKey(0)\n",
     "pretty()"
    ]
   },
@@ -78,7 +79,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.PRNGKey(0)\n",
     "size_of_batch = 20"
    ]
   },
@@ -113,6 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "key, subkey = jax.random.split(key)\n",
     "traces = batched_double_flip.simulate(key, (p, q))\n",
     "traces.get_retval()"
    ]
@@ -130,9 +131,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "key, subkey = jax.random.split(key)\n",
     "p = jax.random.uniform(key, (size_of_batch,))\n",
-    "q = jax.random.uniform(key, (size_of_batch,))\n",
+    "q = jax.random.uniform(subkey, (size_of_batch,))\n",
     "batched_double_flip_v2 = double_flip.vmap(in_axes=(0, 0))\n",
+    "key, subkey = jax.random.split(key)\n",
     "traces = batched_double_flip_v2.simulate(key, (p, q))\n",
     "traces.get_retval()"
    ]
@@ -151,8 +154,10 @@
    "outputs": [],
    "source": [
     "try:\n",
+    "    key, subkey = jax.random.split(key)\n",
     "    p = jax.random.uniform(key, (size_of_batch,))\n",
-    "    q = jax.random.uniform(key, (size_of_batch + 1,))\n",
+    "    q = jax.random.uniform(subkey, (size_of_batch + 1,))\n",
+    "    key, subkey = jax.random.split(key)\n",
     "    traces = batched_double_flip_v2.simulate(key, (p, q))\n",
     "    print(traces.get_retval())\n",
     "except ValueError as e:\n",
@@ -172,7 +177,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.PRNGKey(42)\n",
     "image = jnp.zeros([300, 500], dtype=jnp.float32)"
    ]
   },
@@ -195,6 +199,7 @@
     "    return new_pixel\n",
     "\n",
     "\n",
+    "key, subkey = jax.random.split(key)\n",
     "tr = sample_pixel.simulate(key, (0.0,))\n",
     "tr.get_sample()[\"new_pixel\"]"
    ]
@@ -215,6 +220,7 @@
    "outputs": [],
    "source": [
     "sample_image = sample_pixel.vmap(in_axes=(0,)).vmap(in_axes=(0,))\n",
+    "key, subkey = jax.random.split(key)\n",
     "tr = sample_image.simulate(key, (image,))"
    ]
   },
@@ -260,6 +266,7 @@
     "    return sampled_image[0] + p\n",
     "\n",
     "\n",
+    "key, subkey = jax.random.split(key)\n",
     "tr = model.simulate(key, (0.0,))\n",
     "tr"
    ]
@@ -295,6 +302,7 @@
    "outputs": [],
    "source": [
     "sample_image_flat = sample_pixel.vmap(in_axes=(0,))\n",
+    "key, subkey = jax.random.split(key)\n",
     "tr = sample_image_flat.simulate(key, (image.flatten(),))\n",
     "# resize the sample to the original shape\n",
     "out_image = tr.get_sample()[..., \"new_pixel\"].reshape(image.shape)\n",
@@ -343,7 +351,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.PRNGKey(42)\n",
     "key, subkey = jax.random.split(key)\n",
     "initial_x = 0.0\n",
     "tr_1 = hmm.simulate(key, (initial_x, None))\n",
@@ -404,7 +411,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tr_2 = hmm_v2.simulate(subkey, (initial_x, None))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "tr_2 = hmm_v2.simulate(key, (initial_x, None))\n",
     "tr_2.get_sample()[0, \"z\"], tr_2.get_sample()[9, \"y\"], tr_2.get_sample()[..., \"z\"]"
    ]
   },
@@ -429,8 +437,8 @@
     "    return y\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(0)\n",
     "arg = 3.0\n",
+    "key, subkey = jax.random.split(key)\n",
     "tr = model.repeat(n=10).simulate(key, (arg,))\n",
     "\n",
     "tr.get_sample()[..., \"x\"], tr.get_retval()"
@@ -449,10 +457,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sub_keys = jax.random.split(key, 3)\n",
+    "keys = jax.random.split(subkey, 3)\n",
     "args = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0])\n",
     "n = 3\n",
-    "tr = jax.jit(jax.vmap(model.repeat(n=n).simulate, in_axes=(0, None)))(sub_keys, (args,))\n",
+    "tr = jax.jit(jax.vmap(model.repeat(n=n).simulate, in_axes=(0, None)))(keys, (args,))\n",
     "tr.get_sample()"
    ]
   },
@@ -489,7 +497,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/cookbook/expressivity/iterating_computation.ipynb
+++ b/notebooks/cookbook/expressivity/iterating_computation.ipynb
@@ -96,7 +96,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p = jax.random.uniform(key, (size_of_batch,))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "p = jax.random.uniform(subkey, (size_of_batch,))\n",
     "q = 0.5"
    ]
   },
@@ -114,7 +115,7 @@
    "outputs": [],
    "source": [
     "key, subkey = jax.random.split(key)\n",
-    "traces = batched_double_flip.simulate(key, (p, q))\n",
+    "traces = batched_double_flip.simulate(subkey, (p, q))\n",
     "traces.get_retval()"
    ]
   },
@@ -132,11 +133,12 @@
    "outputs": [],
    "source": [
     "key, subkey = jax.random.split(key)\n",
-    "p = jax.random.uniform(key, (size_of_batch,))\n",
+    "p = jax.random.uniform(subkey, (size_of_batch,))\n",
+    "key, subkey = jax.random.split(key)\n",
     "q = jax.random.uniform(subkey, (size_of_batch,))\n",
     "batched_double_flip_v2 = double_flip.vmap(in_axes=(0, 0))\n",
     "key, subkey = jax.random.split(key)\n",
-    "traces = batched_double_flip_v2.simulate(key, (p, q))\n",
+    "traces = batched_double_flip_v2.simulate(subkey, (p, q))\n",
     "traces.get_retval()"
    ]
   },
@@ -155,10 +157,11 @@
    "source": [
     "try:\n",
     "    key, subkey = jax.random.split(key)\n",
-    "    p = jax.random.uniform(key, (size_of_batch,))\n",
+    "    p = jax.random.uniform(subkey, (size_of_batch,))\n",
+    "    key, subkey = jax.random.split(key)\n",
     "    q = jax.random.uniform(subkey, (size_of_batch + 1,))\n",
     "    key, subkey = jax.random.split(key)\n",
-    "    traces = batched_double_flip_v2.simulate(key, (p, q))\n",
+    "    traces = batched_double_flip_v2.simulate(subkey, (p, q))\n",
     "    print(traces.get_retval())\n",
     "except ValueError as e:\n",
     "    print(e)"
@@ -200,7 +203,7 @@
     "\n",
     "\n",
     "key, subkey = jax.random.split(key)\n",
-    "tr = sample_pixel.simulate(key, (0.0,))\n",
+    "tr = sample_pixel.simulate(subkey, (0.0,))\n",
     "tr.get_sample()[\"new_pixel\"]"
    ]
   },
@@ -221,7 +224,7 @@
    "source": [
     "sample_image = sample_pixel.vmap(in_axes=(0,)).vmap(in_axes=(0,))\n",
     "key, subkey = jax.random.split(key)\n",
-    "tr = sample_image.simulate(key, (image,))"
+    "tr = sample_image.simulate(subkey, (image,))"
    ]
   },
   {
@@ -267,7 +270,7 @@
     "\n",
     "\n",
     "key, subkey = jax.random.split(key)\n",
-    "tr = model.simulate(key, (0.0,))\n",
+    "tr = model.simulate(subkey, (0.0,))\n",
     "tr"
    ]
   },
@@ -303,7 +306,7 @@
    "source": [
     "sample_image_flat = sample_pixel.vmap(in_axes=(0,))\n",
     "key, subkey = jax.random.split(key)\n",
-    "tr = sample_image_flat.simulate(key, (image.flatten(),))\n",
+    "tr = sample_image_flat.simulate(subkey, (image.flatten(),))\n",
     "# resize the sample to the original shape\n",
     "out_image = tr.get_sample()[..., \"new_pixel\"].reshape(image.shape)\n",
     "out_image"
@@ -353,7 +356,7 @@
    "source": [
     "key, subkey = jax.random.split(key)\n",
     "initial_x = 0.0\n",
-    "tr_1 = hmm.simulate(key, (initial_x, None))\n",
+    "tr_1 = hmm.simulate(subkey, (initial_x, None))\n",
     "print(\"Value of z at the beginning:\")\n",
     "tr_1.get_sample()[0, \"x1\", \"z\"]"
    ]
@@ -412,7 +415,7 @@
    "outputs": [],
    "source": [
     "key, subkey = jax.random.split(key)\n",
-    "tr_2 = hmm_v2.simulate(key, (initial_x, None))\n",
+    "tr_2 = hmm_v2.simulate(subkey, (initial_x, None))\n",
     "tr_2.get_sample()[0, \"z\"], tr_2.get_sample()[9, \"y\"], tr_2.get_sample()[..., \"z\"]"
    ]
   },
@@ -439,7 +442,7 @@
     "\n",
     "arg = 3.0\n",
     "key, subkey = jax.random.split(key)\n",
-    "tr = model.repeat(n=10).simulate(key, (arg,))\n",
+    "tr = model.repeat(n=10).simulate(subkey, (arg,))\n",
     "\n",
     "tr.get_sample()[..., \"x\"], tr.get_retval()"
    ]
@@ -457,6 +460,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "key, subkey = jax.random.split(key)\n",
     "keys = jax.random.split(subkey, 3)\n",
     "args = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0])\n",
     "n = 3\n",

--- a/notebooks/cookbook/expressivity/mixture.ipynb
+++ b/notebooks/cookbook/expressivity/mixture.ipynb
@@ -89,7 +89,8 @@
     "    return a + z\n",
     "\n",
     "\n",
-    "tr = mixture_model.simulate(key, (0.4,))\n",
+    "key, subkey = random.split(key)\n",
+    "tr = mixture_model.simulate(subkey, (0.4,))\n",
     "print(\"return value:\", tr.get_retval())\n",
     "print(\"value for z:\", tr.get_sample()[\"z\"])"
    ]

--- a/notebooks/cookbook/expressivity/mixture.ipynb
+++ b/notebooks/cookbook/expressivity/mixture.ipynb
@@ -21,7 +21,9 @@
    "outputs": [],
    "source": [
     "from genjax import flip, gen, inverse_gamma, mix, normal\n",
-    "from jax import random"
+    "from jax import random\n",
+    "\n",
+    "key = random.PRNGKey(0)"
    ]
   },
   {
@@ -87,7 +89,6 @@
     "    return a + z\n",
     "\n",
     "\n",
-    "key = random.PRNGKey(23)\n",
     "tr = mixture_model.simulate(key, (0.4,))\n",
     "print(\"return value:\", tr.get_retval())\n",
     "print(\"value for z:\", tr.get_sample()[\"z\"])"
@@ -126,7 +127,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/cookbook/expressivity/stochastic_probabilities.ipynb
+++ b/notebooks/cookbook/expressivity/stochastic_probabilities.ipynb
@@ -196,7 +196,8 @@
     "means = jnp.array([0.0, 1.0, 2.0, 3.0])\n",
     "vars = jnp.array([1.0, 1.0, 1.0, 1.0])\n",
     "\n",
-    "tr = model.simulate(key, (cat_probs, means, vars))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "tr = model.simulate(subkey, (cat_probs, means, vars))\n",
     "tr"
    ]
   },
@@ -209,7 +210,7 @@
     "# TODO: assess currently raises a not implemented error, but we can use importance with a full trace instead\n",
     "# model.assess(tr.get_choices(), (cat_probs, means, vars))\n",
     "key, subkey = jax.random.split(key)\n",
-    "_, w = model.importance(key, tr.get_choices(), (cat_probs, means, vars))\n",
+    "_, w = model.importance(subkey, tr.get_choices(), (cat_probs, means, vars))\n",
     "w"
    ]
   },
@@ -221,7 +222,7 @@
    "source": [
     "y = 2.0\n",
     "key, subkey = jax.random.split(key)\n",
-    "model.importance(key, C[\"y\"].set(y), (cat_probs, means, vars))"
+    "model.importance(subkey, C[\"y\"].set(y), (cat_probs, means, vars))"
    ]
   },
   {
@@ -245,11 +246,12 @@
     "cat_probs = cat_probs / jnp.sum(cat_probs)\n",
     "means = jnp.arange(0.0, N * 1.0, 1.0)\n",
     "vars = jnp.ones(N) / N\n",
-    "keys = jax.random.split(subkey, n_estimates)\n",
     "key, subkey = jax.random.split(key)\n",
-    "log_density = gm.estimate_logpdf(key, x, cat_probs, means, vars)  # exact value\n",
+    "log_density = gm.estimate_logpdf(subkey, x, cat_probs, means, vars)  # exact value\n",
     "log_density\n",
     "jitted = jax.jit(jax.vmap(sgm.estimate_logpdf, in_axes=(0, None, None, None, None)))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "keys = jax.random.split(subkey, n_estimates)\n",
     "estimates = jitted(keys, x, cat_probs, means, vars)\n",
     "log_mean_estimates = jax.scipy.special.logsumexp(estimates) - jnp.log(len(estimates))\n",
     "log_density, log_mean_estimates"
@@ -272,7 +274,6 @@
    "source": [
     "N = 30000\n",
     "n_estimates = 10\n",
-    "keys = jax.random.split(subkey, n_estimates)\n",
     "cat_probs = jnp.array(jnp.arange(1.0 / N, 1.0 + 1.0 / N, 1.0 / N))\n",
     "cat_probs = cat_probs / jnp.sum(cat_probs)\n",
     "means = jnp.arange(0.0, N * 1.0, 1.0)\n",
@@ -290,10 +291,14 @@
     "\n",
     "# warmup the jit\n",
     "key, subkey = jax.random.split(key)\n",
-    "jitted_exact(key, x, cat_probs, means, vars)\n",
+    "jitted_exact(subkey, x, cat_probs, means, vars)\n",
+    "key, subkey = jax.random.split(key)\n",
+    "keys = jax.random.split(subkey, n_estimates)\n",
     "jitted_approx(keys, x, cat_probs, means, vars)\n",
-    "keys = jax.random.split(key, n_estimates)\n",
+    "key, subkey = jax.random.split(key)\n",
+    "keys = jax.random.split(subkey, n_estimates)\n",
     "%timeit jitted(keys, x, cat_probs, means, vars)\n",
+    "key, subkey = jax.random.split(key)\n",
     "keys = jax.random.split(subkey, n_estimates)\n",
     "%timeit jitted_approx(keys, x, cat_probs, means, vars)"
    ]
@@ -376,7 +381,7 @@
     "\n",
     "key, subkey = jax.random.split(key)\n",
     "gensp_importance_sampling(model, obs, proposal)(\n",
-    "    key, ((cat_probs, means, vars),), ((obs, cat_probs, means, vars),)\n",
+    "    subkey, ((cat_probs, means, vars),), ((obs, cat_probs, means, vars),)\n",
     ")"
    ]
   },

--- a/notebooks/cookbook/expressivity/stochastic_probabilities.ipynb
+++ b/notebooks/cookbook/expressivity/stochastic_probabilities.ipynb
@@ -34,10 +34,10 @@
     "from genjax import Pytree, Weight, pretty\n",
     "from genjax._src.generative_functions.distributions.distribution import Distribution\n",
     "from genjax.typing import Any, Tuple\n",
-    "from jax.random import PRNGKey, split\n",
     "from tensorflow_probability.substrates import jax as tfp\n",
     "\n",
     "tfd = tfp.distributions\n",
+    "key = jax.random.PRNGKey(0)\n",
     "pretty()"
    ]
   },
@@ -56,14 +56,16 @@
    "source": [
     "@Pytree.dataclass\n",
     "class GaussianMixture(Distribution):\n",
-    "    def random_weighted(self, key: PRNGKey, probs, means, vars) -> Tuple[Any, Weight]:\n",
+    "    def random_weighted(\n",
+    "        self, key: jax.random.PRNGKey, probs, means, vars\n",
+    "    ) -> Tuple[Any, Weight]:\n",
     "        probs = jnp.asarray(probs)\n",
     "        means = jnp.asarray(means)\n",
     "        vars = jnp.asarray(vars)\n",
     "        cat = tfd.Categorical(probs=probs)\n",
     "        cat_index = jnp.asarray(cat.sample(seed=key))\n",
     "        normal = tfd.Normal(loc=means[cat_index], scale=vars[cat_index])\n",
-    "        key, subkey = split(key)\n",
+    "        key, subkey = jax.random.split(key)\n",
     "        normal_sample = normal.sample(seed=subkey)\n",
     "        zipped = jnp.stack([jnp.arange(0, len(probs)), means, vars], axis=1)\n",
     "        weight_recip = -jax.scipy.special.logsumexp(\n",
@@ -75,7 +77,7 @@
     "\n",
     "        return normal_sample, weight_recip\n",
     "\n",
-    "    def estimate_logpdf(self, key: PRNGKey, x, probs, means, vars) -> Weight:\n",
+    "    def estimate_logpdf(self, key: jax.random.PRNGKey, x, probs, means, vars) -> Weight:\n",
     "        zipped = jnp.stack([jnp.arange(0, len(probs)), means, vars], axis=1)\n",
     "        return jax.scipy.special.logsumexp(\n",
     "            jax.vmap(\n",
@@ -127,14 +129,16 @@
    "source": [
     "@Pytree.dataclass\n",
     "class StochasticGaussianMixture(Distribution):\n",
-    "    def random_weighted(self, key: PRNGKey, probs, means, vars) -> Tuple[Any, Weight]:\n",
+    "    def random_weighted(\n",
+    "        self, key: jax.random.PRNGKey, probs, means, vars\n",
+    "    ) -> Tuple[Any, Weight]:\n",
     "        probs = jnp.asarray(probs)\n",
     "        means = jnp.asarray(means)\n",
     "        vars = jnp.asarray(vars)\n",
     "        cat = tfd.Categorical(probs=probs)\n",
     "        cat_index = jnp.asarray(cat.sample(seed=key))\n",
     "        normal = tfd.Normal(loc=means[cat_index], scale=vars[cat_index])\n",
-    "        key, subkey = split(key)\n",
+    "        key, subkey = jax.random.split(key)\n",
     "        normal_sample = normal.sample(seed=subkey)\n",
     "        # We can estimate the reciprocal (marginal) density in constant time. Math magic explained at the end!\n",
     "        weight_recip = -tfd.Normal(\n",
@@ -145,7 +149,7 @@
     "    # Given a sample `x`, we can also estimate the density in constant time\n",
     "    # Math again explained at the end.\n",
     "    # TODO: we could probably improve further with a better proposal\n",
-    "    def estimate_logpdf(self, key: PRNGKey, x, probs, means, vars) -> Weight:\n",
+    "    def estimate_logpdf(self, key: jax.random.PRNGKey, x, probs, means, vars) -> Weight:\n",
     "        cat = tfd.Categorical(probs=probs)\n",
     "        cat_index = jnp.asarray(cat.sample(seed=key))\n",
     "        return tfd.Normal(loc=means[cat_index], scale=vars[cat_index]).log_prob(x)"
@@ -164,7 +168,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = PRNGKey(0)\n",
     "sgm = StochasticGaussianMixture()\n",
     "\n",
     "\n",
@@ -205,6 +208,7 @@
    "source": [
     "# TODO: assess currently raises a not implemented error, but we can use importance with a full trace instead\n",
     "# model.assess(tr.get_choices(), (cat_probs, means, vars))\n",
+    "key, subkey = jax.random.split(key)\n",
     "_, w = model.importance(key, tr.get_choices(), (cat_probs, means, vars))\n",
     "w"
    ]
@@ -216,6 +220,7 @@
    "outputs": [],
    "source": [
     "y = 2.0\n",
+    "key, subkey = jax.random.split(key)\n",
     "model.importance(key, C[\"y\"].set(y), (cat_probs, means, vars))"
    ]
   },
@@ -240,8 +245,8 @@
     "cat_probs = cat_probs / jnp.sum(cat_probs)\n",
     "means = jnp.arange(0.0, N * 1.0, 1.0)\n",
     "vars = jnp.ones(N) / N\n",
-    "key = PRNGKey(0)\n",
-    "keys = split(key, n_estimates)\n",
+    "keys = jax.random.split(subkey, n_estimates)\n",
+    "key, subkey = jax.random.split(key)\n",
     "log_density = gm.estimate_logpdf(key, x, cat_probs, means, vars)  # exact value\n",
     "log_density\n",
     "jitted = jax.jit(jax.vmap(sgm.estimate_logpdf, in_axes=(0, None, None, None, None)))\n",
@@ -267,8 +272,7 @@
    "source": [
     "N = 30000\n",
     "n_estimates = 10\n",
-    "key = PRNGKey(0)\n",
-    "keys = split(key, n_estimates)\n",
+    "keys = jax.random.split(subkey, n_estimates)\n",
     "cat_probs = jnp.array(jnp.arange(1.0 / N, 1.0 + 1.0 / N, 1.0 / N))\n",
     "cat_probs = cat_probs / jnp.sum(cat_probs)\n",
     "means = jnp.arange(0.0, N * 1.0, 1.0)\n",
@@ -285,9 +289,12 @@
     ")\n",
     "\n",
     "# warmup the jit\n",
+    "key, subkey = jax.random.split(key)\n",
     "jitted_exact(key, x, cat_probs, means, vars)\n",
     "jitted_approx(keys, x, cat_probs, means, vars)\n",
+    "keys = jax.random.split(key, n_estimates)\n",
     "%timeit jitted(keys, x, cat_probs, means, vars)\n",
+    "keys = jax.random.split(subkey, n_estimates)\n",
     "%timeit jitted_approx(keys, x, cat_probs, means, vars)"
    ]
   },
@@ -340,11 +347,12 @@
    "source": [
     "def gensp_importance_sampling(target, obs, proposal):\n",
     "    def _inner(key, target_args, proposal_args):\n",
+    "        key, subkey = jax.random.split(key)\n",
     "        trace = proposal.simulate(key, *proposal_args)\n",
     "        chm = obs ^ trace.get_sample()\n",
     "        proposal_logpdf = trace.get_score()\n",
     "        # TODO: using importance instead of assess, as assess is not implemented\n",
-    "        _, target_logpdf = target.importance(key, chm, *target_args)\n",
+    "        _, target_logpdf = target.importance(subkey, chm, *target_args)\n",
     "        importance_weight = target_logpdf - proposal_logpdf\n",
     "        return (trace, importance_weight)\n",
     "\n",
@@ -366,6 +374,7 @@
    "source": [
     "obs = C[\"y\"].set(2.0)\n",
     "\n",
+    "key, subkey = jax.random.split(key)\n",
     "gensp_importance_sampling(model, obs, proposal)(\n",
     "    key, ((cat_probs, means, vars),), ((obs, cat_probs, means, vars),)\n",
     ")"

--- a/notebooks/cookbook/inference/custom_proposal.ipynb
+++ b/notebooks/cookbook/inference/custom_proposal.ipynb
@@ -29,12 +29,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import jax\n",
     "import jax.numpy as jnp\n",
     "from genjax import ChoiceMapBuilder as C\n",
     "from genjax import Target, gen, normal, pretty, smc\n",
-    "from jax import jit, random, vmap\n",
+    "from jax import jit, vmap\n",
     "from jax.scipy.special import logsumexp\n",
     "\n",
+    "key = jax.random.PRNGKey(0)\n",
     "pretty()"
    ]
   },
@@ -80,8 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = random.PRNGKey(0)\n",
-    "key, *sub_keys = random.split(key, 1000 + 1)\n",
+    "key, *sub_keys = jax.random.split(key, 1000 + 1)\n",
     "sub_keys = jnp.array(sub_keys)\n",
     "args = ()\n",
     "jitted = jit(vmap(model.importance, in_axes=(0, None, None)))\n",
@@ -168,8 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = random.PRNGKey(0)\n",
-    "key, *sub_keys = random.split(key, 1000 + 1)\n",
+    "key, *sub_keys = jax.random.split(key, 1000 + 1)\n",
     "sub_keys = jnp.array(sub_keys)\n",
     "args_for_model = ()\n",
     "args_for_proposal = (jnp.array([obs[\"obs1\"], obs[\"obs2\"], obs[\"obs3\"]]),)\n",
@@ -270,6 +270,7 @@
    "outputs": [],
    "source": [
     "jitted = jit(alg.simulate)\n",
+    "key, sub_key = jax.random.split(key)\n",
     "posterior_samples = jitted(key, (target_posterior,))\n",
     "posterior_samples"
    ]

--- a/notebooks/cookbook/inference/custom_proposal.ipynb
+++ b/notebooks/cookbook/inference/custom_proposal.ipynb
@@ -270,8 +270,8 @@
    "outputs": [],
    "source": [
     "jitted = jit(alg.simulate)\n",
-    "key, sub_key = jax.random.split(key)\n",
-    "posterior_samples = jitted(key, (target_posterior,))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "posterior_samples = jitted(subkey, (target_posterior,))\n",
     "posterior_samples"
    ]
   }

--- a/notebooks/cookbook/inference/importance_sampling.ipynb
+++ b/notebooks/cookbook/inference/importance_sampling.ipynb
@@ -88,8 +88,9 @@
     "model_args = (0.0, 1.0)\n",
     "proposal_args = (3.0, 4.0)\n",
     "\n",
+    "key, subkey = jax.random.split(key)\n",
     "sample, importance_weight = jit(importance_sample(model, proposal))(\n",
-    "    key, (model_args,), (proposal_args,)\n",
+    "    subkey, (model_args,), (proposal_args,)\n",
     ")\n",
     "print(importance_weight, sample.get_sample())"
    ]
@@ -174,7 +175,7 @@
    "outputs": [],
    "source": [
     "key, subkey = jax.random.split(key)\n",
-    "trace, weight = beta_bernoulli_process.importance(key, obs, args)\n",
+    "trace, weight = beta_bernoulli_process.importance(subkey, obs, args)\n",
     "\n",
     "trace, weight"
    ]
@@ -192,7 +193,7 @@
     "def SIR(N, K, model, chm):\n",
     "    @jit\n",
     "    def _inner(key, args):\n",
-    "        key, subkey = jax.random.split(key, 2)\n",
+    "        key, subkey = jax.random.split(key)\n",
     "        traces, weights = vmap(model.importance, in_axes=(0, None, None))(\n",
     "            jax.random.split(key, N), chm, args\n",
     "        )\n",
@@ -224,7 +225,7 @@
     "chm = C[\"v\"].set(1)\n",
     "args = (0.5,)\n",
     "key, subkey = jax.random.split(key)\n",
-    "samples = jit(SIR(N, K, beta_bernoulli_process, chm))(key, args)\n",
+    "samples = jit(SIR(N, K, beta_bernoulli_process, chm))(subkey, args)\n",
     "samples"
    ]
   },

--- a/notebooks/cookbook/inference/importance_sampling.ipynb
+++ b/notebooks/cookbook/inference/importance_sampling.ipynb
@@ -34,8 +34,8 @@
     "from genjax import ChoiceMapBuilder as C\n",
     "from genjax import Target, bernoulli, beta, gen, pretty, smc\n",
     "from jax import jit, vmap\n",
-    "from jax.random import PRNGKey, split\n",
     "\n",
+    "key = jax.random.PRNGKey(0)\n",
     "pretty()"
    ]
   },
@@ -87,7 +87,7 @@
     "\n",
     "model_args = (0.0, 1.0)\n",
     "proposal_args = (3.0, 4.0)\n",
-    "key = PRNGKey(0)\n",
+    "\n",
     "sample, importance_weight = jit(importance_sample(model, proposal))(\n",
     "    key, (model_args,), (proposal_args,)\n",
     ")\n",
@@ -113,7 +113,7 @@
     "        in_axes=(0, None, None),\n",
     "    )\n",
     ")\n",
-    "key, *sub_keys = split(key, 100 + 1)\n",
+    "key, *sub_keys = jax.random.split(key, 100 + 1)\n",
     "sub_keys = jnp.array(sub_keys)\n",
     "(sample, importance_weight) = jitted(sub_keys, (model_args,), (proposal_args,))\n",
     "sample.get_choices(), importance_weight"
@@ -173,6 +173,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "key, subkey = jax.random.split(key)\n",
     "trace, weight = beta_bernoulli_process.importance(key, obs, args)\n",
     "\n",
     "trace, weight"
@@ -220,9 +221,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.PRNGKey(0)\n",
     "chm = C[\"v\"].set(1)\n",
     "args = (0.5,)\n",
+    "key, subkey = jax.random.split(key)\n",
     "samples = jit(SIR(N, K, beta_bernoulli_process, chm))(key, args)\n",
     "samples"
    ]
@@ -289,8 +290,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sub_keys = split(key, K)\n",
-    "\n",
     "# It's a bit different from the previous example, because each of the final\n",
     "# K samples is obtained by running a different set of N-particles.\n",
     "# This can of course be optimized but we keep it simple here.\n",
@@ -310,6 +309,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "key, *sub_keys = jax.random.split(key, K + 1)\n",
+    "sub_keys = jnp.array(sub_keys)\n",
     "posterior_samples = jitted(sub_keys, (target_posterior,)).get_retval()\n",
     "\n",
     "# This only does the importance sampling step, not the resampling step\n",

--- a/notebooks/cookbook/inference/mcmc.ipynb
+++ b/notebooks/cookbook/inference/mcmc.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def metropolis_hastings_move(mh_args, subkey):\n",
+    "def metropolis_hastings_move(mh_args, key):\n",
     "    # For now, we give the kernel the full state of the model, the proposal, and the observations.\n",
     "    trace, model, proposal, proposal_args, observations = mh_args\n",
     "    model_args = trace.get_args()\n",
@@ -97,7 +97,8 @@
     "\n",
     "    # We sample the proposed changes to the trace.\n",
     "    # This is encapsulated in a simple GenJAX generative function.\n",
-    "    fwd_choices, fwd_weight, _ = proposal.propose(subkey, proposal_args_forward)\n",
+    "    key, subkey = jax.random.split(key)\n",
+    "    fwd_choices, fwd_weight, _ = proposal.propose(key, proposal_args_forward)\n",
     "\n",
     "    update = GenericProblem(argdiffs, fwd_choices)\n",
     "    new_trace, weight, _, discard = model.update(subkey, trace, update)\n",
@@ -107,6 +108,7 @@
     "    proposal_args_backward = (new_trace, *proposal_args)\n",
     "    bwd_weight, _ = proposal.assess(discard, proposal_args_backward)\n",
     "    α = weight - fwd_weight + bwd_weight\n",
+    "    key, subkey = jax.random.split(key)\n",
     "    ret_fun = jax.lax.cond(\n",
     "        jnp.log(jax.random.uniform(subkey)) < α, lambda: new_trace, lambda: trace\n",
     "    )\n",
@@ -235,7 +237,8 @@
    "source": [
     "model_args = (5.0,)\n",
     "num_samples = 40000\n",
-    "_, mh_chain = run_inference(model, model_args, obs, key, num_samples)\n",
+    "key, subkey = jax.random.split(key)\n",
+    "_, mh_chain = run_inference(model, model_args, obs, subkey, num_samples)\n",
     "validate_mh(mh_chain)"
    ]
   }

--- a/notebooks/cookbook/inference/mcmc.ipynb
+++ b/notebooks/cookbook/inference/mcmc.ipynb
@@ -27,6 +27,7 @@
     "from genjax import GenericProblem, gen, normal, pretty\n",
     "from genjax._src.core.interpreters.incremental import Diff\n",
     "\n",
+    "key = jax.random.PRNGKey(0)\n",
     "pretty()"
    ]
   },
@@ -232,7 +233,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.PRNGKey(5000)\n",
     "model_args = (5.0,)\n",
     "num_samples = 40000\n",
     "_, mh_chain = run_inference(model, model_args, obs, key, num_samples)\n",

--- a/notebooks/cookbook/library_author/dimap_combinator.ipynb
+++ b/notebooks/cookbook/library_author/dimap_combinator.ipynb
@@ -134,7 +134,8 @@
     "    return NewOrElseCombinator(if_model, else_model)(toss, (1.0,), (10.0,)) @ \"tossed\"\n",
     "\n",
     "\n",
-    "tr = jax.jit(model.simulate)(key, (True,))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "tr = jax.jit(model.simulate)(subkey, (True,))\n",
     "tr.get_choices()"
    ]
   },
@@ -162,8 +163,8 @@
     "    return or_else_model(toss, (1.0,), (10.0,)) @ \"tossed\"\n",
     "\n",
     "\n",
-    "key, _ = jax.random.split(key)\n",
-    "tr2 = jax.jit(model_v2.simulate)(key, (True,))\n",
+    "key, subkey = jax.random.split(key)\n",
+    "tr2 = jax.jit(model_v2.simulate)(subkey, (True,))\n",
     "tr.get_choices() == tr2.get_choices()"
    ]
   }

--- a/notebooks/cookbook/library_author/dimap_combinator.ipynb
+++ b/notebooks/cookbook/library_author/dimap_combinator.ipynb
@@ -33,6 +33,7 @@
     "from genjax._src.core.generative import GenerativeFunction\n",
     "from genjax._src.core.typing import Callable, ScalarBool, Tuple, typecheck\n",
     "\n",
+    "key = jax.random.PRNGKey(0)\n",
     "pretty()"
    ]
   },
@@ -133,7 +134,6 @@
     "    return NewOrElseCombinator(if_model, else_model)(toss, (1.0,), (10.0,)) @ \"tossed\"\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(314159)\n",
     "tr = jax.jit(model.simulate)(key, (True,))\n",
     "tr.get_choices()"
    ]
@@ -162,7 +162,7 @@
     "    return or_else_model(toss, (1.0,), (10.0,)) @ \"tossed\"\n",
     "\n",
     "\n",
-    "key = jax.random.PRNGKey(314159)\n",
+    "key, _ = jax.random.split(key)\n",
     "tr2 = jax.jit(model_v2.simulate)(key, (True,))\n",
     "tr.get_choices() == tr2.get_choices()"
    ]


### PR DESCRIPTION
- Fixing the misleading explanation of `update` in the `methods_of_generative_fun.ipynb` cookbook (will still require a entire cookbook or two to explain the details and subtleties, especially for the expressivity of generalised interface)
- Fixing the usage of random keys to be the intended usage in JAX (new key every time, even when not strictly necessary).