### PR TITLE
add test for assess on tupled address trace (GEN-29)

### DIFF
--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -41,7 +41,7 @@ from genjax._src.core.typing import (
 # Address types #
 #################
 
-StaticAddressComponent = String | int
+StaticAddressComponent = String
 DynamicAddressComponent = ArrayLike
 AddressComponent = StaticAddressComponent | DynamicAddressComponent
 Address = tuple[()] | tuple[AddressComponent, ...]
@@ -49,7 +49,6 @@ StaticAddress = tuple[()] | tuple[StaticAddressComponent, ...]
 ExtendedStaticAddressComponent = StaticAddressComponent | EllipsisType
 ExtendedAddressComponent = ExtendedStaticAddressComponent | DynamicAddressComponent
 ExtendedAddress = tuple[()] | tuple[ExtendedAddressComponent, ...]
-
 
 ##############
 # Selections #

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -41,7 +41,7 @@ from genjax._src.core.typing import (
 # Address types #
 #################
 
-StaticAddressComponent = String
+StaticAddressComponent = String | int
 DynamicAddressComponent = ArrayLike
 AddressComponent = StaticAddressComponent | DynamicAddressComponent
 Address = tuple[()] | tuple[AddressComponent, ...]

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -17,17 +17,21 @@ codebase.
 Type annotations in the codebase are exported out of this module for consistency.
 """
 
-from typing import Annotated  # noqa: I001
+import sys
 from types import EllipsisType
+from typing import Annotated
 
 import beartype.typing as btyping
-from jax import core as jc
 import jax.numpy as jnp
 import jaxtyping as jtyping
 import numpy as np
 from beartype.vale import Is
+from jax import core as jc
 
-from typing_extensions import Self
+if sys.version_info >= (3, 11, 0):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 Any = btyping.Any
 PRNGKey = jtyping.PRNGKeyArray

--- a/tests/core/generative/test_core.py
+++ b/tests/core/generative/test_core.py
@@ -17,6 +17,19 @@ import jax
 import jax.numpy as jnp
 
 import genjax
+from genjax import SelectionBuilder as S
+
+
+class TestTupleAddr:
+    def test_tupled_address(self):
+        @genjax.gen
+        def f():
+            x = genjax.normal(0.0, 1.0) @ ("x", 0)
+            y = genjax.normal(x, 1.0) @ "y"
+            return y
+
+        tr = f.simulate(jax.random.PRNGKey(0), ())
+        assert -2.7931314 == tr.project(jax.random.PRNGKey(1), S["x", 0])
 
 
 class TestCombinators:

--- a/tests/core/generative/test_core.py
+++ b/tests/core/generative/test_core.py
@@ -24,12 +24,12 @@ class TestTupleAddr:
     def test_tupled_address(self):
         @genjax.gen
         def f():
-            x = genjax.normal(0.0, 1.0) @ ("x", 0)
+            x = genjax.normal(0.0, 1.0) @ ("x", "x0")
             y = genjax.normal(x, 1.0) @ "y"
             return y
 
         tr = f.simulate(jax.random.PRNGKey(0), ())
-        assert -2.7931314 == tr.project(jax.random.PRNGKey(1), S["x", 0])
+        assert -2.7931314 == tr.project(jax.random.PRNGKey(1), S["x", "x0"])
 
 
 class TestCombinators:


### PR DESCRIPTION
This PR fixes type errors that show up when someone traces to an address like `("x", 0)`.