### PR TITLE
Remove reverse, unroll flags from scan and friends (GEN-404)

### DIFF
--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -861,8 +861,6 @@ class GenerativeFunction(Generic[R], Pytree):
         /,
         *,
         n: Int | None = None,
-        reverse: bool = False,
-        unroll: int | bool = 1,
     ) -> "GenerativeFunction[tuple[Carry, Y]]":
         """
         When called on a [`genjax.GenerativeFunction`][] of type `(c, a) -> (c, b)`, returns a new [`genjax.GenerativeFunction`][] of type `(c, [a]) -> (c, [b])` where
@@ -895,10 +893,6 @@ class GenerativeFunction(Generic[R], Pytree):
 
         Args:
             n: optional integer specifying the number of loop iterations, which (if supplied) must agree with the sizes of leading axes of the arrays in the returned function's second argument. If supplied then the returned generative function can take `None` as its second argument.
-
-            reverse: optional boolean specifying whether to run the scan iteration forward (the default) or in reverse, equivalent to reversing the leading axes of the arrays in both `xs` and in `ys`.
-
-            unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many scan iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
 
         Returns:
             A new [`genjax.GenerativeFunction`][] that takes a loop-carried value and a new input, and returns a new loop-carried value along with either `None` or an output to be collected into the second return value.
@@ -949,11 +943,9 @@ class GenerativeFunction(Generic[R], Pytree):
         """
         import genjax
 
-        return genjax.scan(n=n, reverse=reverse, unroll=unroll)(self)
+        return genjax.scan(n=n)(self)
 
-    def accumulate(
-        self, /, *, reverse: bool = False, unroll: int | bool = 1
-    ) -> "GenerativeFunction[R]":
+    def accumulate(self) -> "GenerativeFunction[R]":
         """
         When called on a [`genjax.GenerativeFunction`][] of type `(c, a) -> c`, returns a new [`genjax.GenerativeFunction`][] of type `(c, [a]) -> [c]` where
 
@@ -981,11 +973,6 @@ class GenerativeFunction(Generic[R], Pytree):
 
         The loop-carried value `c` must hold a fixed shape and dtype across all iterations (and not just be consistent up to NumPy rank/shape broadcasting and dtype promotion rules, for example). In other words, the type `c` in the type signature above represents an array with a fixed shape and dtype (or a nested tuple/list/dict container data structure with a fixed structure and arrays with fixed shape and dtype at the leaves).
 
-        Args:
-            reverse: optional boolean specifying whether to run the accumulation forward (the default) or in reverse, equivalent to reversing the leading axes of the arrays in both `xs` and in `carries`.
-
-            unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
-
         Examples:
             ```python exec="yes" html="true" source="material-block" session="scan"
             import jax
@@ -1010,11 +997,9 @@ class GenerativeFunction(Generic[R], Pytree):
         """
         import genjax
 
-        return genjax.accumulate(reverse=reverse, unroll=unroll)(self)
+        return genjax.accumulate()(self)
 
-    def reduce(
-        self, /, *, reverse: bool = False, unroll: int | bool = 1
-    ) -> "GenerativeFunction[R]":
+    def reduce(self) -> "GenerativeFunction[R]":
         """
         When called on a [`genjax.GenerativeFunction`][] of type `(c, a) -> c`, returns a new [`genjax.GenerativeFunction`][] of type `(c, [a]) -> c` where
 
@@ -1038,11 +1023,6 @@ class GenerativeFunction(Generic[R], Pytree):
         Unlike that Python version, both `xs` and `carry` may be arbitrary pytree values, and so multiple arrays can be scanned over at once and produce multiple output arrays.
 
         The loop-carried value `c` must hold a fixed shape and dtype across all iterations (and not just be consistent up to NumPy rank/shape broadcasting and dtype promotion rules, for example). In other words, the type `c` in the type signature above represents an array with a fixed shape and dtype (or a nested tuple/list/dict container data structure with a fixed structure and arrays with fixed shape and dtype at the leaves).
-
-        Args:
-            reverse: optional boolean specifying whether to run the accumulation forward (the default) or in reverse, equivalent to reversing the leading axis of the array `xs`.
-
-            unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
 
         Examples:
             sum an array of numbers:
@@ -1069,9 +1049,9 @@ class GenerativeFunction(Generic[R], Pytree):
         """
         import genjax
 
