### PR TITLE
Add more missing generics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,6 @@ repos:
         types_or: [ python, pyi, jupyter ]
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.376
+    rev: v1.1.377
     hooks:
     - id: pyright

--- a/notebooks/cookbook/inference/mcmc.ipynb
+++ b/notebooks/cookbook/inference/mcmc.ipynb
@@ -260,7 +260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/cookbook/inference/mcmc.ipynb
+++ b/notebooks/cookbook/inference/mcmc.ipynb
@@ -260,7 +260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ defineConstant = { DEBUG = true }
 typeCheckingMode = "standard"
 reportMatchNotExhaustive = true
 reportMissingImports = true
-# reportMissingTypeArgument = true
+reportMissingTypeArgument = true
 reportInvalidTypeVarUse = "error"
 reportMissingTypeStubs = false
 analyzeUnannotatedFunctions = true

--- a/src/genjax/_src/adev/core.py
+++ b/src/genjax/_src/adev/core.py
@@ -169,7 +169,7 @@ def batch_primitive(args, dims, **params):
     batched, out_dims = batch_fun(lu.wrap_init(fun_impl, params), dims)
 
     # populate the out_dims generator
-    _ = batched.call_wrapped(*args)
+    _ = batched.call_wrapped(*args)  # pyright: ignore
 
     # Now, we construct our actual batch primitive, and insert it
     # into the IR by binding it via `sample_primitive`.

--- a/src/genjax/_src/adev/core.py
+++ b/src/genjax/_src/adev/core.py
@@ -74,7 +74,7 @@ class ADEVPrimitive(Pytree):
     ) -> "Dual":
         pass
 
-    def get_batched_prim(self, dims: tuple):
+    def get_batched_prim(self, dims: tuple[Any, ...]):
         """
         To use ADEV primitives inside of `vmap`, they must provide a custom batched primitive version of themselves.
 
@@ -105,14 +105,14 @@ class TailCallADEVPrimitive(ADEVPrimitive):
         _, kdual = konts
         return kdual(key, self.before_tail_call(key, dual_tree))
 
-    def get_batched_prim(self, dims: tuple):
+    def get_batched_prim(self, dims: tuple[Any, ...]):
         return TailCallBatchedADEVPrimitive(self, dims)
 
 
 @Pytree.dataclass
 class TailCallBatchedADEVPrimitive(TailCallADEVPrimitive):
     original_prim: TailCallADEVPrimitive
-    dims: tuple = Pytree.static()
+    dims: tuple[Any, ...] = Pytree.static()
 
     def sample(self, key, *args):
         return jax.vmap(self.original_prim.sample, in_axes=self.dims)(key, *args)
@@ -272,7 +272,7 @@ class ADInterpreter(Pytree):
     """
 
     @staticmethod
-    def flat_unzip(duals: list):
+    def flat_unzip(duals: list[Any]):
         primals, tangents = jax_util.unzip2((t.primal, t.tangent) for t in duals)
         return list(primals), list(tangents)
 
@@ -361,7 +361,7 @@ class ADInterpreter(Pytree):
                         pure_env = Dual.tree_primal(dual_env)
 
                         # Create dual continuation for the computation after the cond_p.
-                        def _cond_dual_kont(dual_tree: list):
+                        def _cond_dual_kont(dual_tree: list[Any]):
                             dual_leaves = Dual.tree_pure(dual_tree)
                             return eval_jaxpr_iterate_dual(
                                 key,
@@ -489,7 +489,11 @@ class ADEVProgram(Pytree):
 
     @typecheck
     def debug_transform_adev(
-        self, key: PRNGKey, primals: tuple, tangents: tuple, mapping: Callable[..., Any]
+        self,
+        key: PRNGKey,
+        primals: tuple[Any, ...],
+        tangents: tuple[Any, ...],
+        mapping: Callable[..., Any],
     ):
         raise NotImplementedError()
 
@@ -520,7 +524,7 @@ class Expectation(Pytree):
 
     # The JVP rules here are registered below.
     # (c.f. Register custom forward mode with JAX)
-    def grad_estimate(self, key: PRNGKey, primals: tuple):
+    def grad_estimate(self, key: PRNGKey, primals: tuple[Any, ...]):
         def _invoke_closed_over(primals):
             return invoke_closed_over(self, key, primals)
 
@@ -534,8 +538,8 @@ class Expectation(Pytree):
     def debug_transform_adev(
         self,
         key: PRNGKey,
-        primals: tuple,
-        tangents: tuple,
+        primals: tuple[Any, ...],
+        tangents: tuple[Any, ...],
     ):
         def _identity(x):
             return x

--- a/src/genjax/_src/adev/primitives.py
+++ b/src/genjax/_src/adev/primitives.py
@@ -57,7 +57,7 @@ class REINFORCE(ADEVPrimitive):
         self,
         key: PRNGKey,
         dual_tree: DualTree,
-        konts: tuple,
+        konts: tuple[Any, ...],
     ):
         (_, kdual) = konts
         primals = Dual.tree_primal(dual_tree)
@@ -95,7 +95,7 @@ class FlipEnum(ADEVPrimitive):
         self,
         key: PRNGKey,
         dual_tree: DualTree,
-        konts: tuple,
+        konts: tuple[Any, ...],
     ):
         (_, kdual) = konts
         (p_primal,) = Dual.tree_primal(dual_tree)
@@ -135,7 +135,7 @@ class FlipMVD(ADEVPrimitive):
         self,
         key: PRNGKey,
         dual_tree: DualTree,
-        konts: tuple,
+        konts: tuple[Any, ...],
     ):
         (kpure, kdual) = konts
         (p_primal,) = Dual.tree_primal(dual_tree)
@@ -162,7 +162,7 @@ class FlipEnumParallel(ADEVPrimitive):
         self,
         key: PRNGKey,
         dual_tree: DualTree,
-        konts: tuple,
+        konts: tuple[Any, ...],
     ):
         (_, kdual) = konts
         (p_primal,) = Dual.tree_primal(dual_tree)
@@ -199,7 +199,7 @@ class CategoricalEnumParallel(ADEVPrimitive):
         self,
         key: PRNGKey,
         dual_tree: DualTree,
-        konts: tuple,
+        konts: tuple[Any, ...],
     ):
         (_, kdual) = konts
         (probs_primal,) = Dual.tree_primal(dual_tree)
@@ -351,7 +351,7 @@ class Uniform(TailCallADEVPrimitive):
     def before_tail_call(
         self,
         key: PRNGKey,
-        dual_tree: tuple,
+        dual_tree: tuple[Any, ...],
     ):
         key, sub_key = jax.random.split(key)
         x = tfd.Uniform(low=0.0, high=1.0).sample(seed=sub_key)
@@ -403,7 +403,7 @@ class Baseline(ADEVPrimitive):
         self,
         key: PRNGKey,
         dual_tree: DualTree,
-        konts: tuple,
+        konts: tuple[Any, ...],
     ):
         (kpure, kdual) = konts
         (b_primal, *prim_primals) = Dual.tree_primal(dual_tree)
@@ -459,7 +459,7 @@ class AddCost(ADEVPrimitive):
         self,
         key: PRNGKey,
         dual_tree: DualTree,
-        konts: tuple,
+        konts: tuple[Any, ...],
     ) -> Dual:
         (_, kdual) = konts
         (w,) = Dual.tree_primal(dual_tree)

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -414,7 +414,7 @@ class _ChoiceMapBuilder(Pytree):
     def v(self, v) -> "ChoiceMap":
         return ChoiceMap.value(v)
 
-    def d(self, d: dict) -> "ChoiceMap":
+    def d(self, d: dict[Any, Any]) -> "ChoiceMap":
         return ChoiceMap.d(d)
 
     def kw(self, **kwargs) -> "ChoiceMap":
@@ -623,7 +623,7 @@ class ChoiceMap(Sample, Constraint):
         )
 
     @classmethod
