### PR TITLE
fix GEN-387, GEN-333

### DIFF
--- a/notebooks/cookbook/basics/choicemap_creation_selection.ipynb
+++ b/notebooks/cookbook/basics/choicemap_creation_selection.ipynb
@@ -464,7 +464,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that this limitation is dependent on the model, and the simpler thing may work anyway for some classes models."
+    "Note that this limitation is dependent on the model, and the simpler thing may work anyway for some classes' models."
    ]
   },
   {
@@ -498,7 +498,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -714,11 +714,17 @@ class IdxChm(ChoiceMap):
                 else check_fn(addr, self.addr)
             )
 
+            check_array = jnp.asarray(check, copy=False)
+            if check_array.shape and check_array.shape[0] == 0:
+                # this is an obscure case which can arise when doing an importance
+                # update of a scan GF with an array of shape (0,) or (0, ...)
+                return choice_map_empty
+
             return (
                 choice_map_masked(
                     Flag(check[addr]), jtu.tree_map(lambda v: v[addr], self.c)
                 )
-                if jnp.array(check, copy=False).shape
+                if check_array.shape
                 else choice_map_masked(Flag(check), self.c)
             )
 

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -237,7 +237,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
 
         return ScanTrace(
             self,
-            self.length or len(scanned_in),
+            self.length or scanned_in.shape[0],
             tr,
             args,
             (carried_out, scanned_out),
@@ -296,7 +296,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
         return (
             ScanTrace[Carry, Y](
                 self,
-                self.length or len(scanned_in),
+                self.length or scanned_in.shape[0],
                 tr,
                 args,
                 (carried_out, scanned_out),

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -23,7 +23,6 @@ from genjax import Diff
 from genjax import SelectionBuilder as S
 from genjax import UpdateProblemBuilder as U
 from genjax._src.core.typing import ArrayLike
-from genjax._src.generative_functions.combinators.scan import ScanTrace
 from genjax.typing import FloatArray
 
 
@@ -388,20 +387,24 @@ class TestScanWithParameters:
             new_x = genjax.normal(x, std) @ "x"
             return new_x, None
 
-        tr = walk_step.scan(n=5).simulate(
-            key, (0.0, jnp.array([2.0, 4.0, 3.0, 5.0, 1.0]))
-        )
-        assert isinstance(tr, ScanTrace)
-        assert tr.length == 5
+        args = (0.0, jnp.array([2.0, 4.0, 3.0, 5.0, 1.0]))
+        tr = walk_step.scan(n=5).simulate(key, args)
+        expected = jnp.array([
+            -0.75375533,
+            -5.818158,
+            -3.4942584,
+            -5.0217595,
+            -4.4125495,
+        ])
         assert jnp.allclose(
-            tr.get_sample()[..., "x"],
-            jnp.array([-0.75375533, -5.818158, -3.4942584, -5.0217595, -4.4125495]),
+            tr.get_choices()[..., "x"],
+            expected,
         )
 
-        tr = walk_step.scan().simulate(key, (0.0, jnp.array([2.0, 4.0, 3.0, 5.0, 1.0])))
-        assert isinstance(tr, ScanTrace)
-        assert tr.length == 5
-        assert jnp.allclose(
-            tr.get_sample()[..., "x"],
-            jnp.array([-0.75375533, -5.818158, -3.4942584, -5.0217595, -4.4125495]),
-        )
+        tr = walk_step.scan().simulate(key, args)
+        assert jnp.allclose(tr.get_choices()[..., "x"], expected)
+
+        # now with jit
+        jitted = jax.jit(walk_step.scan().simulate)
+        tr = jitted(key, args)
+        assert jnp.allclose(tr.get_choices()[..., "x"], expected)

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -388,12 +388,20 @@ class TestScanWithParameters:
             new_x = genjax.normal(x, std) @ "x"
             return new_x, None
 
-        tr = walk_step.scan(n=5).simulate(key, (0.0, jnp.array([2.0, 4.0, 3.0, 5.0, 1.0])))
+        tr = walk_step.scan(n=5).simulate(
+            key, (0.0, jnp.array([2.0, 4.0, 3.0, 5.0, 1.0]))
+        )
         assert isinstance(tr, ScanTrace)
         assert tr.length == 5
-        assert jnp.allclose(tr.get_sample()[...,'x'], jnp.array([-0.75375533, -5.818158  , -3.4942584 , -5.0217595 , -4.4125495 ]))
+        assert jnp.allclose(
+            tr.get_sample()[..., "x"],
+            jnp.array([-0.75375533, -5.818158, -3.4942584, -5.0217595, -4.4125495]),
+        )
 
         tr = walk_step.scan().simulate(key, (0.0, jnp.array([2.0, 4.0, 3.0, 5.0, 1.0])))
         assert isinstance(tr, ScanTrace)
         assert tr.length == 5
-        assert jnp.allclose(tr.get_sample()[...,'x'], jnp.array([-0.75375533, -5.818158  , -3.4942584 , -5.0217595 , -4.4125495 ]))
+        assert jnp.allclose(
+            tr.get_sample()[..., "x"],
+            jnp.array([-0.75375533, -5.818158, -3.4942584, -5.0217595, -4.4125495]),
+        )

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -23,6 +23,7 @@ from genjax import Diff
 from genjax import SelectionBuilder as S
 from genjax import UpdateProblemBuilder as U
 from genjax._src.core.typing import ArrayLike
+from genjax._src.generative_functions.combinators.scan import ScanTrace
 from genjax.typing import FloatArray
 
 
@@ -380,3 +381,19 @@ class TestScanWithParameters:
 
         assert jnp.allclose(steps, jnp.array([8.0, 14.0, 21.0]), atol=0.1)
         assert jnp.allclose(end, jnp.array(21.0), atol=0.1)
+
+    def test_scan_length_inferred(self, key):
+        @genjax.gen
+        def walk_step(x, std):
+            new_x = genjax.normal(x, std) @ "x"
+            return new_x, None
+
+        tr = walk_step.scan(n=5).simulate(key, (0.0, jnp.array([2.0, 4.0, 3.0, 5.0, 1.0])))
+        assert isinstance(tr, ScanTrace)
+        assert tr.length == 5
+        assert jnp.allclose(tr.get_sample()[...,'x'], jnp.array([-0.75375533, -5.818158  , -3.4942584 , -5.0217595 , -4.4125495 ]))
+
+        tr = walk_step.scan().simulate(key, (0.0, jnp.array([2.0, 4.0, 3.0, 5.0, 1.0])))
+        assert isinstance(tr, ScanTrace)
+        assert tr.length == 5
+        assert jnp.allclose(tr.get_sample()[...,'x'], jnp.array([-0.75375533, -5.818158  , -3.4942584 , -5.0217595 , -4.4125495 ]))


### PR DESCRIPTION
If the length in the `ScanCombinator` is `None`, use the observed length of the scanned-over array from the trace in its place.

GEN-333 proposes to run importance over a scan with `jnp.arange(0)`, which produces an array of shape `(0,)`, which JAX doesn't want to deal with so we have to screen it out.