-        return genjax.reduce(reverse=reverse, unroll=unroll)(self)
+        return genjax.reduce()(self)
 
-    def iterate(self, /, *, n: Int, unroll: int | bool = 1) -> "GenerativeFunction[R]":
+    def iterate(self, /, *, n: Int) -> "GenerativeFunction[R]":
         """
         When called on a [`genjax.GenerativeFunction`][] of type `a -> a`, returns a new [`genjax.GenerativeFunction`][] of type `a -> [a]` where
 
@@ -1099,8 +1079,6 @@ class GenerativeFunction(Generic[R], Pytree):
         Args:
             n: the number of iterations to run.
 
-            unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
-
         Examples:
             iterative addition, returning all intermediate sums:
             ```python exec="yes" html="true" source="material-block" session="scan"
@@ -1123,11 +1101,9 @@ class GenerativeFunction(Generic[R], Pytree):
         """
         import genjax
 
-        return genjax.iterate(n=n, unroll=unroll)(self)
+        return genjax.iterate(n=n)(self)
 
-    def iterate_final(
-        self, /, *, n: Int, unroll: int | bool = 1
-    ) -> "GenerativeFunction[R]":
+    def iterate_final(self, /, *, n: Int) -> "GenerativeFunction[R]":
         """
         Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type `a -> a` and returns a new [`genjax.GenerativeFunction`][] of type `a -> a` where
 
@@ -1153,8 +1129,6 @@ class GenerativeFunction(Generic[R], Pytree):
             Args:
                 n: the number of iterations to run.
 
-            unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
-
         Examples:
             iterative addition:
             ```python exec="yes" html="true" source="material-block" session="scan"
@@ -1177,7 +1151,7 @@ class GenerativeFunction(Generic[R], Pytree):
         """
         import genjax
 
-        return genjax.iterate_final(n=n, unroll=unroll)(self)
+        return genjax.iterate_final(n=n)(self)
 
     def mask(self, /) -> "GenerativeFunction[genjax.Mask[R]]":
         """

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -128,10 +128,6 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
 
         length: optional integer specifying the number of loop iterations, which (if supplied) must agree with the sizes of leading axes of the arrays in the returned function's second argument. If supplied then the returned generative function can take `None` as its second argument.
 
-        reverse: optional boolean specifying whether to run the scan iteration forward (the default) or in reverse, equivalent to reversing the leading axes of the arrays in both `xs` and in `ys`.
-
-        unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many scan iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
-
     Examples:
         Use the [`genjax.GenerativeFunction.scan`][] method:
         ```python exec="yes" html="true" source="material-block" session="scan"
@@ -173,8 +169,6 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
 
     # Only required for `None` carry inputs
     length: Int | None = Pytree.static()
-    reverse: bool = Pytree.static(default=False)
-    unroll: int | bool = Pytree.static(default=1)
 
     # To get the type of return value, just invoke
     # the scanned over source (with abstract tracer arguments).
@@ -185,14 +179,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
             v, scanned_out = self.kernel_gen_fn.__abstract_call__(carry, scanned_in)
             return v, scanned_out
 
-        v, scanned_out = jax.lax.scan(
-            _inner,
-            carry,
-            scanned_in,
-            length=self.length,
-            reverse=self.reverse,
-            unroll=self.unroll,
-        )
+        v, scanned_out = jax.lax.scan(_inner, carry, scanned_in, length=self.length)
 
         return v, scanned_out
 
@@ -229,8 +216,6 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
             (key, jnp.asarray(0), carry),
             scanned_in,
             length=self.length,
-            reverse=self.reverse,
-            unroll=self.unroll,
         )
 
         return ScanTrace(
@@ -287,8 +272,6 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
             (key, jnp.asarray(0), carry),
             scanned_in,
             length=self.length,
-            reverse=self.reverse,
-            unroll=self.unroll,
         )
         return (
             ScanTrace[Carry, Y](
@@ -397,8 +380,6 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
             (key, jnp.asarray(0), carry_diff),
             (trace.inner, *scanned_in_diff),
             length=self.length,
-            reverse=self.reverse,
-            unroll=self.unroll,
         )
         carried_out, scanned_out = Diff.tree_primal((
             carried_out_diff,
@@ -540,8 +521,6 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
             (0, carry),
             scanned_in,
             length=self.length,
-            reverse=self.reverse,
-            unroll=self.unroll,
         )
         return (
             jnp.sum(scores),
@@ -555,7 +534,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
 
 
 def scan(
-    *, n: Int | None = None, reverse: bool = False, unroll: int | bool = 1
+    *, n: Int | None = None
 ) -> Callable[
     [GenerativeFunction[tuple[Carry, Y]]], GenerativeFunction[tuple[Carry, Y]]
 ]:
@@ -591,10 +570,6 @@ def scan(
 
     Args:
         n: optional integer specifying the number of loop iterations, which (if supplied) must agree with the sizes of leading axes of the arrays in the returned function's second argument. If supplied then the returned generative function can take `None` as its second argument.
-
-        reverse: optional boolean specifying whether to run the scan iteration forward (the default) or in reverse, equivalent to reversing the leading axes of the arrays in both `xs` and in `ys`.
-
-        unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many scan iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
 
     Returns:
         A new [`genjax.GenerativeFunction`][] that takes a loop-carried value and a new input, and returns a new loop-carried value along with either `None` or an output to be collected into the second return value.
@@ -643,7 +618,7 @@ def scan(
     """
 
     def decorator(f: GenerativeFunction[tuple[Carry, Y]]):
