### PR TITLE
Annotate ignored types, add specific pyright ignores (GEN-512)

### DIFF
--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -343,13 +343,13 @@ class Trace(Generic[R], Pytree):
         This method calls out to the underlying [`GenerativeFunction.update`][genjax.core.GenerativeFunction.update] method - see [`UpdateProblem`][genjax.core.UpdateProblem] and [`update`][genjax.core.GenerativeFunction.update] for more information.
         """
         if isinstance(problem, GenericProblem) and argdiffs is None:
-            return self.get_gen_fn().update(key, self, problem)  # pyright: ignore
+            return self.get_gen_fn().update(key, self, problem)  # pyright: ignore[reportReturnType]
         else:
             return self.get_gen_fn().update(
                 key,
                 self,
                 GenericProblem(Diff.tree_diff_no_change(self.get_args()), problem),
-            )  # pyright: ignore
+            )  # pyright: ignore[reportReturnType]
 
     def project(
         self,
@@ -1600,7 +1600,7 @@ class GenerativeFunctionClosure(Generic[R], GenerativeFunction[R]):
 
     # This override returns `R`, while the superclass returns a `GenerativeFunctionClosure`; this is
     # a hint that subclassing may not be the right relationship here.
-    def __call__(self, key: PRNGKey, *args) -> R:  # pyright: ignore
+    def __call__(self, key: PRNGKey, *args) -> R:  # pyright: ignore[reportIncompatibleMethodOverride]
         full_args = (*self.args, *args)
         if self.kwargs:
             maybe_kwarged_gen_fn = self.get_gen_fn_with_kwargs()

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -42,6 +42,7 @@ FloatArray = jtyping.Float[jtyping.Array, "..."]
 BoolArray = jtyping.Bool[jtyping.Array, "..."]
 Callable = btyping.Callable
 Sequence = btyping.Sequence
+Generator = btyping.Generator
 
 # JAX Type alias.
 InAxes = int | None | Sequence[Any]
@@ -111,6 +112,7 @@ __all__ = [
     "EllipsisType",
     "Float",
     "FloatArray",
+    "Generator",
     "Generic",
     "InAxes",
     "Int",


### PR DESCRIPTION
This PR fixes our blanket `pyright: ignore` directives in favor of

- adding explicit directives to ignore
- for the `staging` and `forward` ignores, adding back types that were obscured by jax's use of `@partial`.