### PR TITLE
flag fixes

### DIFF
--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -25,7 +25,6 @@ from genjax._src.core.generative.core import Constraint, ProjectProblem, Sample
 from genjax._src.core.generative.functional_types import Mask, Sum
 from genjax._src.core.interpreters.staging import (
     Flag,
-    flag,
     staged_err,
 )
 from genjax._src.core.pytree import Pytree
@@ -201,7 +200,7 @@ class Selection(ProjectProblem):
 @Pytree.dataclass
 class AllSel(Selection):
     def check(self) -> Flag:
-        return flag(True)
+        return Flag(True)
 
     def get_subselection(self, addr: ExtendedAddressComponent) -> Selection:
         return AllSel()
@@ -262,10 +261,10 @@ class StaticSel(Selection):
     s: Selection = Pytree.field()
 
     def check(self) -> Flag:
-        return flag(False)
+        return Flag(False)
 
     def get_subselection(self, addr: EllipsisType | AddressComponent) -> Selection:
-        check = flag(addr == self.addr or isinstance(addr, EllipsisType))
+        check = Flag(addr == self.addr or isinstance(addr, EllipsisType))
         return select_defer(check, self.s)
 
 
@@ -283,7 +282,7 @@ class IdxSel(Selection):
     s: Selection
 
     def check(self) -> Flag:
-        return flag(False)
+        return Flag(False)
 
     def get_subselection(self, addr: EllipsisType | AddressComponent) -> Selection:
         if isinstance(addr, EllipsisType):
@@ -300,7 +299,7 @@ class IdxSel(Selection):
                     jnp.any(v == self.idxs),
                 )
 