-        return ScanCombinator[Carry, Y](f, length=n, reverse=reverse, unroll=unroll)
+        return ScanCombinator[Carry, Y](f, length=n)
 
     return decorator
 
@@ -675,9 +650,7 @@ def prepend_initial_acc(args: tuple[Carry, Any], ret: tuple[Carry, Carry]) -> Ca
     return jax.tree.map(cat, init_acc, xs)
 
 
-def accumulate(
-    *, reverse: bool = False, unroll: int | bool = 1
-) -> Callable[[GenerativeFunction[Carry]], GenerativeFunction[Carry]]:
+def accumulate() -> Callable[[GenerativeFunction[Carry]], GenerativeFunction[Carry]]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `(c, a) -> c` and returns a new [`genjax.GenerativeFunction`][] of type
     `(c, [a]) -> [c]` where.
@@ -706,11 +679,6 @@ def accumulate(
 
     The loop-carried value `c` must hold a fixed shape and dtype across all iterations (and not just be consistent up to NumPy rank/shape broadcasting and dtype promotion rules, for example). In other words, the type `c` in the type signature above represents an array with a fixed shape and dtype (or a nested tuple/list/dict container data structure with a fixed structure and arrays with fixed shape and dtype at the leaves).
 
-    Args:
-        reverse: optional boolean specifying whether to run the accumulation forward (the default) or in reverse, equivalent to reversing the leading axes of the arrays in both `xs` and in `carries`.
-
-        unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
-
     Examples:
         accumulate a running total:
         ```python exec="yes" html="true" source="material-block" session="scan"
@@ -738,16 +706,14 @@ def accumulate(
     def decorator(f: GenerativeFunction[Carry]) -> GenerativeFunction[Carry]:
         return (
             f.map(lambda ret: (ret, ret))
-            .scan(reverse=reverse, unroll=unroll)
+            .scan()
             .dimap(pre=lambda *args: args, post=prepend_initial_acc)
         )
 
     return decorator
 
 
-def reduce(
-    *, reverse: bool = False, unroll: int | bool = 1
-) -> Callable[[GenerativeFunction[Carry]], GenerativeFunction[Carry]]:
+def reduce() -> Callable[[GenerativeFunction[Carry]], GenerativeFunction[Carry]]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `(c, a) -> c` and returns a new [`genjax.GenerativeFunction`][] of type
     `(c, [a]) -> c` where.
@@ -772,11 +738,6 @@ def reduce(
     Unlike that Python version, both `xs` and `carry` may be arbitrary pytree values, and so multiple arrays can be scanned over at once and produce multiple output arrays.
 
     The loop-carried value `c` must hold a fixed shape and dtype across all iterations (and not just be consistent up to NumPy rank/shape broadcasting and dtype promotion rules, for example). In other words, the type `c` in the type signature above represents an array with a fixed shape and dtype (or a nested tuple/list/dict container data structure with a fixed structure and arrays with fixed shape and dtype at the leaves).
-
-    Args:
-        reverse: optional boolean specifying whether to run the accumulation forward (the default) or in reverse, equivalent to reversing the leading axis of the array `xs`.
-
-        unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
 
     Examples:
         sum an array of numbers:
@@ -809,14 +770,12 @@ def reduce(
         def post(ret: tuple[Carry, None]):
             return ret[0]
 
-        return f.map(pre).scan(reverse=reverse, unroll=unroll).map(post)
+        return f.map(pre).scan().map(post)
 
     return decorator
 
 
-def iterate(
-    *, n: Int, unroll: int | bool = 1
-) -> Callable[[GenerativeFunction[Y]], GenerativeFunction[Y]]:
+def iterate(*, n: Int) -> Callable[[GenerativeFunction[Y]], GenerativeFunction[Y]]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `a -> a` and returns a new [`genjax.GenerativeFunction`][] of type `a ->
     [a]` where.
@@ -845,8 +804,6 @@ def iterate(
     Args:
         n: the number of iterations to run.
 
-        unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
-
     Examples:
         iterative addition, returning all intermediate sums:
         ```python exec="yes" html="true" source="material-block" session="scan"
@@ -872,7 +829,7 @@ def iterate(
         # strip off the JAX-supplied `None` on the way in, accumulate `ret` on the way out.
         return (
             f.dimap(pre=lambda *args: args[:-1], post=lambda _, ret: (ret, ret))
-            .scan(n=n, unroll=unroll)
+            .scan(n=n)
             .dimap(pre=lambda *args: (*args, None), post=prepend_initial_acc)
         )
 
@@ -880,7 +837,7 @@ def iterate(
 
 
 def iterate_final(
-    *, n: Int, unroll: int | bool = 1
+    *, n: Int
 ) -> Callable[[GenerativeFunction[Y]], GenerativeFunction[Y]]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `a -> a` and returns a new [`genjax.GenerativeFunction`][] of type `a -> a`
@@ -907,8 +864,6 @@ def iterate_final(
 
     Args:
         n: the number of iterations to run.
-
-        unroll: optional positive int or bool specifying, in the underlying operation of the scan primitive, how many iterations to unroll within a single iteration of a loop. If an integer is provided, it determines how many unrolled loop iterations to run within a single rolled iteration of the loop. If a boolean is provided, it will determine if the loop is competely unrolled (i.e. `unroll=True`) or left completely unrolled (i.e. `unroll=False`).
 
     Examples:
         iterative addition:
@@ -941,7 +896,7 @@ def iterate_final(
 
         return (
             f.dimap(pre=lambda *args: args[:-1], post=pre_post)
-            .scan(n=n, unroll=unroll)
+            .scan(n=n)
             .dimap(pre=lambda *args: (*args, None), post=post_post)
         )
 


### PR DESCRIPTION
This PR removes the reverse and unroll options that currently flow through to `jax.lax.scan`. @femtomc and I did some investigation and found that the behavior here is weird enough that we don't want to take on interpreting it, given that no one yet wants this and no one is using it!

`reverse=True` reverses the input sequence, but ALSO reverses the accumulated output. The confusion here is, what do the indices mean in the ChoiceMap?

If we do take on support of `reverse`, we should copy the `keep_order` argument here and re-reverse the accumulated outputs: https://flax.readthedocs.io/en/latest/_modules/flax/linen/recurrent.html#RNN In 

Properly supporting reverse means explaining to the users that we are walking from right to left on the input array, and telling a good story about what indices in the choicemap refer to what entries in the output.