### PR TITLE
Lock down types for SwitchCombinator, cast / throw in concrete idx case (GEN-486)

### DIFF
--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -51,7 +51,6 @@ R = TypeVar("R")
 """
 Generic denoting the return type of a generative function.
 """
-
 S = TypeVar("S")
 
 Carry = TypeVar("Carry")
@@ -1229,8 +1228,8 @@ class GenerativeFunction(Generic[R], Pytree):
         return genjax.mask(self)
 
     def or_else(
-        self, gen_fn: "GenerativeFunction[S]", /
-    ) -> "GenerativeFunction[R | S]":
+        self, gen_fn: "GenerativeFunction[R]", /
+    ) -> "GenerativeFunction[R | genjax.Sum[R]]":
         """
         Returns a [`GenerativeFunction`][genjax.GenerativeFunction] that accepts
 
@@ -1278,7 +1277,9 @@ class GenerativeFunction(Generic[R], Pytree):
 
         return genjax.or_else(self, gen_fn)
 
-    def switch(self, *branches: "GenerativeFunction[Any]") -> "GenerativeFunction[Any]":
+    def switch(
+        self, *branches: "GenerativeFunction[R]"
+    ) -> "genjax.SwitchCombinator[R]":
         """
         Given `n` [`genjax.GenerativeFunction`][] inputs, returns a new [`genjax.GenerativeFunction`][] that accepts `n+2` arguments:
 
@@ -1319,7 +1320,9 @@ class GenerativeFunction(Generic[R], Pytree):
 
         return genjax.switch(self, *branches)
 
-    def mix(self, *fns: "GenerativeFunction[Any]") -> "GenerativeFunction[Any]":
+    def mix(
+        self, *fns: "GenerativeFunction[R]"
+    ) -> "GenerativeFunction[R | genjax.Sum[R]]":
         """
         Takes any number of [`genjax.GenerativeFunction`][]s and returns a new [`genjax.GenerativeFunction`][] that represents a mixture model.
 

--- a/src/genjax/_src/core/generative/functional_types.py
+++ b/src/genjax/_src/core/generative/functional_types.py
@@ -221,5 +221,5 @@ class Sum(Generic[R], Pytree):
         else:
             return self
 
-    def __getitem__(self, idx: Int):
+    def __getitem__(self, idx: Int) -> R | Mask[R] | None:
         return Mask.maybe_none(Flag(idx == self.idx), self.values[idx])

--- a/src/genjax/_src/core/generative/functional_types.py
+++ b/src/genjax/_src/core/generative/functional_types.py
@@ -27,6 +27,7 @@ from genjax._src.core.typing import (
     ArrayLike,
     Generic,
     Int,
+    Self,
     TypeVar,
 )
 
@@ -181,7 +182,7 @@ class Sum(Generic[R], Pytree):
         cls,
         idx: ArrayLike | Diff[Any],
         vs: list[R],
-    ):
+    ) -> "R | Sum[R]":
         return Sum[R](idx, vs).maybe_collapse()
 
     @classmethod
@@ -189,8 +190,8 @@ class Sum(Generic[R], Pytree):
         cls,
         idx: ArrayLike | Diff[Any],
         vs: list[R],
-    ):
-        possibles = []
+    ) -> "R | Mask[R] | Sum[R] | None":
+        possibles: list[R | Mask[R] | None] = []
         for _idx, v in enumerate(vs):
             if v is not None:
                 possibles.append(Mask.maybe_none(Flag(idx == _idx), v))
@@ -201,7 +202,7 @@ class Sum(Generic[R], Pytree):
         else:
             return Sum.maybe(idx, vs)
 
-    def maybe_collapse(self):
+    def maybe_collapse(self) -> R | Self:
         def choose(*vs):
             # Computing `result` above the branch allows us to:
             # - catch incompatible types / shapes in the result

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -61,6 +61,7 @@ Value = Any
 ScalarShaped = Is[lambda arr: jnp.array(arr, copy=False).shape == ()]
 ScalarBool = Annotated[Bool | BoolArray, ScalarShaped]
 
+
 ############
 # Generics #
 ############

--- a/src/genjax/_src/generative_functions/combinators/mixture.py
+++ b/src/genjax/_src/generative_functions/combinators/mixture.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 
-from genjax._src.core.generative import GenerativeFunction
-from genjax._src.core.typing import Any
+from genjax._src.core.generative import GenerativeFunction, Sum
+from genjax._src.core.typing import TypeVar
 from genjax._src.generative_functions.combinators.switch import (
     switch,
 )
@@ -23,8 +23,10 @@ from genjax._src.generative_functions.distributions.tensorflow_probability impor
 )
 from genjax._src.generative_functions.static import gen
 
+R = TypeVar("R")
 
-def mix(*gen_fns: GenerativeFunction[Any]) -> GenerativeFunction[Any]:
+
+def mix(*gen_fns: GenerativeFunction[R]) -> GenerativeFunction[R | Sum[R]]:
     """
     Creates a mixture model from a set of generative functions.
 
@@ -74,7 +76,7 @@ def mix(*gen_fns: GenerativeFunction[Any]) -> GenerativeFunction[Any]:
     inner_combinator_closure = switch(*gen_fns)
 
     @gen
-    def mixture_model(mixture_logits, *args) -> Any:
+    def mixture_model(mixture_logits, *args) -> R | Sum[R]:
         mix_idx = categorical(mixture_logits) @ "mixture_component"
         v = inner_combinator_closure(mix_idx, *args) @ "component_sample"
         return v

--- a/src/genjax/_src/generative_functions/combinators/or_else.py
+++ b/src/genjax/_src/generative_functions/combinators/or_else.py
@@ -14,17 +14,16 @@
 
 import jax.numpy as jnp
 
-from genjax._src.core.generative import GenerativeFunction
+from genjax._src.core.generative import GenerativeFunction, Sum
 from genjax._src.core.typing import Any, ScalarBool, TypeVar
 
 R = TypeVar("R")
-T = TypeVar("T")
 
 
 def or_else(
     if_gen_fn: GenerativeFunction[R],
-    else_gen_fn: GenerativeFunction[T],
-) -> GenerativeFunction[R | T]:
+    else_gen_fn: GenerativeFunction[R],
+) -> GenerativeFunction[R | Sum[R]]:
     """
     Given two [`genjax.GenerativeFunction`][]s `if_gen_fn` and `else_gen_fn`, returns a new [`genjax.GenerativeFunction`][] that accepts
 


### PR DESCRIPTION
@littleredcomputer and I discovered that `SwitchCombinator` ALREADY casts / requires that all of the incoming generative functions have the same return type, thanks to `jnp.choose` (invoked when an index is not an `int`).

This behavior allowed the user to see different return types when they passed an `int` index vs an array.

This PR:
- removes this difference in behavior by _always_ calling `jnp.choose` (to benefit from its shape-and-type checking and errors), but then in the case of a concrete `int` index, selecting using `vs[idx]` instead of returning the result of `jnp.choose`.
- types `SwitchCombinator` as `GenerativeFunction[R | Sum[R]]` and pushes this through `mix` and `or_else`
- swaps out `Sum.maybe_none` calls throughout `SwitchCombinator` for `Sum.maybe` calls