-    def d(cls, d: dict) -> "ChoiceMap":
+    def d(cls, d: dict[Any, Any]) -> "ChoiceMap":
         start = ChoiceMap.empty()
         if d:
             for k, v in d.items():

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -91,7 +91,7 @@ When used under type checking, `Retdiff` assumes that the argument values are `P
 
 
 Retdiff = Annotated[
-    Diff[R],
+    Any,
     Is[Diff.static_check_tree_diff],
 ]
 
@@ -377,7 +377,7 @@ class Trace(Generic[R], Pytree):
         key: PRNGKey,
         problem: GenericProblem | UpdateProblem,
         argdiffs: tuple[Any, ...] | None = None,
-    ) -> tuple["Trace[R]", Weight, Retdiff[R], UpdateProblem]:
+    ) -> tuple["Trace[R]", Weight, Retdiff, UpdateProblem]:
         """
         This method calls out to the underlying [`GenerativeFunction.update`][genjax.core.GenerativeFunction.update] method - see [`UpdateProblem`][genjax.core.UpdateProblem] and [`update`][genjax.core.GenerativeFunction.update] for more information.
         """
@@ -595,7 +595,7 @@ class GenerativeFunction(Generic[R], Pytree):
         key: PRNGKey,
         trace: Trace[R],
         update_problem: GenericProblem,
-    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
         """
         Update a trace in response to an [`UpdateProblem`][genjax.core.UpdateProblem], returning a new [`Trace`][genjax.core.Trace], an incremental [`Weight`][genjax.core.Weight] for the new target, a [`Retdiff`][genjax.core.Retdiff] return value tagged with change information, and a backward [`UpdateProblem`][genjax.core.UpdateProblem] which requests the reverse move (to go back to the original trace).
 
@@ -1269,9 +1269,7 @@ class GenerativeFunction(Generic[R], Pytree):
 
         return genjax.mask(self)
 
-    def or_else(
-        self, gen_fn: "GenerativeFunction[S]", /
-    ) -> "GenerativeFunction[R | S]":
+    def or_else(self, gen_fn: "GenerativeFunction[R]", /) -> "GenerativeFunction[R]":
         """
         Returns a [`GenerativeFunction`][genjax.GenerativeFunction] that accepts
 
@@ -1693,7 +1691,7 @@ class GenerativeFunctionClosure(Generic[R], GenerativeFunction[R]):
         key: PRNGKey,
         trace: Trace[R],
         update_problem: UpdateProblem,
-    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
         match update_problem:
             case GenericProblem(argdiffs, subproblem):
                 full_argdiffs = (*self.args, *argdiffs)

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -1612,7 +1612,9 @@ class IgnoreKwargs(Generic[R], GenerativeFunction[R]):
 
     @GenerativeFunction.gfi_boundary
     @typecheck
-    def update(self, key: PRNGKey, trace: Trace[R], update_problem: GenericProblem):
+    def update(
+        self, key: PRNGKey, trace: Trace[R], update_problem: GenericProblem
+    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
         (argdiffs, _kwargdiffs) = update_problem.argdiffs
         return self.wrapped.update(
             key, trace, GenericProblem(argdiffs, update_problem.subproblem)

--- a/src/genjax/_src/core/generative/functional_types.py
+++ b/src/genjax/_src/core/generative/functional_types.py
@@ -63,15 +63,15 @@ class Mask(Generic[R], Pytree):
     value: R
 
     @classmethod
-    def maybe(cls, f: Flag, v: R) -> "Mask[R] | None":
+    def maybe(cls, f: Flag, v: "R | Mask[R]") -> "Mask[R]":
         match v:
             case Mask(flag, value):
-                return Mask.maybe_none(f.and_(flag), value)
+                return Mask[R](f.and_(flag), value)
             case _:
                 return Mask[R](f, v)
 
     @classmethod
-    def maybe_none(cls, f: Flag, v: R) -> "R | Mask[R] | None":
+    def maybe_none(cls, f: Flag, v: "R | Mask[R]") -> "R | Mask[R] | None":
         if v is None or f.concrete_false():
             return None
         elif f.concrete_true():
@@ -89,7 +89,6 @@ class Sum(Generic[R], Pytree):
 
     Examples:
         A common scenario which will produce `Sum` types is when using a `SwitchCombinator` with branches that have multiple possible return value types:
-
         ```python exec="yes" html="true" source="material-block" session="core"
         from genjax import gen, normal, bernoulli
 

--- a/src/genjax/_src/core/generative/functional_types.py
+++ b/src/genjax/_src/core/generative/functional_types.py
@@ -88,8 +88,8 @@ class Sum(Generic[R], Pytree):
     The `Sum` type is used to represent a choice between multiple possible values, and is used in generative computations to represent uncertainty over values.
 
     Examples:
