### PR TITLE
Use `pass` vs `UnimplementedError` for abstract methods

### DIFF
--- a/src/genjax/_src/adev/core.py
+++ b/src/genjax/_src/adev/core.py
@@ -61,8 +61,8 @@ class ADEVPrimitive(Pytree):
     """
 
     @abstractmethod
-    def sample(self, key, *args):
-        raise NotImplementedError
+    def sample(self, key, *args) -> Any:
+        pass
 
     @abstractmethod
     def jvp_estimate(
@@ -73,7 +73,7 @@ class ADEVPrimitive(Pytree):
     ) -> "Dual":
         pass
 
-    def get_batched_prim(self, dims: tuple[Any, ...]):
+    def get_batched_prim(self, dims: tuple[Any, ...]) -> "ADEVPrimitive":
         """
         To use ADEV primitives inside of `vmap`, they must provide a custom batched primitive version of themselves.
 
@@ -92,7 +92,7 @@ class TailCallADEVPrimitive(ADEVPrimitive):
         key: PRNGKey,
         dual_tree: DualTree,  # Pytree with Dual leaves.
     ) -> "Dual":
-        raise NotImplementedError
+        pass
 
     def jvp_estimate(
         self,

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -318,11 +318,11 @@ class Selection(Projection["ChoiceMap"]):
 
     @abstractmethod
     def check(self) -> Flag:
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def get_subselection(self, addr: ExtendedAddressComponent) -> "Selection":
-        raise NotImplementedError
+        pass
 
 
 #######################
@@ -776,14 +776,14 @@ class ChoiceMap(Sample):
 
     @abstractmethod
     def get_value(self) -> Any:
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def get_submap(
         self,
         addr: ExtendedAddressComponent,
     ) -> "ChoiceMap":
-        raise NotImplementedError
+        pass
 
     def has_value(self) -> Flag:
         match self.get_value():
@@ -965,7 +965,7 @@ class ChoiceMap(Sample):
             A ChoiceMap containing the key-value pairs from the input keyword arguments.
 
         Example:
-            ```python
+            ```python exec="yes" html="true" source="material-block" session="choicemap"
             kw_chm = ChoiceMap.kw(x=42, y=[1, 2, 3], z={"w": 10.0})
             assert kw_chm["x"] == 42
             assert kw_chm["y"] == [1, 2, 3]
@@ -973,6 +973,41 @@ class ChoiceMap(Sample):
             ```
         """
         return ChoiceMap.d(kwargs)
+
+    @staticmethod
+    def switch(idx: ArrayLike, chms: Iterable["ChoiceMap"]) -> "ChoiceMap":
+        """
+        Creates a ChoiceMap that switches between multiple ChoiceMaps based on an index.
+
+        This method creates a new ChoiceMap that selectively includes values from a sequence of
+        input ChoiceMaps based on the provided index. The resulting ChoiceMap will contain
+        values from the ChoiceMap at the position specified by the index, while masking out
+        values from all other ChoiceMaps.
+
+        Args:
+            idx: An index or array of indices specifying which ChoiceMap(s) to select from.
+            chms: An iterable of ChoiceMaps to switch between.
+
+        Returns:
+            A new ChoiceMap containing values from the selected ChoiceMap(s).
+
+        Example:
+            ```python exec="yes" html="true" source="material-block" session="choicemap"
+            chm1 = ChoiceMap.d({"x": 1, "y": 2})
+            chm2 = ChoiceMap.d({"x": 3, "y": 4})
+            chm3 = ChoiceMap.d({"x": 5, "y": 6})
+
+            switched = ChoiceMap.switch(1, [chm1, chm2, chm3])
+            assert switched["x"] == 3
+            assert switched["y"] == 4
+            ```
+        """
+        acc = ChoiceMap.empty()
+        for _idx, _chm in enumerate(chms):
+            assert isinstance(_chm, ChoiceMap)
+            masked = _chm.mask(_idx == idx)
+            acc ^= masked
+        return acc
 
     ######################
     # Combinator methods #

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -143,11 +143,11 @@ class MaskedConstraint(Constraint):
 class Projection(Generic[S], Pytree):
     @abstractmethod
     def filter(self, sample: S) -> S:
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def complement(self) -> "Projection[S]":
-        raise NotImplementedError
+        pass
 
 
 #########################

--- a/src/genjax/_src/core/generative/generative_function.py
+++ b/src/genjax/_src/core/generative/generative_function.py
@@ -141,15 +141,15 @@ class Trace(Generic[R], Pytree):
     def get_sample(self) -> Sample:
         """Return the [`Sample`][genjax.core.Sample] sampled from the distribution over samples by the generative function during the invocation which created the [`Trace`][genjax.core.Trace]."""
 
-    # TODO: deprecated.
+    @abstractmethod
     def get_choices(self) -> "genjax.ChoiceMap":
         """Version of [`genjax.Trace.get_sample`][] for traces where the sample is an instance of [`genjax.ChoiceMap`][]."""
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def get_gen_fn(self) -> "GenerativeFunction[R]":
         """Returns the [`GenerativeFunction`][genjax.core.GenerativeFunction] whose invocation created the [`Trace`][genjax.core.Trace]."""
-        raise NotImplementedError
+        pass
 
     def edit(
         self,
@@ -337,7 +337,7 @@ class GenerativeFunction(Generic[R], Pytree):
             print(tr.render_html())
             ```
         """
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def assess(
@@ -380,7 +380,7 @@ class GenerativeFunction(Generic[R], Pytree):
             print((score, retval))
             ```
         """
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def generate(
@@ -389,7 +389,7 @@ class GenerativeFunction(Generic[R], Pytree):
         constraint: Constraint,
         args: Arguments,
     ) -> tuple[Trace[R], Weight]:
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def project(
@@ -398,7 +398,7 @@ class GenerativeFunction(Generic[R], Pytree):
         trace: Trace[R],
         projection: Projection[Any],
     ) -> Weight:
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def edit(
@@ -514,7 +514,7 @@ class GenerativeFunction(Generic[R], Pytree):
 
         Argument changes induce changes to the distribution over samples, internal K and L proposals, and (by virtue of changes to $P$) target distributions. The [`Argdiffs`][genjax.core.Argdiffs] type denotes the type of values attached with a _change type_, a piece of data which indicates how the value has changed from the arguments which created the trace. Generative functions can utilize change type information to inform efficient [`edit`][genjax.core.GenerativeFunction.edit] implementations.
         """
-        raise NotImplementedError
+        pass
 
     ######################
     # Derived interfaces #

--- a/src/genjax/_src/generative_functions/distributions/distribution.py
+++ b/src/genjax/_src/generative_functions/distributions/distribution.py
@@ -348,11 +348,11 @@ class Distribution(Generic[R], GenerativeFunction[R]):
 class ExactDensity(Generic[R], Distribution[R]):
     @abstractmethod
     def sample(self, key: PRNGKey, *args) -> R:
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def logpdf(self, v: R, *args) -> Score:
-        raise NotImplementedError
+        pass
 
     def __abstract_call__(self, *args):
         key = jax.random.PRNGKey(0)

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -203,7 +203,7 @@ class StaticHandler(StatefulHandler):
         gen_fn: GenerativeFunction[R],
         args: tuple[Any, ...],
     ):
-        raise NotImplementedError
+        pass
 
     def handle_retval(self, v):
         return jtu.tree_leaves(v)

--- a/src/genjax/_src/inference/smc.py
+++ b/src/genjax/_src/inference/smc.py
@@ -119,19 +119,19 @@ class SMCAlgorithm(Generic[R], Algorithm[R]):
     """Abstract class for SMC algorithms."""
 
     @abstractmethod
-    def get_num_particles(self):
-        raise NotImplementedError
+    def get_num_particles(self) -> int:
+        pass
 
     @abstractmethod
-    def get_final_target(self):
-        raise NotImplementedError
+    def get_final_target(self) -> Target[R]:
+        pass
 
     @abstractmethod
     def run_smc(
         self,
         key: PRNGKey,
     ) -> ParticleCollection[R]:
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def run_csmc(
@@ -139,7 +139,7 @@ class SMCAlgorithm(Generic[R], Algorithm[R]):
         key: PRNGKey,
         retained: ChoiceMap,
     ) -> ParticleCollection[R]:
-        raise NotImplementedError
+        pass
 
     # Convenience method for returning an estimate of the normalizing constant
     # of the target.


### PR DESCRIPTION
This lets us find the actual unimplemented methods that we need to fill in.