### PR TITLE
fix GEN-524 by equilibrating argdiff shape in `VmapTrace`

### DIFF
--- a/src/genjax/_src/core/interpreters/staging.py
+++ b/src/genjax/_src/core/interpreters/staging.py
@@ -115,6 +115,12 @@ class Flag(Pytree):
             return ff(*args)
         return jax.lax.cond(self.f, tf, ff, *args)
 
+    @staticmethod
+    def as_flag(f):
+        if isinstance(f, Flag):
+            return f
+        return Flag(f)
+
 
 def staged_check(v):
     return static_check_is_concrete(v) and v

--- a/src/genjax/_src/generative_functions/combinators/mask.py
+++ b/src/genjax/_src/generative_functions/combinators/mask.py
@@ -121,6 +121,9 @@ class MaskCombinator(Generic[R], GenerativeFunction[Mask[R]]):
         args: tuple[Any, ...],
     ) -> MaskTrace[R]:
         check, inner_args = args[0], args[1:]
+        if not isinstance(check, Flag):
+            check = Flag(check)
+
         tr = self.gen_fn.simulate(key, inner_args)
         return MaskTrace(self, tr, check)
 

--- a/src/genjax/_src/generative_functions/combinators/mask.py
+++ b/src/genjax/_src/generative_functions/combinators/mask.py
@@ -121,8 +121,7 @@ class MaskCombinator(Generic[R], GenerativeFunction[Mask[R]]):
         args: tuple[Any, ...],
     ) -> MaskTrace[R]:
         check, inner_args = args[0], args[1:]
-        if not isinstance(check, Flag):
-            check = Flag(check)
+        check = Flag.as_flag(check)
 
         tr = self.gen_fn.simulate(key, inner_args)
         return MaskTrace(self, tr, check)

--- a/src/genjax/_src/generative_functions/combinators/mask.py
+++ b/src/genjax/_src/generative_functions/combinators/mask.py
@@ -122,7 +122,7 @@ class MaskCombinator(Generic[R], GenerativeFunction[Mask[R]]):
     ) -> MaskTrace[R]:
         check, inner_args = args[0], args[1:]
         tr = self.gen_fn.simulate(key, inner_args)