-        A common scenario which will produce `Sum` types is when using a `SwitchCombinator` with branches that have
-        multiple possible return value types:
+        A common scenario which will produce `Sum` types is when using a `SwitchCombinator` with branches that have multiple possible return value types:
+
         ```python exec="yes" html="true" source="material-block" session="core"
         from genjax import gen, normal, bernoulli
 

--- a/src/genjax/_src/core/interpreters/forward.py
+++ b/src/genjax/_src/core/interpreters/forward.py
@@ -34,7 +34,7 @@ from genjax._src.core.typing import Any, Bool, Callable, Value, typecheck
 
 
 def batch_fun(fun: lu.WrappedFun, in_dims):
-    fun, out_dims = batching.batch_subtrace(fun)
+    fun, out_dims = batching.batch_subtrace(fun)  # pyright: ignore
     return _batch_fun(fun, in_dims), out_dims
 
 
@@ -74,7 +74,7 @@ class FlatPrimitive(jc.Primitive):
 
         def _batch(args, dims, **params):
             batched, out_dims = batch_fun(lu.wrap_init(self.impl, params), dims)
-            return batched.call_wrapped(*args), out_dims()
+            return batched.call_wrapped(*args), out_dims()  # pyright: ignore
 
         batching.primitive_batchers[self] = _batch
 

--- a/src/genjax/_src/core/interpreters/forward.py
+++ b/src/genjax/_src/core/interpreters/forward.py
@@ -192,7 +192,7 @@ class StatefulHandler:
         primitive: jc.Primitive,
         *args,
         **kwargs,
-    ) -> list:
+    ) -> list[Any]:
         pass
 
 
@@ -202,8 +202,8 @@ class ForwardInterpreter(Pytree):
         self,
         stateful_handler,
         _jaxpr: jc.Jaxpr,
-        consts: list,
-        args: list,
+        consts: list[Any],
+        args: list[Any],
     ):
         env = Environment()
         jax_util.safe_map(env.write, _jaxpr.constvars, consts)

--- a/src/genjax/_src/core/interpreters/incremental.py
+++ b/src/genjax/_src/core/interpreters/incremental.py
@@ -40,11 +40,15 @@ from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
     Any,
     Callable,
+    Generic,
     IntArray,
+    TypeVar,
     Value,
     static_check_is_concrete,
     typecheck,
 )
+
+R = TypeVar("R")
 
 #######################################
 # Change type lattice and propagation #
@@ -106,9 +110,9 @@ def static_check_is_change_tangent(v):
 
 
 @Pytree.dataclass
-class Diff(Pytree):
-    primal: Any
-    tangent: Any
+class Diff(Generic[R], Pytree):
+    primal: R
+    tangent: R
 
     def __post_init__(self):
         assert not isinstance(self.primal, Diff)
@@ -285,8 +289,8 @@ def incremental(f: Callable[..., Any]):
     @typecheck
     def wrapped(
         _stateful_handler: StatefulHandler | None,
-        primals: tuple,
-        tangents: tuple,
+        primals: tuple[Any, ...],
+        tangents: tuple[Any, ...],
     ):
         interpreter = IncrementalInterpreter()
         return interpreter.run_interpreter(

--- a/src/genjax/_src/core/interpreters/staging.py
+++ b/src/genjax/_src/core/interpreters/staging.py
@@ -169,7 +169,7 @@ def stage(f):
     def wrapped(*args, **kwargs):
         fun = lu.wrap_init(f, kwargs)
         flat_args, in_tree = jtu.tree_flatten(args)
-        flat_fun, out_tree = flatten_fun_nokwargs(fun, in_tree)
+        flat_fun, out_tree = flatten_fun_nokwargs(fun, in_tree)  # pyright: ignore
         flat_avals = safe_map(get_shaped_aval, flat_args)
         typed_jaxpr = cached_stage_dynamic(flat_fun, tuple(flat_avals))
         return typed_jaxpr, (flat_args, in_tree, out_tree)

--- a/src/genjax/_src/core/interpreters/time_travel.py
+++ b/src/genjax/_src/core/interpreters/time_travel.py
@@ -204,17 +204,17 @@ def time_travel(f):
 @Pytree.dataclass
 class TimeTravelingDebugger(Pytree):
     final_retval: Any
-    sequence: list[FrameRecording]
+    sequence: list[FrameRecording[Any, Any]]
     jump_points: dict[Any, Any] = Pytree.static()
     ptr: Int = Pytree.static()
 
-    def frame(self) -> tuple[String | None, FrameRecording]:
+    def frame(self) -> tuple[String | None, FrameRecording[Any, Any]]:
         frame = self.sequence[self.ptr]
         reverse_jump_points = {v: k for (k, v) in self.jump_points.items()}
         jump_tag = reverse_jump_points.get(self.ptr, None)
         return jump_tag, frame
 
-    def summary(self) -> tuple[Any, tuple[String | None, FrameRecording]]:
+    def summary(self) -> tuple[Any, tuple[String | None, FrameRecording[Any, Any]]]:
         frame = self.sequence[self.ptr]
         reverse_jump_points = {v: k for (k, v) in self.jump_points.items()}
         jump_tag = reverse_jump_points.get(self.ptr, None)

--- a/src/genjax/_src/core/interpreters/time_travel.py
+++ b/src/genjax/_src/core/interpreters/time_travel.py
@@ -46,7 +46,7 @@ record_p = InitialStylePrimitive("record_p")
 @Pytree.dataclass
 class FrameRecording(Generic[R, S], Pytree):
     f: Callable[..., R]
-    args: tuple
+    args: tuple[Any, ...]
     local_retval: R
     cont: Callable[..., S]
 
@@ -205,7 +205,7 @@ def time_travel(f):
 class TimeTravelingDebugger(Pytree):
     final_retval: Any
     sequence: list[FrameRecording]
-    jump_points: dict = Pytree.static()
+    jump_points: dict[Any, Any] = Pytree.static()
     ptr: Int = Pytree.static()
 
     def frame(self) -> tuple[String | None, FrameRecording]:

--- a/src/genjax/_src/core/serialization/backend.py
+++ b/src/genjax/_src/core/serialization/backend.py
@@ -16,13 +16,17 @@ import abc
 from dataclasses import dataclass
 
 from genjax._src.core.generative import GenerativeFunction, Trace
+from genjax._src.core.typing import Any, Generic, TypeVar
 
 """This module contains a trace serialization interface that interacts with different backend implementations.
 """
 
 
+R = TypeVar("R")
+
+
 @dataclass
-class SerializationBackend:
+class SerializationBackend(Generic[R]):
     """
     This class supports serialization methods and provides pickle-like functions for convenience.
 
@@ -30,22 +34,22 @@ class SerializationBackend:
     """
 
     @abc.abstractmethod
-    def serialize(self, tr: Trace):
+    def serialize(self, tr: Trace[R]):
         pass
 
     @abc.abstractmethod
-    def deserialize(self, bytes, gen_fn: GenerativeFunction, args: tuple):
+    def deserialize(self, bytes, gen_fn: GenerativeFunction[R], args: tuple[Any, ...]):
         pass
 
-    def dumps(self, tr: Trace):
+    def dumps(self, tr: Trace[R]):
         return self.serialize(tr)
 
-    def loads(self, bytes, gen_fn: GenerativeFunction, args: tuple):
+    def loads(self, bytes, gen_fn: GenerativeFunction[R], args: tuple[Any, ...]):
         return self.deserialize(bytes, gen_fn, args)
 
-    def dump(self, tr: Trace, file):
+    def dump(self, tr: Trace[R], file):
         file.write(self.dumps(tr))
 
-    def load(self, file, gen_fn: GenerativeFunction, args: tuple):
+    def load(self, file, gen_fn: GenerativeFunction[R], args: tuple[Any, ...]):
         bytes = file.read()
         return self.loads(bytes, gen_fn, args)

--- a/src/genjax/_src/core/traceback_util.py
+++ b/src/genjax/_src/core/traceback_util.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import jax._src.traceback_util as traceback_util
-from beartype.typing import Callable, TypeVar
 
-_C = TypeVar("_C", bound=Callable)
+from genjax._src.core.typing import Any, Callable, TypeVar
+
+_C = TypeVar("_C", bound=Callable[..., Any])
 
 
 def gfi_boundary(c: _C) -> _C:

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -62,7 +62,6 @@ ScalarBool = Annotated[Bool | BoolArray, ScalarShaped]
 
 Generic = btyping.Generic
 TypeVar = btyping.TypeVar
-TypeVarTuple = btyping.TypeVarTuple
 ParamSpec = btyping.ParamSpec
 
 ########################################

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -62,6 +62,7 @@ ScalarBool = Annotated[Bool | BoolArray, ScalarShaped]
 
 Generic = btyping.Generic
 TypeVar = btyping.TypeVar
+TypeVarTuple = btyping.TypeVarTuple
 ParamSpec = btyping.ParamSpec
 
 ########################################

--- a/src/genjax/_src/generative_functions/combinators/dimap.py
+++ b/src/genjax/_src/generative_functions/combinators/dimap.py
@@ -132,7 +132,7 @@ class DimapCombinator(Generic[ArgTuple, R, S], GenerativeFunction[S]):
         trace: Trace[S],
         update_problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[DimapTrace[R, S], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[DimapTrace[R, S], Weight, Retdiff[S], UpdateProblem]:
         assert isinstance(trace, EmptyTrace | DimapTrace)
 
         primals = Diff.tree_primal(argdiffs)
@@ -180,7 +180,7 @@ class DimapCombinator(Generic[ArgTuple, R, S], GenerativeFunction[S]):
         key: PRNGKey,
         trace: Trace[S],
         update_problem: UpdateProblem,
-    ) -> tuple[DimapTrace[R, S], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[DimapTrace[R, S], Weight, Retdiff[S], UpdateProblem]:
         match update_problem:
             case GenericProblem(argdiffs, subproblem):
                 return self.update_change_target(key, trace, subproblem, argdiffs)

--- a/src/genjax/_src/generative_functions/combinators/mask.py
+++ b/src/genjax/_src/generative_functions/combinators/mask.py
@@ -131,7 +131,7 @@ class MaskCombinator(Generic[R], GenerativeFunction[Mask[R]]):
         trace: Trace[Mask[R]],
         update_problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[MaskTrace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[MaskTrace[R], Weight, Retdiff[Mask[R]], UpdateProblem]:
         check = Diff.tree_primal(argdiffs)[0]
         check_diff, inner_argdiffs = argdiffs[0], argdiffs[1:]
         match trace:
@@ -162,7 +162,7 @@ class MaskCombinator(Generic[R], GenerativeFunction[Mask[R]]):
         trace: Trace[Mask[R]],
         update_problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[MaskTrace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[MaskTrace[R], Weight, Retdiff[Mask[R]], UpdateProblem]:
         check = Diff.tree_primal(argdiffs)[0]
         check_diff, inner_argdiffs = argdiffs[0], argdiffs[1:]
 
@@ -194,7 +194,7 @@ class MaskCombinator(Generic[R], GenerativeFunction[Mask[R]]):
         key: PRNGKey,
         trace: Trace[Mask[R]],
         update_problem: UpdateProblem,
-    ) -> tuple[MaskTrace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[MaskTrace[R], Weight, Retdiff[Mask[R]], UpdateProblem]:
         assert isinstance(trace, MaskTrace) or isinstance(trace, EmptyTrace)
 
         match update_problem:

--- a/src/genjax/_src/generative_functions/combinators/mixture.py
+++ b/src/genjax/_src/generative_functions/combinators/mixture.py
@@ -14,7 +14,7 @@
 
 
 from genjax._src.core.generative import GenerativeFunction
-from genjax._src.core.typing import typecheck
+from genjax._src.core.typing import TypeVar, typecheck
 from genjax._src.generative_functions.combinators.switch import (
     switch,
 )
@@ -23,9 +23,11 @@ from genjax._src.generative_functions.distributions.tensorflow_probability impor
 )
 from genjax._src.generative_functions.static import gen
 
+R = TypeVar("R")
+
 
 @typecheck
-def mix(*gen_fns: GenerativeFunction) -> GenerativeFunction:
+def mix(*gen_fns: GenerativeFunction[R]) -> GenerativeFunction[R]:
     """
     Creates a mixture model from a set of generative functions.
 
@@ -75,9 +77,9 @@ def mix(*gen_fns: GenerativeFunction) -> GenerativeFunction:
     inner_combinator_closure = switch(*gen_fns)
 
     @gen
-    def mixture_model(mixture_logits, *args):
+    def mixture_model(mixture_logits, *args) -> R:
         mix_idx = categorical(mixture_logits) @ "mixture_component"
-        v = inner_combinator_closure(mix_idx, *args) @ "component_sample"
+        v: R = inner_combinator_closure(mix_idx, *args) @ "component_sample"
         return v
 
     return mixture_model

--- a/src/genjax/_src/generative_functions/combinators/mixture.py
+++ b/src/genjax/_src/generative_functions/combinators/mixture.py
@@ -14,7 +14,7 @@
 
 
 from genjax._src.core.generative import GenerativeFunction
-from genjax._src.core.typing import TypeVar, typecheck
+from genjax._src.core.typing import Any, typecheck
 from genjax._src.generative_functions.combinators.switch import (
     switch,
 )
@@ -23,11 +23,9 @@ from genjax._src.generative_functions.distributions.tensorflow_probability impor
 )
 from genjax._src.generative_functions.static import gen
 
-R = TypeVar("R")
-
 
 @typecheck
-def mix(*gen_fns: GenerativeFunction[R]) -> GenerativeFunction[R]:
+def mix(*gen_fns: GenerativeFunction[Any]) -> GenerativeFunction[Any]:
     """
     Creates a mixture model from a set of generative functions.
 
@@ -77,9 +75,9 @@ def mix(*gen_fns: GenerativeFunction[R]) -> GenerativeFunction[R]:
     inner_combinator_closure = switch(*gen_fns)
 
     @gen
-    def mixture_model(mixture_logits, *args) -> R:
+    def mixture_model(mixture_logits, *args) -> Any:
         mix_idx = categorical(mixture_logits) @ "mixture_component"
-        v: R = inner_combinator_closure(mix_idx, *args) @ "component_sample"
+        v = inner_combinator_closure(mix_idx, *args) @ "component_sample"
         return v
 
     return mixture_model

--- a/src/genjax/_src/generative_functions/combinators/or_else.py
+++ b/src/genjax/_src/generative_functions/combinators/or_else.py
@@ -15,14 +15,16 @@
 import jax.numpy as jnp
 
 from genjax._src.core.generative import GenerativeFunction
-from genjax._src.core.typing import Any, ScalarBool, typecheck
+from genjax._src.core.typing import Any, ScalarBool, TypeVar, typecheck
+
+R = TypeVar("R")
 
 
 @typecheck
 def or_else(
-    if_gen_fn: GenerativeFunction,
-    else_gen_fn: GenerativeFunction,
-) -> GenerativeFunction:
+    if_gen_fn: GenerativeFunction[R],
+    else_gen_fn: GenerativeFunction[R],
+) -> GenerativeFunction[R]:
     """
     Given two [`genjax.GenerativeFunction`][]s `if_gen_fn` and `else_gen_fn`, returns a new [`genjax.GenerativeFunction`][] that accepts
 

--- a/src/genjax/_src/generative_functions/combinators/or_else.py
+++ b/src/genjax/_src/generative_functions/combinators/or_else.py
@@ -18,13 +18,14 @@ from genjax._src.core.generative import GenerativeFunction
 from genjax._src.core.typing import Any, ScalarBool, TypeVar, typecheck
 
 R = TypeVar("R")
+T = TypeVar("T")
 
 
 @typecheck
 def or_else(
     if_gen_fn: GenerativeFunction[R],
-    else_gen_fn: GenerativeFunction[R],
-) -> GenerativeFunction[R]:
+    else_gen_fn: GenerativeFunction[T],
+) -> GenerativeFunction[R | T]:
     """
     Given two [`genjax.GenerativeFunction`][]s `if_gen_fn` and `else_gen_fn`, returns a new [`genjax.GenerativeFunction`][] that accepts
 

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -41,19 +41,24 @@ from genjax._src.core.typing import (
     Int,
     IntArray,
     PRNGKey,
+    TypeVar,
     typecheck,
 )
+
+Carry = TypeVar("Carry")
+X = TypeVar("X")
+Y = TypeVar("Y")
 
 
 @Pytree.dataclass
 class ScanTrace(Trace):
     scan_gen_fn: "ScanCombinator"
     inner: Trace
-    args: tuple
+    args: tuple[Any, ...]
     retval: Any
     score: FloatArray
 
-    def get_args(self) -> tuple:
+    def get_args(self) -> tuple[Any, ...]:
         return self.args
 
     def get_retval(self):
@@ -207,7 +212,7 @@ class ScanCombinator(GenerativeFunction):
     def simulate(
         self,
         key: PRNGKey,
-        args: tuple,
+        args: tuple[Any, ...],
     ) -> ScanTrace:
         carry, scanned_in = args
 
@@ -242,7 +247,7 @@ class ScanCombinator(GenerativeFunction):
         self,
         key: PRNGKey,
         constraint: ChoiceMap,
-        args: tuple,
+        args: tuple[Any, ...],
     ) -> tuple[Trace, Weight, Retdiff, UpdateProblem]:
         (carry, scanned_in) = args
 
@@ -491,7 +496,7 @@ class ScanCombinator(GenerativeFunction):
     def assess(
         self,
         sample: Sample,
-        args: tuple,
+        args: tuple[Any, ...],
     ) -> tuple[Score, Any]:
         (carry, scanned_in) = args
         assert isinstance(sample, ChoiceMap)

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -248,7 +248,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
         key: PRNGKey,
         constraint: ChoiceMap,
         args: tuple[Any, ...],
-    ) -> tuple[Trace[tuple[Carry, Y]], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[ScanTrace[Carry, Y], Weight, Retdiff[tuple[Carry, Y]], UpdateProblem]:
         (carry, scanned_in) = args
 
         def _inner_importance(key, constraint, carry, scanned_in):
@@ -315,7 +315,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
         trace: ScanTrace[Carry, Y],
         problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[ScanTrace[Carry, Y], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[ScanTrace[Carry, Y], Weight, Retdiff[tuple[Carry, Y]], UpdateProblem]:
         carry_diff, *scanned_in_diff = Diff.tree_diff_unknown_change(
             Diff.tree_primal(argdiffs)
         )
@@ -446,7 +446,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
         trace: Trace[tuple[Carry, Y]],
         update_problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[Trace[tuple[Carry, Y]], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[ScanTrace[Carry, Y], Weight, Retdiff[tuple[Carry, Y]], UpdateProblem]:
         assert isinstance(trace, EmptyTrace | ScanTrace)
         match update_problem:
             case ImportanceProblem(constraint) if isinstance(constraint, ChoiceMap):
@@ -478,7 +478,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
         key: PRNGKey,
         trace: Trace[tuple[Carry, Y]],
         update_problem: UpdateProblem,
-    ) -> tuple[Trace[tuple[Carry, Y]], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[ScanTrace[Carry, Y], Weight, Retdiff[tuple[Carry, Y]], UpdateProblem]:
         match update_problem:
             case GenericProblem(argdiffs, subproblem):
                 return self.update_change_target(key, trace, subproblem, argdiffs)

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -38,6 +38,7 @@ from genjax._src.core.typing import (
     Any,
     Callable,
     FloatArray,
+    Generic,
     Int,
     IntArray,
     PRNGKey,
@@ -46,22 +47,21 @@ from genjax._src.core.typing import (
 )
 
 Carry = TypeVar("Carry")
-X = TypeVar("X")
 Y = TypeVar("Y")
 
 
 @Pytree.dataclass
-class ScanTrace(Trace):
-    scan_gen_fn: "ScanCombinator"
-    inner: Trace
+class ScanTrace(Generic[Carry, Y], Trace[tuple[Carry, Y]]):
+    scan_gen_fn: "ScanCombinator[Carry, Y]"
+    inner: Trace[tuple[Carry, Y]]
     args: tuple[Any, ...]
-    retval: Any
+    retval: tuple[Carry, Y]
     score: FloatArray
 
     def get_args(self) -> tuple[Any, ...]:
         return self.args
 
-    def get_retval(self):
+    def get_retval(self) -> tuple[Carry, Y]:
         return self.retval
 
     def get_sample(self):
@@ -104,7 +104,7 @@ class CheckerboardProblem(UpdateProblem):
 
 
 @Pytree.dataclass
-class ScanCombinator(GenerativeFunction):
+class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
     """`ScanCombinator` wraps a `kernel_gen_fn` [`genjax.GenerativeFunction`][]
     of type `(c, a) -> (c, b)` in a new [`genjax.GenerativeFunction`][] of type
     `(c, [a]) -> (c, [b])`, where.
@@ -181,7 +181,7 @@ class ScanCombinator(GenerativeFunction):
         ```
     """
 
-    kernel_gen_fn: GenerativeFunction
+    kernel_gen_fn: GenerativeFunction[tuple[Carry, Y]]
 
     # Only required for `None` carry inputs
     length: Int | None = Pytree.static()
@@ -190,10 +190,10 @@ class ScanCombinator(GenerativeFunction):
 
     # To get the type of return value, just invoke
     # the scanned over source (with abstract tracer arguments).
-    def __abstract_call__(self, *args) -> Any:
+    def __abstract_call__(self, *args) -> tuple[Carry, Y]:
         (carry, scanned_in) = args
 
-        def _inner(carry, scanned_in):
+        def _inner(carry: Carry, scanned_in: Any):
             v, scanned_out = self.kernel_gen_fn.__abstract_call__(carry, scanned_in)
             return v, scanned_out
 
@@ -213,7 +213,7 @@ class ScanCombinator(GenerativeFunction):
         self,
         key: PRNGKey,
         args: tuple[Any, ...],
-    ) -> ScanTrace:
+    ) -> ScanTrace[Carry, Y]:
         carry, scanned_in = args
 
         def _inner_simulate(key, carry, scanned_in):
@@ -248,7 +248,7 @@ class ScanCombinator(GenerativeFunction):
         key: PRNGKey,
         constraint: ChoiceMap,
         args: tuple[Any, ...],
-    ) -> tuple[Trace, Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[tuple[Carry, Y]], Weight, Retdiff, UpdateProblem]:
         (carry, scanned_in) = args
 
         def _inner_importance(key, constraint, carry, scanned_in):
@@ -284,7 +284,9 @@ class ScanCombinator(GenerativeFunction):
             unroll=self.unroll,
         )
         return (
-            ScanTrace(self, tr, args, (carried_out, scanned_out), jnp.sum(scores)),
+            ScanTrace[Carry, Y](
+                self, tr, args, (carried_out, scanned_out), jnp.sum(scores)
+            ),
             jnp.sum(ws),
             Diff.unknown_change((carried_out, scanned_out)),
             bwd_problems,
@@ -310,10 +312,10 @@ class ScanCombinator(GenerativeFunction):
     def update_generic(
         self,
         key: PRNGKey,
-        trace: ScanTrace,
+        trace: ScanTrace[Carry, Y],
         problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[ScanTrace, Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[ScanTrace[Carry, Y], Weight, Retdiff, UpdateProblem]:
         carry_diff, *scanned_in_diff = Diff.tree_diff_unknown_change(
             Diff.tree_primal(argdiffs)
         )
@@ -393,7 +395,7 @@ class ScanCombinator(GenerativeFunction):
     def update_index(
         self,
         key: PRNGKey,
-        trace: ScanTrace,
+        trace: ScanTrace[Carry, Y],
         index: IntArray,
         update_problem: UpdateProblem,
     ):
@@ -425,7 +427,7 @@ class ScanCombinator(GenerativeFunction):
         )
         new_retvals = new_inner.get_retval()
         return (
-            ScanTrace(
+            ScanTrace[Carry, Y](
                 self,
                 new_inner,
                 new_inner.get_args(),
@@ -441,10 +443,10 @@ class ScanCombinator(GenerativeFunction):
     def update_change_target(
         self,
         key: PRNGKey,
-        trace: Trace,
+        trace: Trace[tuple[Carry, Y]],
         update_problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[Trace, Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[tuple[Carry, Y]], Weight, Retdiff, UpdateProblem]:
         assert isinstance(trace, EmptyTrace | ScanTrace)
         match update_problem:
             case ImportanceProblem(constraint) if isinstance(constraint, ChoiceMap):
@@ -474,9 +476,9 @@ class ScanCombinator(GenerativeFunction):
     def update(
         self,
         key: PRNGKey,
-        trace: Trace,
+        trace: Trace[tuple[Carry, Y]],
         update_problem: UpdateProblem,
-    ) -> tuple[Trace, Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[tuple[Carry, Y]], Weight, Retdiff, UpdateProblem]:
         match update_problem:
             case GenericProblem(argdiffs, subproblem):
                 return self.update_change_target(key, trace, subproblem, argdiffs)
@@ -537,7 +539,9 @@ class ScanCombinator(GenerativeFunction):
 @typecheck
 def scan(
     *, n: Int | None = None, reverse: bool = False, unroll: int | bool = 1
-) -> Callable[[GenerativeFunction], GenerativeFunction]:
+) -> Callable[
+    [GenerativeFunction[tuple[Carry, Y]]], GenerativeFunction[tuple[Carry, Y]]
+]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `(c, a) -> (c, b)`and returns a new [`genjax.GenerativeFunction`][] of type
     `(c, [a]) -> (c, [b])` where.
@@ -621,13 +625,13 @@ def scan(
         ```
     """
 
