### PR TITLE
Fix assess in switch combinator (GEN-433)

### DIFF
--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -26,12 +26,8 @@ import jax.numpy as jnp
 import jaxtyping as jtyping
 import numpy as np
 from beartype.vale import Is
-import sys
 
-if sys.version_info >= (3, 11, 0):
-    from typing import Self
-else:
-    from typing_extensions import Self
+from typing_extensions import Self
 
 Any = btyping.Any
 PRNGKey = jtyping.PRNGKeyArray

--- a/tests/generative_functions/test_or_else.py
+++ b/tests/generative_functions/test_or_else.py
@@ -1,0 +1,36 @@
+# Copyright 2023 MIT Probabilistic Computing Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+from jax import numpy as jnp
+
+import genjax
+
+
+class TestOrElse:
+    def test_switch_combinator_simulate_in_gen_fn(self):
+        p = 0.5
+
+        @genjax.gen
+        def f():
+            flip = jnp.bool_(genjax.flip(p) @ "flip")
+            return (
+                genjax.normal(0.0, 1.0).or_else(genjax.normal(2.0, 1.0))(flip, (), ())
+                @ "value"
+            )
+
+        key = jax.random.PRNGKey(17)
+        args = ()
+
+        f.assess(f.simulate(key, args).get_choices(), args)


### PR DESCRIPTION
This PR:

- Removes the python version fork for `typing_extensions`, as it's available in 3.11 and up as well
- threads the `R` type parameter through so that values traced with `@` return `R` instead of `Any`
- fixes the `assess` implementation of `switch` to properly pass branch args around and not create lists vs tuples