-        return MaskTrace(self, tr, Flag(check))
+        return MaskTrace(self, tr, check)
 
     def update_change_target(
         self,
@@ -142,7 +142,7 @@ class MaskCombinator(Generic[R], GenerativeFunction[Mask[R]]):
                 raise NotImplementedError(f"Unexpected trace type: {trace}")
 
         premasked_trace, w, retdiff, bwd_problem = self.gen_fn.update(
-            key, inner_trace, GenericProblem(tuple(inner_argdiffs), update_problem)
+            key, inner_trace, GenericProblem(inner_argdiffs, update_problem)
         )
 
         w = check.where(w, -trace.get_score())
@@ -170,14 +170,15 @@ class MaskCombinator(Generic[R], GenerativeFunction[Mask[R]]):
         imp_update_problem = ImportanceProblem(update_problem)
 
         premasked_trace, w, _, _ = self.gen_fn.update(
-            key, inner_trace, GenericProblem(tuple(inner_argdiffs), imp_update_problem)
+            key, inner_trace, GenericProblem(inner_argdiffs, imp_update_problem)
         )
 
         _, _, retdiff, bwd_problem = self.gen_fn.update(
-            key, premasked_trace, GenericProblem(tuple(inner_argdiffs), update_problem)
+            key, premasked_trace, GenericProblem(inner_argdiffs, update_problem)
         )
 
-        w = check.where(premasked_trace.get_score(), 0.0)
+        premasked_score = premasked_trace.get_score()
+        w = check.where(premasked_score, jnp.zeros(premasked_score.shape))
 
         return (
             MaskTrace(self, premasked_trace, check),

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -202,7 +202,7 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         w = jnp.sum(w)
         retval = tr.get_retval()
         scores = tr.get_score()
-        map_tr = VmapTrace(self, tr, args, retval, jnp.sum(scores))
+        map_tr = VmapTrace(self, tr, Diff.tree_primal(args), retval, jnp.sum(scores))
         return map_tr, w, rd, bwd_problem
 
     def update_choice_map(
@@ -231,7 +231,7 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         w = jnp.sum(w)
         retval = new_subtraces.get_retval()
         scores = new_subtraces.get_score()
-        map_tr = VmapTrace(self, new_subtraces, argdiffs, retval, jnp.sum(scores))
+        map_tr = VmapTrace(self, new_subtraces, primals, retval, jnp.sum(scores))
         return map_tr, w, retdiff, bwd_problems
 
     def update_change_target(

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -177,20 +177,21 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         self,
         key: PRNGKey,
         choice_map: ChoiceMap,
-        args: tuple[Any, ...],
+        argdiffs: Argdiffs,
     ) -> tuple[VmapTrace[R], Weight, Retdiff[R], UpdateProblem]:
-        self._static_check_broadcastable(args)
-        broadcast_dim_length = self._static_broadcast_dim_length(args)
+        primals = Diff.tree_primal(argdiffs)
+        self._static_check_broadcastable(primals)
+        broadcast_dim_length = self._static_broadcast_dim_length(primals)
         idx_array = jnp.arange(0, broadcast_dim_length)
         sub_keys = jax.random.split(key, broadcast_dim_length)
 
-        def _importance(key, idx, choice_map, args):
+        def _importance(key, idx, choice_map, primals):
             submap = choice_map(idx)
             tr, w, rd, bwd_problem = self.gen_fn.update(
                 key,
                 EmptyTrace(self.gen_fn),
                 GenericProblem(
-                    Diff.unknown_change(args),
+                    Diff.unknown_change(primals),
                     ImportanceProblem(submap),
                 ),
             )
@@ -198,11 +199,11 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
 
         (tr, w, rd, bwd_problem) = jax.vmap(
             _importance, in_axes=(0, 0, None, self.in_axes)
-        )(sub_keys, idx_array, choice_map, args)
+        )(sub_keys, idx_array, choice_map, primals)
         w = jnp.sum(w)
         retval = tr.get_retval()
         scores = tr.get_score()
-        map_tr = VmapTrace(self, tr, Diff.tree_primal(args), retval, jnp.sum(scores))
+        map_tr = VmapTrace(self, tr, primals, retval, jnp.sum(scores))
         return map_tr, w, rd, bwd_problem
 
     def update_choice_map(

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -231,7 +231,7 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         w = jnp.sum(w)
         retval = new_subtraces.get_retval()
         scores = new_subtraces.get_score()
-        map_tr = VmapTrace(self, new_subtraces, primals, retval, jnp.sum(scores))
+        map_tr = VmapTrace(self, new_subtraces, argdiffs, retval, jnp.sum(scores))
         return map_tr, w, retdiff, bwd_problems
 
     def update_change_target(

--- a/tests/generative_functions/test_mask_combinator.py
+++ b/tests/generative_functions/test_mask_combinator.py
@@ -37,20 +37,20 @@ class TestMaskCombinator:
         return jax.random.PRNGKey(314159)
 
     def test_mask_simple_normal_true(self, key):
-        tr = jax.jit(model.simulate)(key, (Flag(True), -4.0))
+        tr = jax.jit(model.simulate)(key, (True, -4.0))
         assert tr.get_score() == tr.inner.get_score()
         assert tr.get_retval() == genjax.Mask(
             Flag(jnp.array(True)), tr.inner.get_retval()
         )
 
-        tr = jax.jit(model.simulate)(key, (Flag(False), -4.0))
+        tr = jax.jit(model.simulate)(key, (False, -4.0))
         assert tr.get_score() == 0.0
         assert tr.get_retval() == genjax.Mask(
             Flag(jnp.array(False)), tr.inner.get_retval()
         )
 
     def test_mask_simple_normal_false(self, key):
-        tr = jax.jit(model.simulate)(key, (Flag(False), 2.0))
+        tr = jax.jit(model.simulate)(key, (False, 2.0))
         assert tr.get_score() == 0.0
         assert not tr.get_retval().flag
 
@@ -63,7 +63,7 @@ class TestMaskCombinator:
 
     def test_mask_update_weight_to_argdiffs_from_true(self, key):
         # pre-update mask arg is True
-        tr = jax.jit(model.simulate)(key, (Flag(True), 2.0))
+        tr = jax.jit(model.simulate)(key, (True, 2.0))
         # mask check arg transition: True --> True
         argdiffs = U.g(
             (Diff.unknown_change(Flag(True)), Diff.no_change(tr.get_args()[1])), C.n()
@@ -98,7 +98,6 @@ class TestMaskCombinator:
         # score should be sum of sub-scores masked True
         assert tr.get_score() == inner_scores[0] + inner_scores[2]
 
-    @pytest.mark.skip(reason="This test is currently skipped")
     def test_mask_update_weight_to_argdiffs_from_false(self, key):
         # pre-update mask arg is False
         tr = jax.jit(model.simulate)(key, (False, 2.0))
@@ -143,7 +142,7 @@ class TestMaskCombinator:
         key = jax.random.PRNGKey(0)
         mask_steps = jnp.arange(10) < 5
         model = masked_scan_combinator(step, n=len(mask_steps))
-        init_particle = model.simulate(key, ((0.0,), Flag(mask_steps)))
+        init_particle = model.simulate(key, ((0.0,), mask_steps))
 
         # Update the model:
         update = genjax.UpdateProblemBuilder.g(


### PR DESCRIPTION
- correct an imbalance of argdiffs vs primals in VmapTrace
- stop auto-wrapping Flag around MaskTrace flag argument
- add Rif's failing example as unit test