-    def decorator(f):
-        return ScanCombinator(f, length=n, reverse=reverse, unroll=unroll)
+    def decorator(f: GenerativeFunction[tuple[Carry, Y]]):
+        return ScanCombinator[Carry, Y](f, length=n, reverse=reverse, unroll=unroll)
 
     return decorator
 
 
-def prepend_initial_acc(args, ret):
+def prepend_initial_acc(args: tuple[Carry, Any], ret: tuple[Carry, Carry]) -> Carry:
     """Prepends the initial accumulator value to the array of accumulated
     values.
 
@@ -657,7 +661,7 @@ def prepend_initial_acc(args, ret):
 @typecheck
 def accumulate(
     *, reverse: bool = False, unroll: int | bool = 1
-) -> Callable[[GenerativeFunction], GenerativeFunction]:
+) -> Callable[[GenerativeFunction[Carry]], GenerativeFunction[Carry]]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `(c, a) -> c` and returns a new [`genjax.GenerativeFunction`][] of type
     `(c, [a]) -> [c]` where.
@@ -715,7 +719,7 @@ def accumulate(
         ```
     """
 
-    def decorator(f: GenerativeFunction):
+    def decorator(f: GenerativeFunction[Carry]) -> GenerativeFunction[Carry]:
         return (
             f.map(lambda ret: (ret, ret))
             .scan(reverse=reverse, unroll=unroll)
@@ -728,7 +732,7 @@ def accumulate(
 @typecheck
 def reduce(
     *, reverse: bool = False, unroll: int | bool = 1
-) -> Callable[[GenerativeFunction], GenerativeFunction]:
+) -> Callable[[GenerativeFunction[Carry]], GenerativeFunction[Carry]]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `(c, a) -> c` and returns a new [`genjax.GenerativeFunction`][] of type
     `(c, [a]) -> c` where.
@@ -783,11 +787,11 @@ def reduce(
         ```
     """
 
-    def decorator(f: GenerativeFunction):
-        def pre(ret):
+    def decorator(f: GenerativeFunction[Carry]) -> GenerativeFunction[Carry]:
+        def pre(ret: Carry):
             return ret, None
 
-        def post(ret):
+        def post(ret: tuple[Carry, None]):
             return ret[0]
 
         return f.map(pre).scan(reverse=reverse, unroll=unroll).map(post)
@@ -798,7 +802,7 @@ def reduce(
 @typecheck
 def iterate(
     *, n: Int, unroll: int | bool = 1
-) -> Callable[[GenerativeFunction], GenerativeFunction]:
+) -> Callable[[GenerativeFunction[Y]], GenerativeFunction[Y]]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `a -> a` and returns a new [`genjax.GenerativeFunction`][] of type `a ->
     [a]` where.
@@ -850,7 +854,7 @@ def iterate(
         ```
     """
 
-    def decorator(f: GenerativeFunction):
+    def decorator(f: GenerativeFunction[Y]) -> GenerativeFunction[Y]:
         # strip off the JAX-supplied `None` on the way in, accumulate `ret` on the way out.
         return (
             f.dimap(pre=lambda *args: args[:-1], post=lambda _, ret: (ret, ret))
@@ -864,7 +868,7 @@ def iterate(
 @typecheck
 def iterate_final(
     *, n: Int, unroll: int | bool = 1
-) -> Callable[[GenerativeFunction], GenerativeFunction]:
+) -> Callable[[GenerativeFunction[Y]], GenerativeFunction[Y]]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `a -> a` and returns a new [`genjax.GenerativeFunction`][] of type `a -> a`
     where.
@@ -914,12 +918,12 @@ def iterate_final(
         ```
     """
 
-    def decorator(f: GenerativeFunction):
+    def decorator(f: GenerativeFunction[Y]) -> GenerativeFunction[Y]:
         # strip off the JAX-supplied `None` on the way in, no accumulation on the way out.
-        def pre_post(_, ret):
+        def pre_post(_, ret: Y):
             return ret, None
 
-        def post_post(_, ret):
+        def post_post(_, ret: tuple[Y, None]):
             return ret[0]
 
         return (

--- a/src/genjax/_src/generative_functions/combinators/switch.py
+++ b/src/genjax/_src/generative_functions/combinators/switch.py
@@ -248,7 +248,7 @@ class SwitchCombinator(GenerativeFunction[Any]):
     @typecheck
     def _empty_update_defs(
         self,
-        trace: SwitchTrace[R],
+        trace: SwitchTrace[Any],
         problem: UpdateProblem,
         argdiffs: Argdiffs,
     ):
@@ -294,7 +294,7 @@ class SwitchCombinator(GenerativeFunction[Any]):
         self,
         key: PRNGKey,
         static_idx: Int,
-        trace: SwitchTrace[R],
+        trace: SwitchTrace[Any],
         problem: UpdateProblem,
         idx: IntArray,
         argdiffs: Argdiffs,
@@ -321,7 +321,7 @@ class SwitchCombinator(GenerativeFunction[Any]):
         self,
         key: PRNGKey,
         static_idx: Int,
-        trace: SwitchTrace[R],
+        trace: SwitchTrace[Any],
         problem: UpdateProblem,
         idx: IntArray,
         argdiffs: Argdiffs,
@@ -382,10 +382,10 @@ class SwitchCombinator(GenerativeFunction[Any]):
     def update_generic(
         self,
         key: PRNGKey,
-        trace: SwitchTrace[R],
+        trace: SwitchTrace[Any],
         problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
+    ) -> tuple[SwitchTrace[Any], Weight, Retdiff[Any], UpdateProblem]:
         (idx_argdiff, *branch_argdiffs) = argdiffs
         self.static_check_num_arguments_equals_num_branches(branch_argdiffs)
 

--- a/src/genjax/_src/generative_functions/combinators/switch.py
+++ b/src/genjax/_src/generative_functions/combinators/switch.py
@@ -39,12 +39,16 @@ from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
     Any,
     FloatArray,
+    Generic,
     Int,
     IntArray,
     PRNGKey,
     Sequence,
+    TypeVar,
     typecheck,
 )
+
+R = TypeVar("R")
 
 #######################
 # Switch sample types #
@@ -63,11 +67,11 @@ class HeterogeneousSwitchSample(Sample):
 
 
 @Pytree.dataclass
-class SwitchTrace(Trace):
-    gen_fn: GenerativeFunction
+class SwitchTrace(Generic[R], Trace[R]):
+    gen_fn: GenerativeFunction[R]
     args: tuple[Any, ...]
-    subtraces: list[Trace]
-    retval: Any
+    subtraces: list[Trace[R]]
+    retval: R
     score: FloatArray
 
     def get_args(self) -> tuple[Any, ...]:
@@ -108,7 +112,7 @@ class SwitchTrace(Trace):
 
 
 @Pytree.dataclass
-class SwitchCombinator(GenerativeFunction):
+class SwitchCombinator(Generic[R], GenerativeFunction[R]):
     """
     `SwitchCombinator` accepts `n` generative functions as input and returns a new [`genjax.GenerativeFunction`][] that accepts `n+1` arguments:
 
@@ -154,11 +158,11 @@ class SwitchCombinator(GenerativeFunction):
         ```
     """
 
-    branches: tuple[GenerativeFunction, ...]
+    branches: tuple[GenerativeFunction[R], ...]
 
     def __abstract_call__(self, *args):
         idx, *args = args
-        retvals = []
+        retvals: list[R] = []
         for _idx in range(len(self.branches)):
             branch_gen_fn = self.branches[_idx]
             branch_args = args[_idx]
@@ -209,7 +213,7 @@ class SwitchCombinator(GenerativeFunction):
         self,
         key: PRNGKey,
         args: tuple[Any, ...],
-    ) -> SwitchTrace:
+    ) -> SwitchTrace[R]:
         (idx, *branch_args) = args
         self.static_check_num_arguments_equals_num_branches(branch_args)
 