-            check = flag(
+            check = Flag(
                 jax.vmap(check_fn)(addr)
                 if jnp.array(addr, copy=False).shape
                 else check_fn(addr)
@@ -439,11 +438,11 @@ ChoiceMapBuilder = _ChoiceMapBuilder()
 
 def check_none(v) -> Flag:
     if v is None:
-        return flag(False)
+        return Flag(False)
     elif isinstance(v, Mask):
         return v.flag
     else:
-        return flag(True)
+        return Flag(True)
 
 
 class ChoiceMap(Sample, Constraint):
@@ -743,10 +742,10 @@ class IdxChm(ChoiceMap):
 
             return (
                 choice_map_masked(
-                    flag(check[addr]), jtu.tree_map(lambda v: v[addr], self.c)
+                    Flag(check[addr]), jtu.tree_map(lambda v: v[addr], self.c)
                 )
                 if jnp.array(check, copy=False).shape
-                else choice_map_masked(flag(check), self.c)
+                else choice_map_masked(Flag(check), self.c)
             )
 
 
@@ -767,7 +766,7 @@ class StaticChm(ChoiceMap):
         return None
 
     def get_submap(self, addr: ExtendedAddressComponent) -> ChoiceMap:
-        check = flag(addr == self.addr)
+        check = Flag(addr == self.addr)
         return choice_map_masked(check, self.c)
 
 

--- a/src/genjax/_src/core/generative/functional_types.py
+++ b/src/genjax/_src/core/generative/functional_types.py
@@ -18,7 +18,6 @@ from jax.tree_util import tree_map
 from genjax._src.core.interpreters.incremental import Diff
 from genjax._src.core.interpreters.staging import (
     Flag,
-    flag,
 )
 from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
@@ -178,7 +177,7 @@ class Sum(Pytree):
         possibles = []
         for _idx, v in enumerate(vs):
             if v is not None:
-                possibles.append(Mask.maybe_none(flag(idx == _idx), v))
+                possibles.append(Mask.maybe_none(Flag(idx == _idx), v))
         if not possibles:
             return None
         if len(possibles) == 1:
@@ -195,4 +194,4 @@ class Sum(Pytree):
 
     @typecheck
     def __getitem__(self, idx: Int):
-        return Mask.maybe_none(flag(idx == self.idx), self.values[idx])
+        return Mask.maybe_none(Flag(idx == self.idx), self.values[idx])

--- a/src/genjax/_src/core/generative/functional_types.py
+++ b/src/genjax/_src/core/generative/functional_types.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import jax.numpy as jnp
+from jax.experimental import checkify
 from jax.tree_util import tree_map
 
+from genjax._src.checkify import optional_check
 from genjax._src.core.interpreters.incremental import Diff
 from genjax._src.core.interpreters.staging import (
     Flag,
@@ -80,6 +82,32 @@ class Mask(Generic[R], Pytree):
             if f.concrete_false()
             else Mask.maybe(f, v)
         )
+
+    ######################
+    # Masking interfaces #
+    ######################
+
+    def unmask(self) -> R:
+        """Unmask the `Mask`, returning the value within.
+        This operation is inherently unsafe with respect to inference semantics, and is only valid if the `Mask` wraps valid data at runtime.
+        """
+
+        # If a user chooses to `unmask`, require that they
+        # jax.experimental.checkify.checkify their call in transformed
+        # contexts.
+        def _check():
+            checkify.check(
+                self.flag.f,
+                "Attempted to unmask when a mask flag is False: the masked value is invalid.\n",
+            )
+
+        optional_check(_check)
+        return self.value
+
+    def unsafe_unmask(self) -> R:
+        # Unsafe version of unmask -- should only be used internally,
+        # or carefully.
+        return self.value
 
 
 @Pytree.dataclass(match_args=True)

--- a/src/genjax/_src/core/interpreters/staging.py
+++ b/src/genjax/_src/core/interpreters/staging.py
@@ -28,6 +28,7 @@ from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
     ArrayLike,
     BoolArray,
+    Callable,
     Int,
     static_check_is_concrete,
 )
@@ -35,10 +36,6 @@ from genjax._src.core.typing import (
 ###############################
 # Concrete Boolean arithmetic #
 ###############################
-
-
-def flag(b: bool | BoolArray):
-    return Flag(b, concrete=not isinstance(b, jc.Tracer))
 
 
 @Pytree.dataclass
@@ -59,47 +56,44 @@ class Flag(Pytree):
     """
 
     f: bool | BoolArray
-    concrete: bool = Pytree.static(kw_only=True)
 
     def and_(self, f: "Flag") -> "Flag":
         # True and X => X. False and X => False.
-        if self.concrete:
-            if self.f:
-                return f
-            else:
-                return self
-        if f.concrete:
-            if f.f:
-                return self
-            else:
-                return f
-        return Flag(jnp.logical_and(self.f, f.f), concrete=False)
+        if self.f is True:
+            return f
+        if self.f is False:
+            return self
+        if f.f is True:
+            return self
+        if f.f is False:
+            return f
+        return Flag(jnp.logical_and(self.f, f.f))
 
     def or_(self, f: "Flag") -> "Flag":
         # True or X => True. False or X => X.
-        if self.concrete:
-            if self.f:
-                return self
-            else:
-                return f
-        if f.concrete:
-            if f.f:
-                return f
-            else:
-                return self
-        return Flag(jnp.logical_or(self.f, f.f), concrete=False)
+        if self.f is True:
+            return self
+        if self.f is False:
+            return f
+        if f.f is True:
+            return f
+        if f.f is False:
+            return self
+        return Flag(jnp.logical_or(self.f, f.f))
 
     def not_(self) -> "Flag":
-        if self.concrete:
-            return Flag(not self.f, concrete=True)
+        if self.f is True:
+            return Flag(False)
+        elif self.f is False:
+            return Flag(True)
         else:
-            return Flag(jnp.logical_not(self.f), concrete=False)
+            return Flag(jnp.logical_not(self.f))
 
     def concrete_true(self):
-        return self.concrete and self.f
+        return self.f is True
 
     def concrete_false(self):
-        return self.concrete and not self.f
+        return self.f is False
 
     def __bool__(self) -> bool:
         return bool(jnp.all(self.f))
@@ -107,7 +101,25 @@ class Flag(Pytree):
     def where(self, t: ArrayLike, f: ArrayLike) -> ArrayLike:
         """Return t or f according to the truth value contained in this flag
         in a manner that works in either the concrete or dynamic context"""
+        if self.f is True:
+            return t
+        if self.f is False:
+            return f
         return jax.lax.select(jnp.all(self.f), t, f)
+
+    def cond(self, tf: Callable[..., Any], ff: Callable[...,Any], *args: Any):
+        """Invokes `tf` with `args` if flag is true, else `ff`"""
+        if self.f is True:
+            return tf(*args)
+        if self.f is False:
+            return ff(*args)
+        return jax.lax.cond(
+            self.f,
+            tf,
+            ff,
+            *args
+        )
+
 
 
 def staged_check(v):

--- a/src/genjax/_src/core/interpreters/staging.py
+++ b/src/genjax/_src/core/interpreters/staging.py
@@ -26,6 +26,7 @@ from jax.util import safe_map
 from genjax._src.checkify import optional_check
 from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
+    Any,
     ArrayLike,
     BoolArray,
     Callable,

--- a/src/genjax/_src/core/interpreters/staging.py
+++ b/src/genjax/_src/core/interpreters/staging.py
@@ -107,19 +107,13 @@ class Flag(Pytree):
             return f
         return jax.lax.select(jnp.all(self.f), t, f)
 
-    def cond(self, tf: Callable[..., Any], ff: Callable[...,Any], *args: Any):
+    def cond(self, tf: Callable[..., Any], ff: Callable[..., Any], *args: Any):
         """Invokes `tf` with `args` if flag is true, else `ff`"""
         if self.f is True:
             return tf(*args)
         if self.f is False:
             return ff(*args)
-        return jax.lax.cond(
-            self.f,
-            tf,
-            ff,
-            *args
-        )
-
+        return jax.lax.cond(self.f, tf, ff, *args)
 
 
 def staged_check(v):

--- a/src/genjax/_src/generative_functions/combinators/mask.py
+++ b/src/genjax/_src/generative_functions/combinators/mask.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import jax
 import jax.numpy as jnp
 
 from genjax._src.core.generative import (
@@ -34,7 +33,7 @@ from genjax._src.core.generative import (
 )
 from genjax._src.core.generative.core import Constraint
 from genjax._src.core.interpreters.incremental import Diff
-from genjax._src.core.interpreters.staging import Flag, flag
+from genjax._src.core.interpreters.staging import Flag
 from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
     Any,
@@ -122,7 +121,7 @@ class MaskCombinator(Generic[R], GenerativeFunction[Mask[R]]):
     ) -> MaskTrace[R]:
         check, inner_args = args[0], args[1:]
         tr = self.gen_fn.simulate(key, inner_args)
-        return MaskTrace(self, tr, flag(check))
+        return MaskTrace(self, tr, Flag(check))
 
     @typecheck
     def update_change_target(
@@ -210,15 +209,8 @@ class MaskCombinator(Generic[R], GenerativeFunction[Mask[R]]):
                         "This move is not currently supported! See https://github.com/probcomp/genjax/issues/1230 for notes."
                     )
 
-                return jax.lax.cond(
-                    trace.check.f,
-                    self.update_change_target,
-                    self.update_change_target_from_false,
-                    key,
-                    trace,
-                    subproblem,
-                    argdiffs,
-                )
+                return trace.check.cond(self.update_change_target, self.update_change_target_from_false, key, trace, subproblem, argdiffs)
+
             case _:
                 return self.update_change_target(
                     key, trace, update_problem, Diff.no_change(trace.get_args())

--- a/src/genjax/_src/generative_functions/combinators/mask.py
+++ b/src/genjax/_src/generative_functions/combinators/mask.py
@@ -209,7 +209,14 @@ class MaskCombinator(Generic[R], GenerativeFunction[Mask[R]]):
                         "This move is not currently supported! See https://github.com/probcomp/genjax/issues/1230 for notes."
                     )
 
-                return trace.check.cond(self.update_change_target, self.update_change_target_from_false, key, trace, subproblem, argdiffs)
+                return trace.check.cond(
+                    self.update_change_target,
+                    self.update_change_target_from_false,
+                    key,
+                    trace,
+                    subproblem,
+                    argdiffs,
+                )
 
             case _:
                 return self.update_change_target(

--- a/src/genjax/_src/generative_functions/combinators/switch.py
+++ b/src/genjax/_src/generative_functions/combinators/switch.py
@@ -34,7 +34,7 @@ from genjax._src.core.generative import (
     Weight,
 )
 from genjax._src.core.interpreters.incremental import Diff, NoChange, UnknownChange
-from genjax._src.core.interpreters.staging import flag, get_data_shape
+from genjax._src.core.interpreters.staging import Flag, get_data_shape
 from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
     Any,
@@ -80,7 +80,7 @@ class SwitchTrace(Trace):
             chm = ChoiceMap.empty()
             for _idx, _chm in enumerate(subsamples):
                 assert isinstance(_chm, ChoiceMap)
-                masked_submap = ChoiceMap.maybe(flag(jnp.all(_idx == idx)), _chm)
+                masked_submap = ChoiceMap.maybe(Flag(jnp.all(_idx == idx)), _chm)
                 chm = chm ^ masked_submap
             return chm
         else:

--- a/src/genjax/_src/generative_functions/distributions/distribution.py
+++ b/src/genjax/_src/generative_functions/distributions/distribution.py
@@ -43,7 +43,7 @@ from genjax._src.core.generative import (
     Weight,
 )
 from genjax._src.core.interpreters.incremental import Diff
-from genjax._src.core.interpreters.staging import Flag, flag, staged_check
+from genjax._src.core.interpreters.staging import Flag, staged_check
 from genjax._src.core.pytree import Closure, Pytree
 from genjax._src.core.typing import (
     Any,
@@ -168,12 +168,12 @@ class Distribution(Generic[R], GenerativeFunction[R]):
             return (
                 tr,
                 jnp.array(0.0),
-                MaskedProblem(flag(False), ProjectProblem()),
+                MaskedProblem(Flag(False), ProjectProblem()),
             )
 
         def importance_branch(key, constraint, args):
             tr, w = self.importance(key, constraint, args)
-            return tr, w, MaskedProblem(flag(True), ProjectProblem())
+            return tr, w, MaskedProblem(Flag(True), ProjectProblem())
 
         return jax.lax.cond(
             constraint.flag.f,
@@ -240,7 +240,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
                 tr,
                 w,
                 rd,
-                MaskedProblem(flag(True), old_sample),
+                MaskedProblem(Flag(True), old_sample),
             )
 
         def do_nothing_branch(key, trace, _, argdiffs):
@@ -251,7 +251,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
                 tr,
                 w,
                 Diff.tree_diff_unknown_change(tr.get_retval()),
-                MaskedProblem(flag(False), old_sample),
+                MaskedProblem(Flag(False), old_sample),
             )
 
         return jax.lax.cond(
@@ -415,7 +415,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
             trace,
             GenericProblem(
                 argdiffs,
-                MaskedProblem(flag(check), ProjectProblem()),
+                MaskedProblem(Flag(check), ProjectProblem()),
             ),
         )
 

--- a/tests/core/generative/test_core.py
+++ b/tests/core/generative/test_core.py
@@ -45,9 +45,9 @@ class TestCombinators:
         assert jnp.array_equal(chm[..., "q"], qarr)
 
         # check alternate access route:
-        assert jnp.array_equal(jnp.array([chm(0)["v"], chm(1)["v"], chm(2)["v"]]), varr)
+        assert jnp.array_equal(chm(jnp.arange(3))["v"].unmask(), varr)
 
-        assert jnp.array_equal(jnp.array([chm(0)["q"], chm(1)["q"], chm(2)["q"]]), qarr)
+        assert jnp.array_equal(chm(jnp.arange(3))["q"].unmask(), qarr)
 
     def test_repeat(self):
         key = jax.random.PRNGKey(314159)

--- a/tests/core/test_staging.py
+++ b/tests/core/test_staging.py
@@ -49,18 +49,18 @@ class TestStaging:
 class TestFlag:
     def test_basic_operation(self):
         true_flags = [
-            Flag(True, concrete=True),
-            Flag(jnp.array(True), concrete=True),
-            Flag(jnp.array([True, True]), concrete=False),
-            Flag(jnp.array([3.0, 4.0]), concrete=False),
+            Flag(True),
+            Flag(jnp.array(True)),
+            Flag(jnp.array([True, True])),
+            Flag(jnp.array([3.0, 4.0])),
         ]
         false_flags = [
-            Flag(False, concrete=True),
-            Flag(jnp.array(False), concrete=True),
-            Flag(jnp.array([True, False]), concrete=False),
-            Flag(jnp.array([False, False]), concrete=False),
-            Flag(jnp.array([0.0, 0.0]), concrete=False),
-            Flag(jnp.array([0.0, 1.0]), concrete=False),
+            Flag(False),
+            Flag(jnp.array(False)),
+            Flag(jnp.array([True, False])),
+            Flag(jnp.array([False, False])),
+            Flag(jnp.array([0.0, 0.0])),
+            Flag(jnp.array([0.0, 1.0])),
         ]
         for t in true_flags:
             assert t
@@ -74,5 +74,7 @@ class TestFlag:
                 assert t.or_(u)
 
     def test_where(self):
-        assert Flag(True, concrete=True).where(3.0, 4.0) == 3
-        assert Flag(False, concrete=True).where(3.0, 4.0) == 4
+        assert Flag(True).where(3.0, 4.0) == 3
+        assert Flag(False).where(3.0, 4.0) == 4
+        assert Flag(jnp.array(True)).where(3.0, 4.0) == 3
+        assert Flag(jnp.array(False)).where(3.0, 4.0) == 4

--- a/tests/generative_functions/test_distributions.py
+++ b/tests/generative_functions/test_distributions.py
@@ -18,7 +18,7 @@ import genjax
 from genjax import ChoiceMapBuilder as C
 from genjax import EmptyConstraint, MaskedConstraint
 from genjax import UpdateProblemBuilder as U
-from genjax._src.core.interpreters.staging import flag
+from genjax._src.core.interpreters.staging import Flag
 from genjax.incremental import Diff, NoChange, UnknownChange
 
 
@@ -43,7 +43,7 @@ class TestDistributions:
         # Constraint, mask with True flag.
         (tr, w) = genjax.normal.importance(
             key,
-            MaskedConstraint(flag(True), C.v(1.0)),
+            MaskedConstraint(Flag(True), C.v(1.0)),
             (0.0, 1.0),
         )
         v = tr.get_choices().get_value()
@@ -53,7 +53,7 @@ class TestDistributions:
         # Constraint, mask with False flag.
         (tr, w) = genjax.normal.importance(
             key,
-            MaskedConstraint(flag(False), C.v(1.0)),
+            MaskedConstraint(Flag(False), C.v(1.0)),
             (0.0, 1.0),
         )
         v = tr.get_choices().get_value()
@@ -135,7 +135,7 @@ class TestDistributions:
             tr,
             U.g(
                 (Diff(0.0, NoChange), Diff(1.0, NoChange)),
-                MaskedConstraint(flag(True), C.v(1.0)),
+                MaskedConstraint(Flag(True), C.v(1.0)),
             ),
         )
         assert new_tr.get_choices().get_value() == 1.0
@@ -153,7 +153,7 @@ class TestDistributions:
             tr,
             U.g(
                 (Diff(1.0, UnknownChange), Diff(1.0, NoChange)),
-                MaskedConstraint(flag(True), C.v(1.0)),
+                MaskedConstraint(Flag(True), C.v(1.0)),
             ),
         )
         assert new_tr.get_choices().get_value() == 1.0
@@ -171,7 +171,7 @@ class TestDistributions:
             tr,
             U.g(
                 (Diff(0.0, NoChange), Diff(1.0, NoChange)),
-                MaskedConstraint(flag(False), C.v(1.0)),
+                MaskedConstraint(Flag(False), C.v(1.0)),
             ),
         )
         assert new_tr.get_choices().get_value() == tr.get_choices().get_value()
@@ -187,7 +187,7 @@ class TestDistributions:
             tr,
             U.g(
                 (Diff(1.0, UnknownChange), Diff(1.0, NoChange)),
-                MaskedConstraint(flag(False), C.v(1.0)),
+                MaskedConstraint(Flag(False), C.v(1.0)),
             ),
         )
         assert new_tr.get_choices().get_value() == tr.get_choices().get_value()

--- a/tests/generative_functions/test_mask_combinator.py
+++ b/tests/generative_functions/test_mask_combinator.py
@@ -20,7 +20,7 @@ import genjax
 from genjax import ChoiceMapBuilder as C
 from genjax import Diff
 from genjax import UpdateProblemBuilder as U
-from genjax._src.core.interpreters.staging import Flag, flag
+from genjax._src.core.interpreters.staging import Flag
 
 
 @genjax.mask
@@ -39,13 +39,13 @@ class TestMaskCombinator:
         tr = jax.jit(model.simulate)(key, (True, -4.0))
         assert tr.get_score() == tr.inner.get_score()
         assert tr.get_retval() == genjax.Mask(
-            Flag(jnp.array(True), concrete=False), tr.inner.get_retval()
+            Flag(jnp.array(True)), tr.inner.get_retval()
         )
 
         tr = jax.jit(model.simulate)(key, (False, -4.0))
         assert tr.get_score() == 0.0
         assert tr.get_retval() == genjax.Mask(
-            Flag(jnp.array(False), concrete=False), tr.inner.get_retval()
+            Flag(jnp.array(False)), tr.inner.get_retval()
         )
 
     def test_mask_simple_normal_false(self, key):
@@ -65,14 +65,14 @@ class TestMaskCombinator:
         tr = jax.jit(model.simulate)(key, (True, 2.0))
         # mask check arg transition: True --> True
         argdiffs = U.g(
-            (Diff.unknown_change(flag(True)), Diff.no_change(tr.get_args()[1])), C.n()
+            (Diff.unknown_change(Flag(True)), Diff.no_change(tr.get_args()[1])), C.n()
         )
         w = tr.update(key, argdiffs)[1]
         assert w == tr.inner.update(key, C.n())[1]
         assert w == 0.0
         # mask check arg transition: True --> False
         argdiffs = U.g(
-            (Diff.unknown_change(flag(False)), Diff.no_change(tr.get_args()[1])), C.n()
+            (Diff.unknown_change(Flag(False)), Diff.no_change(tr.get_args()[1])), C.n()
         )
         w = tr.update(key, argdiffs)[1]
         assert w == -tr.get_score()
@@ -83,14 +83,14 @@ class TestMaskCombinator:
         tr = jax.jit(model.simulate)(key, (False, 2.0))
         # mask check arg transition: False --> True
         argdiffs = U.g(
-            (Diff.unknown_change(True), Diff.no_change(tr.get_args()[1])), C.n()
+            (Diff.unknown_change(Flag(True)), Diff.no_change(tr.get_args()[1])), C.n()
         )
         w = tr.update(key, argdiffs)[1]
         assert w == tr.inner.update(key, C.n())[1] + tr.inner.get_score()
         assert w == tr.inner.update(key, C.n())[0].get_score()
         # mask check arg transition: False --> False
         argdiffs = U.g(
-            (Diff.unknown_change(False), Diff.no_change(tr.get_args()[1])), C.n()
+            (Diff.unknown_change(Flag(False)), Diff.no_change(tr.get_args()[1])), C.n()
         )
         w = tr.update(key, argdiffs)[1]
         assert w == 0.0

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -56,9 +56,9 @@ class TestIterateSimpleNormal:
         key, sub_key = jax.random.split(key)
         for i in range(1, 5):
             tr, w = jax.jit(scanner.importance)(sub_key, C[i, "z"].set(0.5), (0.01,))
-            assert tr.get_sample()[i, "z"] == 0.5
-            value = tr.get_sample()[i, "z"]
-            prev = tr.get_sample()[i - 1, "z"]
+            value = tr.get_sample()[i, "z"].unmask()
+            assert value == 0.5
+            prev = tr.get_sample()[i - 1, "z"].unmask()
             assert w == genjax.normal.assess(C.v(value), (prev, 1.0))[0]
 
     def test_iterate_simple_normal_update(self):
@@ -80,7 +80,7 @@ class TestIterateSimpleNormal:
                     C[i, "z"].set(1.0),
                 ),
             )
-            assert new_tr.get_sample()[i, "z"] == 1.0
+            assert new_tr.get_sample()[i, "z"].unmask() == 1.0
 
 
 @genjax.gen

--- a/tests/generative_functions/test_switch_combinator.py
+++ b/tests/generative_functions/test_switch_combinator.py
@@ -222,7 +222,7 @@ class TestSwitchCombinator:
         keys = jax.random.split(jax.random.PRNGKey(17), 3)
         # Just select 0 in all branches for simplicity:
         tr = jax.vmap(s.simulate, in_axes=(0, None))(keys, (0, (), ()))
-        y = tr.get_choices()["y"]
+        y = tr.get_choices()["y"].unmask()
         assert y.shape == (3,)
 
     def test_switch_combinator_with_empty_gen_fn(self):

--- a/tests/generative_functions/test_vmap_combinator.py
+++ b/tests/generative_functions/test_vmap_combinator.py
@@ -74,7 +74,7 @@ class TestVmapCombinator:
         (tr, _) = kernel.importance(sub_key, chm, (map_over,))
         for i in range(0, 3):
             v = tr.get_choices()[i, "z"]
-            assert v == zv[i]
+            assert v.unmask() == zv[i]
 
     def test_vmap_combinator_nested_indexed_choice_map_importance(self):
         @genjax.vmap(in_axes=(0,))


### PR DESCRIPTION
- My Flag idea fell afoul of the fact that Pyrees can be rehydrated by JAX without invoking the `__init__` method. This allowed the creation of flags with an inconsistent `concrete` setting. The former implementation was therefore incorrect and so some of the unmasks that were retired have been restored. The new implementation is more conservative

- improved to cover the `cond` case.
