### PR TITLE
Remove noqa, ignore cls from vulture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,9 @@ fail_under = 45
 
 [tool.vulture]
 paths = ["src"]
+ignore_names = ["cls"]
 exclude = ["*/.ipynb_checkpoints/*"]
-min_confidence = 80
+min_confidence = 70
 sort_by_size = true
 
 [tool.pyright]

--- a/src/genjax/_src/checkify.py
+++ b/src/genjax/_src/checkify.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import contextmanager  # noqa: I001
+from contextlib import contextmanager
+
 from genjax._src.core.typing import Callable
 
 _GLOBAL_CHECKIFY_HANDLER = []

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -166,21 +166,19 @@ class Selection(ProjectProblem):
     #################################################
 
     @classmethod
-    def all(_cls) -> "Selection":
+    def all(cls) -> "Selection":
         return select_all()
 
     @classmethod
-    def str(
-        _cls, comp: ExtendedStaticAddressComponent, sel: "Selection"
-    ) -> "Selection":
+    def str(cls, comp: ExtendedStaticAddressComponent, sel: "Selection") -> "Selection":
         return select_static(comp, sel)
 
     @classmethod
-    def idx(_cls, comp: DynamicAddressComponent, sel: "Selection") -> "Selection":
+    def idx(cls, comp: DynamicAddressComponent, sel: "Selection") -> "Selection":
         return select_idx(comp, sel)
 
     @classmethod
-    def maybe(_cls, flag: Flag, s: "Selection") -> "Selection":
+    def maybe(cls, flag: Flag, s: "Selection") -> "Selection":
         return select_defer(flag, s)
 
 
@@ -608,31 +606,31 @@ class ChoiceMap(Sample, Constraint):
     ######################################
 
     @classmethod
-    def empty(_cls) -> "ChoiceMap":
+    def empty(cls) -> "ChoiceMap":
         return choice_map_empty
 
     @classmethod
-    def value(_cls, v) -> "ChoiceMap":
+    def value(cls, v) -> "ChoiceMap":
         return choice_map_value(v)
 
     @classmethod
-    def maybe(_cls, f: Flag, c: "ChoiceMap") -> "ChoiceMap":
+    def maybe(cls, f: Flag, c: "ChoiceMap") -> "ChoiceMap":
         return choice_map_masked(f, c)
 
     @classmethod
-    def str(_cls, addr: StaticAddressComponent, v: Any) -> "ChoiceMap":
+    def str(cls, addr: StaticAddressComponent, v: Any) -> "ChoiceMap":
         return choice_map_static(
             addr, ChoiceMap.value(v) if not isinstance(v, ChoiceMap) else v
         )
 
     @classmethod
-    def idx(_cls, addr: DynamicAddressComponent, v: Any) -> "ChoiceMap":
+    def idx(cls, addr: DynamicAddressComponent, v: Any) -> "ChoiceMap":
         return choice_map_idx(
             addr, ChoiceMap.value(v) if not isinstance(v, ChoiceMap) else v
         )
 
     @classmethod
-    def d(_cls, d: dict[Any, Any]) -> "ChoiceMap":
+    def d(cls, d: dict[Any, Any]) -> "ChoiceMap":
         start = ChoiceMap.empty()
         if d:
             for k, v in d.items():
@@ -640,7 +638,7 @@ class ChoiceMap(Sample, Constraint):
         return start
 
     @classmethod
-    def kw(_cls, **kwargs) -> "ChoiceMap":
+    def kw(cls, **kwargs) -> "ChoiceMap":
         return ChoiceMap.d(kwargs)
 
     @property

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -127,7 +127,7 @@ class MaskedProblem(UpdateProblem):
     problem: UpdateProblem
 
     @classmethod
-    def maybe_empty(_cls, f: Flag, problem: UpdateProblem):
+    def maybe_empty(cls, f: Flag, problem: UpdateProblem):
         match problem:
             case MaskedProblem(flag, subproblem):
                 return MaskedProblem(f.and_(flag), subproblem)
@@ -165,15 +165,15 @@ class ProjectProblem(UpdateProblem):
 
 class UpdateProblemBuilder(Pytree):
     @classmethod
-    def empty(_cls):
+    def empty(cls):
         return EmptyProblem()
 
     @classmethod
-    def maybe(_cls, flag: Flag, problem: "UpdateProblem"):
+    def maybe(cls, flag: Flag, problem: "UpdateProblem"):
         return MaskedProblem.maybe_empty(flag, problem)
 
     @classmethod
-    def g(_cls, argdiffs: Argdiffs, subproblem: "UpdateProblem") -> "GenericProblem":
+    def g(cls, argdiffs: Argdiffs, subproblem: "UpdateProblem") -> "GenericProblem":
         return GenericProblem(argdiffs, subproblem)
 
 
@@ -489,7 +489,7 @@ class GenerativeFunction(Generic[R], Pytree):
         return get_trace_shape(self, args)
 
     @classmethod
-    def gfi_boundary(_cls, c: _C) -> _C:
+    def gfi_boundary(cls, c: _C) -> _C:
         return gfi_boundary(c)
 
     @abstractmethod