@@ -244,7 +248,7 @@ class SwitchCombinator(GenerativeFunction):
     @typecheck
     def _empty_update_defs(
         self,
-        trace: SwitchTrace,
+        trace: SwitchTrace[R],
         problem: UpdateProblem,
         argdiffs: Argdiffs,
     ):
@@ -290,7 +294,7 @@ class SwitchCombinator(GenerativeFunction):
         self,
         key: PRNGKey,
         static_idx: Int,
-        trace: SwitchTrace,
+        trace: SwitchTrace[R],
         problem: UpdateProblem,
         idx: IntArray,
         argdiffs: Argdiffs,
@@ -317,7 +321,7 @@ class SwitchCombinator(GenerativeFunction):
         self,
         key: PRNGKey,
         static_idx: Int,
-        trace: SwitchTrace,
+        trace: SwitchTrace[R],
         problem: UpdateProblem,
         idx: IntArray,
         argdiffs: Argdiffs,
@@ -378,10 +382,10 @@ class SwitchCombinator(GenerativeFunction):
     def update_generic(
         self,
         key: PRNGKey,
-        trace: SwitchTrace,
+        trace: SwitchTrace[R],
         problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[Trace, Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
         (idx_argdiff, *branch_argdiffs) = argdiffs
         self.static_check_num_arguments_equals_num_branches(branch_argdiffs)
 
@@ -522,7 +526,7 @@ class SwitchCombinator(GenerativeFunction):
         key: PRNGKey,
         problem: ImportanceProblem,
         argdiffs: tuple[Any, ...],
-    ) -> tuple[SwitchTrace, Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[SwitchTrace[R], Weight, Retdiff, UpdateProblem]:
         args = Diff.tree_primal(argdiffs)
         (idx, *branch_args) = args
         (_, *branch_argdiffs) = argdiffs
@@ -596,10 +600,10 @@ class SwitchCombinator(GenerativeFunction):
     def update_change_target(
         self,
         key: PRNGKey,
-        trace: Trace,
+        trace: Trace[R],
         problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[Trace, Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
         assert isinstance(trace, EmptyTrace | SwitchTrace)
         match trace:
             case EmptyTrace():
@@ -615,9 +619,9 @@ class SwitchCombinator(GenerativeFunction):
     def update(
         self,
         key: PRNGKey,
-        trace: Trace,
+        trace: Trace[R],
         update_problem: UpdateProblem,
-    ) -> tuple[Trace, Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
         match update_problem:
             case GenericProblem(argdiffs, subproblem):
                 return self.update_change_target(key, trace, subproblem, argdiffs)
@@ -682,8 +686,8 @@ class SwitchCombinator(GenerativeFunction):
 
 @typecheck
 def switch(
-    *gen_fns: GenerativeFunction,
-) -> GenerativeFunction:
+    *gen_fns: GenerativeFunction[R],
+) -> GenerativeFunction[R]:
     """
     Given `n` [`genjax.GenerativeFunction`][] inputs, returns a [`genjax.GenerativeFunction`][] that accepts `n+1` arguments:
 

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -180,7 +180,7 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         key: PRNGKey,
         choice_map: ChoiceMap,
         args: tuple[Any, ...],
-    ) -> tuple[VmapTrace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[VmapTrace[R], Weight, Retdiff[R], UpdateProblem]:
         self._static_check_broadcastable(args)
         broadcast_dim_length = self._static_broadcast_dim_length(args)
         idx_array = jnp.arange(0, broadcast_dim_length)
@@ -213,7 +213,7 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         prev: VmapTrace[R],
         update_problem: ChoiceMap,
         argdiffs: Argdiffs,
-    ) -> tuple[VmapTrace[R], Weight, Retdiff, ChoiceMap]:
+    ) -> tuple[VmapTrace[R], Weight, Retdiff[R], ChoiceMap]:
         primals = Diff.tree_primal(argdiffs)
         self._static_check_broadcastable(primals)
         broadcast_dim_length = self._static_broadcast_dim_length(primals)
@@ -243,7 +243,7 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         trace: Trace[R],
         update_problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[VmapTrace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[VmapTrace[R], Weight, Retdiff[R], UpdateProblem]:
         match update_problem:
             case ChoiceMap():
                 assert isinstance(
@@ -265,7 +265,7 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         key: PRNGKey,
         trace: Trace[R],
         update_problem: UpdateProblem,
-    ) -> tuple[VmapTrace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[VmapTrace[R], Weight, Retdiff[R], UpdateProblem]:
         match update_problem:
             case GenericProblem(argdiffs, subproblem):
                 return self.update_change_target(key, trace, subproblem, argdiffs)

--- a/src/genjax/_src/generative_functions/distributions/custom/discrete_hmm.py
+++ b/src/genjax/_src/generative_functions/distributions/custom/discrete_hmm.py
@@ -20,10 +20,12 @@ from scipy.linalg import circulant
 from tensorflow_probability.substrates import jax as tfp
 
 from genjax._src.core.pytree import Pytree
-from genjax._src.core.typing import FloatArray, IntArray, PRNGKey
+from genjax._src.core.typing import FloatArray, Generic, IntArray, PRNGKey, TypeVar
 from genjax._src.generative_functions.distributions.distribution import Distribution
 
 tfd = tfp.distributions
+
+R = TypeVar("R")
 
 #####
 # Discrete HMM configuration
@@ -231,13 +233,15 @@ def latent_sequence_posterior(
 
 
 @Pytree.dataclass
-class _DiscreteHMMLatentSequencePosterior(Distribution):
+class _DiscreteHMMLatentSequencePosterior(Generic[R], Distribution[R]):
     def random_weighted(self, key, *args, **kwargs):
         config, observation_sequence = args
         key, sub_key = jax.random.split(key)
         _, (v, _) = forward_filtering_backward_sampling(
             sub_key, config, observation_sequence
         )
+
+        # TODO how is this not a bug, going off of the type signature?
         key, (w, _) = self.estimate_logpdf(
             key, v, config, observation_sequence, **kwargs
         )

--- a/src/genjax/_src/generative_functions/distributions/distribution.py
+++ b/src/genjax/_src/generative_functions/distributions/distribution.py
@@ -190,7 +190,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
         key: PRNGKey,
         constraint: Constraint,
         args: tuple[Any, ...],
-    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
         match constraint:
             case ChoiceMap():
                 tr, w, bwd_problem = self.importance_choice_map(key, constraint, args)
@@ -213,7 +213,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
         self,
         trace: Trace[R],
         argdiffs: Argdiffs,
-    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
         sample = trace.get_choices()
         primals = Diff.tree_primal(argdiffs)
         new_score, _ = self.assess(sample, primals)
@@ -231,7 +231,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
         trace: Trace[R],
         constraint: MaskedConstraint,
         argdiffs: Argdiffs,
-    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
         old_sample = trace.get_choices()
 
         def update_branch(key, trace, constraint, argdiffs):
@@ -270,7 +270,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
         trace: Trace[R],
         constraint: Constraint,
         argdiffs: Argdiffs,
-    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
         primals = Diff.tree_primal(argdiffs)
         match constraint:
             case EmptyConstraint():
@@ -367,7 +367,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
         flag: Flag,
         problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[Trace[ArrayLike], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[ArrayLike], Weight, Retdiff[R], UpdateProblem]:
         old_value = trace.get_retval()
         primals = Diff.tree_primal(argdiffs)
         possible_trace, w, retdiff, bwd_problem = self.update(
@@ -390,7 +390,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
     def update_project(
         self,
         trace: Trace[R],
-    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
         original = trace.get_score()
         removed_value = trace.get_retval()
         retdiff = Diff.tree_diff_unknown_change(trace.get_retval())
@@ -407,7 +407,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
         trace: Trace[R],
         selection: Selection,
         argdiffs: Argdiffs,
-    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
         check = () in selection
 
         return self.update(
@@ -426,7 +426,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
         trace: Trace[R],
         update_problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
         match update_problem:
             case EmptyProblem():
                 return self.update_empty(trace, argdiffs)
@@ -461,7 +461,7 @@ class Distribution(Generic[R], GenerativeFunction[R]):
         key: PRNGKey,
         trace: Trace[R],
         update_problem: UpdateProblem,
-    ) -> tuple[Trace[R], Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[Trace[R], Weight, Retdiff[R], UpdateProblem]:
         match update_problem:
             case GenericProblem(argdiffs, subproblem):
                 return self.update_change_target(key, trace, subproblem, argdiffs)

--- a/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
+++ b/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
@@ -15,13 +15,38 @@
 
 from tensorflow_probability.substrates import jax as tfp
 
-from genjax._src.core.typing import Any, Callable
-from genjax._src.generative_functions.distributions.distribution import exact_density
+from genjax._src.core.typing import Array, Callable
+from genjax._src.generative_functions.distributions.distribution import (
+    ExactDensityFromCallables,
+    exact_density,
+)
 
 tfd = tfp.distributions
 
+from typing import TYPE_CHECKING
 
-def tfp_distribution(dist: Callable[..., Any]):
+if TYPE_CHECKING:
+    import tensorflow_probability.python.distributions.distribution as dist
+
+
+def tfp_distribution(
+    dist: Callable[..., "dist.Distribution"],
+) -> ExactDensityFromCallables[Array]:
+    """
+    Creates an ExactDensityFromCallables generative function from a TensorFlow Probability distribution.
+
+    Args:
+        dist: A callable that returns a TensorFlow Probability distribution.
+        _v: An example object for return type annotation. Defaults to object().
+
+    Returns:
+        A generative function wrapping the TensorFlow Probability distribution.
+
+    This function creates a generative function that encapsulates the sampling and log probability
+    computation of a TensorFlow Probability distribution. It uses the distribution's `sample` and
+    `log_prob` methods to define the generative function's behavior.
+    """
+
     def sampler(key, *args, **kwargs):
         d = dist(*args, **kwargs)
         return d.sample(seed=key)
@@ -38,6 +63,7 @@ def tfp_distribution(dist: Callable[..., Any]):
 #####################
 
 beta = tfp_distribution(tfd.Beta)
+
 """
 A `tfp_distribution` generative function which wraps the [`tfd.Beta`](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/Beta) distribution from TensorFlow Probability distributions.
 """

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -236,7 +236,7 @@ class SimulateHandler(StaticHandler):
     key: PRNGKey
     score: Score = Pytree.field(default_factory=lambda: jnp.zeros(()))
     address_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
-    address_traces: list[Trace] = Pytree.field(default_factory=list)
+    address_traces: list[Trace[Any]] = Pytree.field(default_factory=list)
 
     def visit(self, addr):
         self.address_visitor.visit(addr)
@@ -252,7 +252,7 @@ class SimulateHandler(StaticHandler):
     def handle_trace(
         self,
         addr: StaticAddress,
-        gen_fn: GenerativeFunction,
+        gen_fn: GenerativeFunction[Any],
         args: tuple[Any, ...],
     ):
         self.visit(addr)
@@ -294,12 +294,12 @@ def simulate_transform(source_fn):
 @dataclass
 class UpdateHandler(StaticHandler):
     key: PRNGKey
-    previous_trace: StaticTrace
+    previous_trace: StaticTrace[Any]
     fwd_problem: UpdateProblem
     address_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
     score: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
     weight: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
-    address_traces: list[Trace] = Pytree.field(default_factory=list)
+    address_traces: list[Trace[Any]] = Pytree.field(default_factory=list)
     bwd_problems: list[UpdateProblem] = Pytree.field(default_factory=list)
 
     def yield_state(self):
@@ -333,7 +333,7 @@ class UpdateHandler(StaticHandler):
             case _:
                 raise ValueError(f"Not implemented fwd_problem: {self.fwd_problem}")
 
-    def get_subtrace(self, sub_gen_fn: GenerativeFunction, addr: StaticAddress):
+    def get_subtrace(self, sub_gen_fn: GenerativeFunction[Any], addr: StaticAddress):
         if isinstance(self.previous_trace, EmptyTrace):
             return EmptyTrace(sub_gen_fn)
         else:
@@ -346,7 +346,7 @@ class UpdateHandler(StaticHandler):
     def handle_trace(
         self,
         addr: StaticAddress,
-        gen_fn: GenerativeFunction,
+        gen_fn: GenerativeFunction[Any],
         args: tuple[Any, ...],
     ):
         argdiffs: Argdiffs = args
@@ -430,7 +430,7 @@ class AssessHandler(StaticHandler):
     def handle_trace(
         self,
         addr: StaticAddress,
-        gen_fn: GenerativeFunction,
+        gen_fn: GenerativeFunction[Any],
         args: tuple[Any, ...],
     ):
         submap = self.get_subsample(addr)
@@ -459,7 +459,7 @@ def assess_transform(source_fn):
 @typecheck
 def handler_trace_with_static(
     addr: StaticAddressComponent | StaticAddress,
-    gen_fn: GenerativeFunction,
+    gen_fn: GenerativeFunction[Any],
     args: tuple[Any, ...],
 ):
     return trace(addr if isinstance(addr, tuple) else (addr,), gen_fn, args)

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -515,7 +515,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
         self,
         key: PRNGKey,
         args: tuple[Any, ...],
-    ) -> StaticTrace:
+    ) -> StaticTrace[R]:
         syntax_sugar_handled = push_trace_overload_stack(
             handler_trace_with_static, self.source
         )
@@ -535,10 +535,10 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
     def update_change_target(
         self,
         key: PRNGKey,
-        trace: Trace,
+        trace: Trace[R],
         update_problem: UpdateProblem,
         argdiffs: Argdiffs,
-    ) -> tuple[Trace, Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[StaticTrace[R], Weight, Retdiff[R], UpdateProblem]:
         syntax_sugar_handled = push_trace_overload_stack(
             handler_trace_with_static, self.source
         )
@@ -585,9 +585,9 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
     def update(
         self,
         key: PRNGKey,
-        trace: Trace,
+        trace: Trace[R],
         update_problem: UpdateProblem,
-    ) -> tuple[Trace, Weight, Retdiff, UpdateProblem]:
+    ) -> tuple[StaticTrace[R], Weight, Retdiff[R], UpdateProblem]:
         match update_problem:
             case GenericProblem(argdiffs, subproblem):
                 return self.update_change_target(key, trace, subproblem, argdiffs)

--- a/src/genjax/_src/inference/smc.py
+++ b/src/genjax/_src/inference/smc.py
@@ -106,7 +106,7 @@ class ParticleCollection(Pytree):
     def get_log_marginal_likelihood_estimate(self) -> FloatArray:
         return logsumexp(self.log_weights) - jnp.log(len(self.log_weights))
 
-    def __getitem__(self, idx) -> tuple:
+    def __getitem__(self, idx) -> tuple[Any, ...]:
         return jtu.tree_map(lambda v: v[idx], (self.particles, self.log_weights))
 
     def sample_particle(self, key) -> Trace:
@@ -512,7 +512,7 @@ class KernelTrace(Trace):
     gen_fn: "KernelGenerativeFunction"
     inner: Trace
 
-    def get_args(self) -> tuple:
+    def get_args(self) -> tuple[Any, ...]:
         return self.inner.get_args()
 
     def get_retval(self) -> Any:
@@ -535,7 +535,7 @@ class KernelGenerativeFunction(GenerativeFunction):
     def simulate(
         self,
         key: PRNGKey,
-        args: tuple,
+        args: tuple[Any, ...],
     ) -> Trace:
         gen_fn = gen(self.source)
         tr = gen_fn.simulate(key, args)
@@ -545,7 +545,7 @@ class KernelGenerativeFunction(GenerativeFunction):
         self,
         key: PRNGKey,
         constraint: Constraint,
-        args: tuple,
+        args: tuple[Any, ...],
     ) -> tuple[Trace, Weight]:
         raise NotImplementedError
 
@@ -629,7 +629,7 @@ class AttachTrace(Trace):
     gen_fn: "AttachCombinator"
     inner: Trace
 
-    def get_args(self) -> tuple:
+    def get_args(self) -> tuple[Any, ...]:
         return self.inner.get_args()
 
     def get_retval(self) -> Any:
@@ -651,7 +651,7 @@ class AttachCombinator(GenerativeFunction):
     def simulate(
         self,
         key: PRNGKey,
-        args: tuple,
+        args: tuple[Any, ...],
     ) -> Trace:
         tr = self.gen_fn.simulate(key, args)
         return AttachTrace(self, tr)
@@ -662,7 +662,7 @@ class AttachCombinator(GenerativeFunction):
         self,
         key: PRNGKey,
         constraint: Constraint,
-        args: tuple,
+        args: tuple[Any, ...],
     ) -> tuple[Trace, Weight]:
         move = self.importance_move(constraint)
         match move:

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -112,11 +112,11 @@ class TestIterate:
         the initial value).
         """
         result = inc.iterate(n=4).simulate(key, (0,)).get_retval()
-        assert jnp.array_equal(result, jnp.array([0, 1, 2, 3, 4]))
+        assert jnp.array_equal(jnp.asarray(result), jnp.array([0, 1, 2, 3, 4]))
 
         # same as result, with a jnp.array-wrapped accumulator
         result_wrapped = inc.iterate(n=4).simulate(key, (jnp.array(0),)).get_retval()
-        assert jnp.array_equal(result, result_wrapped)
+        assert jnp.array_equal(jnp.asarray(result), result_wrapped)
 
     def test_iterate_final(self, key):
         """
@@ -130,7 +130,7 @@ class TestIterate:
     def test_inc_tupled(self, key):
         """Baseline test demonstrating `inc_tupled`."""
         result = inc_tupled.simulate(key, ((0, 2),)).get_retval()
-        assert jnp.array_equal(result, jnp.array((2, 2)))
+        assert jnp.array_equal(jnp.asarray(result), jnp.array((2, 2)))
 
     def test_iterate_tupled(self, key):
         """
@@ -139,7 +139,8 @@ class TestIterate:
         """
         result = inc_tupled.iterate(n=4).simulate(key, ((0, 2),)).get_retval()
         assert jnp.array_equal(
-            jnp.asarray(result), jnp.array([[0, 2, 4, 6, 8], [2, 2, 2, 2, 2]])
+            jnp.asarray(result),
+            jnp.array([[0, 2, 4, 6, 8], [2, 2, 2, 2, 2]]),
         )
 
     def test_iterate_final_tupled(self, key):
@@ -253,7 +254,7 @@ class TestAccumulateReduceMethods:
     def test_add_tupled(self, key):
         """Baseline test demonstrating `add_tupled`."""
         result = add_tupled.simulate(key, ((0, 2), 10)).get_retval()
-        assert jnp.array_equal(result, jnp.array((12, 2)))
+        assert jnp.array_equal(jnp.asarray(result), jnp.array((12, 2)))
 
     def test_accumulate_tupled(self, key):
         """

--- a/tests/generative_functions/test_static_gen_fn.py
+++ b/tests/generative_functions/test_static_gen_fn.py
@@ -22,6 +22,7 @@ import genjax
 from genjax import ChoiceMapBuilder as C
 from genjax import Diff, Pytree
 from genjax import UpdateProblemBuilder as U
+from genjax._src.core.typing import Array
 from genjax.generative_functions.static import AddressReuse
 from genjax.typing import Float, FloatArray
 
@@ -155,7 +156,7 @@ def simple_normal(custom_tree):
 
 
 @Pytree.dataclass
-class _CustomNormal(genjax.Distribution):
+class _CustomNormal(genjax.Distribution[Array]):
     def estimate_logpdf(self, key, v, *args):
         v, custom_tree = args
         w, _ = genjax.normal.assess(v, (custom_tree.x, custom_tree.y))

--- a/tests/inference/test_smc.py
+++ b/tests/inference/test_smc.py
@@ -19,6 +19,7 @@ from jax.scipy.special import logsumexp
 
 import genjax
 from genjax import ChoiceMapBuilder as C
+from genjax._src.core.typing import Any
 
 
 def logpdf(v):
@@ -32,7 +33,7 @@ class TestSMC:
             _ = genjax.flip(0.5) @ "x"
             _ = genjax.flip(0.7) @ "y"
 
-        def flip_flip_exact_log_marginal_density(target: genjax.Target):
+        def flip_flip_exact_log_marginal_density(target: genjax.Target[Any]):
             y = target.constraint.get_submap("y")
             return genjax.flip.assess(y, (0.7,))[0]
 
@@ -60,7 +61,7 @@ class TestSMC:
             p = jax.lax.cond(v1, lambda: 0.9, lambda: 0.3)
             _ = genjax.flip(p) @ "y"
 
-        def flip_flip_exact_log_marginal_density(target: genjax.Target):
+        def flip_flip_exact_log_marginal_density(target: genjax.Target[Any]):
             y = target["y"]
             x_prior = jnp.array([
                 logpdf(genjax.flip)(True, 0.5),


### PR DESCRIPTION
This PR:

- adds all missing generics
- `tfp_distribution` objects now report their type as `Distribution[Array]`
- bumps pyright to `1.1.377`
- relaxes the `R` of `switch` and `mix` to `Any`, since we can't say anything the final return type thanks to the multiple return types that might come in
- modifies `Mask.maybe` to never return `None`
- `Mask.maybe_none` made more readable, and with clear types
- fixes bugs in `_DiscreteHMMLatentSequencePosterior`
- `update_constraint` in `Distribution` gains a bugfix on the `UpdateProblem` returned from one of the branches, and an assertion that the type of choicemap we're assuming made it in (`MaskChm`) was in fact a `MaskChm`.