### PR TITLE
Remove Optional in favor of `| None`

### DIFF
--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -34,7 +34,6 @@ from genjax._src.core.typing import (
     Int,
     IntArray,
     Is,
-    Optional,
     PRNGKey,
     String,
     TypeVar,
@@ -1564,8 +1563,8 @@ class GenerativeFunction(Generic[R], Pytree):
         self,
         /,
         *,
-        selection: Optional[Any] = None,
-        algorithm: Optional[Any] = None,
+        selection: Any | None = None,
+        algorithm: Any | None = None,
     ) -> "GenerativeFunction":
         from genjax import Selection, marginal
 

--- a/src/genjax/_src/core/interpreters/incremental.py
+++ b/src/genjax/_src/core/interpreters/incremental.py
@@ -42,7 +42,6 @@ from genjax._src.core.typing import (
     Bool,
     Callable,
     IntArray,
-    Optional,
     Value,
     static_check_is_concrete,
     typecheck,
@@ -305,7 +304,7 @@ def incremental(f: Callable[..., Any]):
     @functools.wraps(f)
     @typecheck
     def wrapped(
-        _stateful_handler: Optional[StatefulHandler],
+        _stateful_handler: StatefulHandler | None,
         primals: tuple,
         tangents: tuple,
     ):

--- a/src/genjax/_src/core/interpreters/time_travel.py
+++ b/src/genjax/_src/core/interpreters/time_travel.py
@@ -32,7 +32,6 @@ from genjax._src.core.typing import (
     ArrayLike,
     Callable,
     Int,
-    Optional,
     String,
     typecheck,
 )
@@ -54,7 +53,7 @@ class FrameRecording(Pytree):
 @Pytree.dataclass
 class RecordPoint(Pytree):
     callable: Closure
-    debug_tag: Optional[String] = Pytree.static()
+    debug_tag: String | None = Pytree.static()
 
     def default_call(self, *args):
         return self.callable(*args)
@@ -84,7 +83,7 @@ class RecordPoint(Pytree):
 @typecheck
 def rec(
     callable: Callable[..., Any],
-    debug_tag: Optional[String] = None,
+    debug_tag: String | None = None,
 ):
     if not isinstance(callable, Closure):
         callable = Pytree.partial()(callable)
@@ -208,13 +207,13 @@ class TimeTravelingDebugger(Pytree):
     jump_points: dict = Pytree.static()
     ptr: Int = Pytree.static()
 
-    def frame(self) -> tuple[Optional[String], FrameRecording]:
+    def frame(self) -> tuple[String | None, FrameRecording]:
         frame = self.sequence[self.ptr]
         reverse_jump_points = {v: k for (k, v) in self.jump_points.items()}
         jump_tag = reverse_jump_points.get(self.ptr, None)
         return jump_tag, frame
 
-    def summary(self) -> tuple[Any, tuple[Optional[String], FrameRecording]]:
+    def summary(self) -> tuple[Any, tuple[String | None, FrameRecording]]:
         frame = self.sequence[self.ptr]
         reverse_jump_points = {v: k for (k, v) in self.jump_points.items()}
         jump_tag = reverse_jump_points.get(self.ptr, None)

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -41,7 +41,6 @@ FloatArray = jtyping.Float[jtyping.Array, "..."]
 BoolArray = jtyping.Bool[jtyping.Array, "..."]
 Callable = btyping.Callable
 Sequence = btyping.Sequence
-Optional = btyping.Optional
 
 # JAX Type alias.
 InAxes = int | None | Sequence[Any]

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -41,7 +41,6 @@ from genjax._src.core.typing import (
     FloatArray,
     Int,
     IntArray,
-    Optional,
     PRNGKey,
     typecheck,
 )
@@ -196,7 +195,7 @@ class ScanCombinator(GenerativeFunction):
     kernel_gen_fn: GenerativeFunction
 
     # Only required for `None` carry inputs
-    length: Optional[Int] = Pytree.static()
+    length: Int | None = Pytree.static()
     reverse: bool = Pytree.static(default=False)
     unroll: int | bool = Pytree.static(default=1)
 
@@ -548,7 +547,7 @@ class ScanCombinator(GenerativeFunction):
 
 @typecheck
 def scan(
-    *, n: Optional[Int] = None, reverse: bool = False, unroll: int | bool = 1
+    *, n: Int | None = None, reverse: bool = False, unroll: int | bool = 1
 ) -> Callable[[GenerativeFunction], GenerativeFunction]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `(c, a) -> (c, b)`and returns a new [`genjax.GenerativeFunction`][] of type

--- a/src/genjax/_src/inference/smc.py
+++ b/src/genjax/_src/inference/smc.py
@@ -44,7 +44,6 @@ from genjax._src.core.typing import (
     Callable,
     FloatArray,
     Int,
-    Optional,
     PRNGKey,
     typecheck,
 )
@@ -156,7 +155,7 @@ class SMCAlgorithm(Algorithm):
 
     # Convenience method for returning an estimate of the normalizing constant
     # of the target.
-    def log_marginal_likelihood_estimate(self, key, target: Optional[Target] = None):
+    def log_marginal_likelihood_estimate(self, key, target: Target | None = None):
         if target:
             algorithm = ChangeTarget(self, target)
         else:


### PR DESCRIPTION
Following the deprecation notice my editor keeps tossing my way.