### PR TITLE
Preserve docstring, metadata on genjax.gen-wrapped fns (GEN-76)

### DIFF
--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -59,6 +59,14 @@ from genjax._src.core.typing import (
     PRNGKey,
 )
 
+_WRAPPER_ASSIGNMENTS = (
+    "__module__",
+    "__name__",
+    "__qualname__",
+    "__doc__",
+    "__annotations__",
+)
+
 
 # Usage in transforms: checks for duplicate addresses.
 @Pytree.dataclass
@@ -490,6 +498,16 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
     def __abstract_call__(self, *args) -> Any:
         return self.source(*args)
 
+    def __post_init__(self):
+        wrapped = self.source.fn
+        # Preserve the original function's docstring and name
+        for k in _WRAPPER_ASSIGNMENTS:
+            v = getattr(wrapped, k, None)
+            if v is not None:
+                object.__setattr__(self, k, v)
+
+        object.__setattr__(self, "__wrapped__", wrapped)
+
     def handle_kwargs(self) -> "StaticGenerativeFunction[R]":
         @Pytree.partial()
         def kwarged_source(args, kwargs):
@@ -629,30 +647,13 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
 # Decorator #
 #############
 
-_WRAPPER_ASSIGNMENTS = (
-    "__module__",
-    "__name__",
-    "__qualname__",
-    "__doc__",
-    "__annotations__",
-)
-
 
 def gen(f: Closure[R] | Callable[..., R]) -> StaticGenerativeFunction[R]:
     if isinstance(f, Closure):
-        gf = StaticGenerativeFunction[R](f)
+        return StaticGenerativeFunction[R](f)
     else:
         closure = Pytree.partial()(f)
-        gf = StaticGenerativeFunction[R](closure)
-
-    # Preserve the original function's docstring and name
-    for k in _WRAPPER_ASSIGNMENTS:
-        v = getattr(f, k, None)
-        if v is not None:
-            object.__setattr__(gf, k, v)
-
-    object.__setattr__(gf, "__wrapped__", f)
-    return gf
+        return StaticGenerativeFunction[R](closure)
 
 
 ###########

--- a/tests/generative_functions/test_static_gen_fn.py
+++ b/tests/generative_functions/test_static_gen_fn.py
@@ -35,6 +35,53 @@ from genjax.typing import Float, FloatArray
 ##################################
 
 
+class TestStaticGenFnMetadata:
+    def test_docstring_transfer(self):
+        def original_function(x: float, y: float) -> float:
+            """
+            This is a test function that adds two numbers.
+
+            Args:
+                x (float): The first number
+                y (float): The second number
+
+            Returns:
+                float: The sum of x and y
+            """
+            return x + y
+
+        wrapped_function = genjax.gen(original_function)
+
+        assert wrapped_function.__doc__ == original_function.__doc__
+        assert wrapped_function.__name__ == original_function.__name__
+        assert wrapped_function.__module__ == original_function.__module__
+        assert wrapped_function.__qualname__ == original_function.__qualname__
+        assert getattr(wrapped_function, "__wrapped__") == original_function
+
+    def test_docstring_transfer_with_annotations(self):
+        @genjax.gen
+        def annotated_function(x: float, y: float) -> float:
+            """
+            This is an annotated test function that multiplies two numbers.
+
+            Args:
+                x (float): The first number
+                y (float): The second number
+
+            Returns:
+                float: The product of x and y
+            """
+            return x * y
+
+        assert annotated_function.__doc__ is not None
+        assert "This is an annotated test function" in annotated_function.__doc__
+        assert annotated_function.__annotations__ == {
+            "x": float,
+            "y": float,
+            "return": float,
+        }
+
+
 class TestStaticGenFnSimulate:
     def test_simulate_with_no_choices(self):
         @genjax.gen


### PR DESCRIPTION
This PR closes #480 by copying metadata over.

Given

```python
@genjax.gen
def adder(x: float, y: float) -> float:
    """
    This is a test function that adds two numbers.

    Args:
        x (float): The first number
        y (float): The second number

    Returns:
        float: The sum of x and y
    """
    return x + y
```

We now get

```python
help(adder)

Help on StaticGenerativeFunction in module __main__:

adder = adder
    This is a test function that adds two numbers.

    Args:
        x (float): The first number
        y (float): The second number

    Returns:
        float: The sum of x and y
```

vs the docs for `StaticGenerativeFunction`.