--- a/src/genjax/_src/core/generative/functional_types.py
+++ b/src/genjax/_src/core/generative/functional_types.py
@@ -63,7 +63,7 @@ class Mask(Generic[R], Pytree):
     value: R
 
     @classmethod
-    def maybe(_cls, f: Flag, v: "R | Mask[R]") -> "Mask[R]":
+    def maybe(cls, f: Flag, v: "R | Mask[R]") -> "Mask[R]":
         match v:
             case Mask(flag, value):
                 return Mask[R](f.and_(flag), value)
@@ -71,7 +71,7 @@ class Mask(Generic[R], Pytree):
                 return Mask[R](f, v)
 
     @classmethod
-    def maybe_none(_cls, f: Flag, v: "R | Mask[R]") -> "R | Mask[R] | None":
+    def maybe_none(cls, f: Flag, v: "R | Mask[R]") -> "R | Mask[R] | None":
         if v is None or f.concrete_false():
             return None
         elif f.concrete_true():
@@ -179,7 +179,7 @@ class Sum(Generic[R], Pytree):
 
     @classmethod
     def maybe(
-        _cls,
+        cls,
         idx: ArrayLike | Diff[Any],
         vs: list[R],
     ):
@@ -191,7 +191,7 @@ class Sum(Generic[R], Pytree):
 
     @classmethod
     def maybe_none(
-        _cls,
+        cls,
         idx: ArrayLike | Diff[Any],
         vs: list[R],
     ):

--- a/src/genjax/_src/core/pytree.py
+++ b/src/genjax/_src/core/pytree.py
@@ -63,7 +63,7 @@ class Pytree(pz.Struct):
     @classmethod
     @overload
     def dataclass(
-        _cls,
+        cls,
         incoming: None = None,
         /,
         **kwargs,
@@ -72,7 +72,7 @@ class Pytree(pz.Struct):
     @classmethod
     @overload
     def dataclass(
-        _cls,
+        cls,
         incoming: type[_T],
         /,
         **kwargs,
@@ -83,7 +83,7 @@ class Pytree(pz.Struct):
     )
     @classmethod
     def dataclass(
-        _cls,
+        cls,
         incoming: type[_T] | None = None,
         /,
         **kwargs,

--- a/src/genjax/_src/generative_functions/distributions/custom/discrete_hmm.py
+++ b/src/genjax/_src/generative_functions/distributions/custom/discrete_hmm.py
@@ -60,7 +60,7 @@ class DiscreteHMMConfiguration(Pytree):
     sigma_obs: FloatArray = Pytree.static()
 
     @classmethod
-    def copy(_cls, config, transition_tensor, observation_tensor):
+    def copy(cls, config, transition_tensor, observation_tensor):
         return DiscreteHMMConfiguration(
             config.linear_grid_dim,
             config.adjacency_distance_trans,

--- a/src/genjax/adev.py
+++ b/src/genjax/adev.py
@@ -12,26 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from genjax._src.adev.core import ADEVPrimitive  # noqa: I001
-from genjax._src.adev.core import Dual
-from genjax._src.adev.core import expectation
-from genjax._src.adev.core import sample_primitive
-from genjax._src.adev.primitives import add_cost
-from genjax._src.adev.primitives import baseline
-from genjax._src.adev.primitives import categorical_enum_parallel
-from genjax._src.adev.primitives import flip_enum
-from genjax._src.adev.primitives import flip_enum_parallel
-from genjax._src.adev.primitives import flip_mvd
-from genjax._src.adev.primitives import flip_reinforce
-from genjax._src.adev.primitives import geometric_reinforce
-from genjax._src.adev.primitives import mv_normal_diag_reparam
-from genjax._src.adev.primitives import mv_normal_reparam
-from genjax._src.adev.primitives import normal_reinforce
-from genjax._src.adev.primitives import normal_reparam
-from genjax._src.adev.primitives import beta_implicit
-from genjax._src.adev.primitives import reinforce
-from genjax._src.adev.primitives import uniform
-
+from genjax._src.adev.core import ADEVPrimitive, Dual, expectation, sample_primitive
+from genjax._src.adev.primitives import (
+    add_cost,
+    baseline,
+    beta_implicit,
+    categorical_enum_parallel,
+    flip_enum,
+    flip_enum_parallel,
+    flip_mvd,
+    flip_reinforce,
+    geometric_reinforce,
+    mv_normal_diag_reparam,
+    mv_normal_reparam,
+    normal_reinforce,
+    normal_reparam,
+    reinforce,
+    uniform,
+)
 
 __all__ = [
     "ADEVPrimitive",

--- a/tests/adev/test_adev.py
+++ b/tests/adev/test_adev.py
@@ -12,15 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import jax  # noqa: I001
+import jax
 import pytest
 
-from genjax.adev import expectation
-from genjax.adev import flip_enum
-from genjax.adev import add_cost
-from genjax.adev import baseline
-from genjax.adev import flip_reinforce
-from genjax.adev import Dual
+from genjax.adev import Dual, add_cost, baseline, expectation, flip_enum, flip_reinforce
 
 
 class TestADEVFlipCond:


### PR DESCRIPTION
This PR reverts the `_cls` changes that were causing warnings from pyright, and removes so extra `noqa` annotations that were floating around.