### PR TITLE
Static ChoiceMap shape validation, `vmap` and `scan` validation upgrades (GEN-418, GEN-83)

### DIFF
--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -27,7 +27,10 @@ from deprecated import deprecated
 from genjax._src.core.generative.core import Constraint, Projection, Sample
 from genjax._src.core.generative.functional_types import Mask, staged_choose
 from genjax._src.core.interpreters import staging
-from genjax._src.core.interpreters.staging import FlagOp, staged_err
+from genjax._src.core.interpreters.staging import (
+    FlagOp,
+    staged_err,
+)
 from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
     Any,
@@ -1021,7 +1024,9 @@ class ChoiceMap(Sample):
         return ChoiceMap.d(kwargs)
 
     @staticmethod
-    def switch(idx: ArrayLike, chms: Iterable["ChoiceMap"]) -> "ChoiceMap":
+    def switch(
+        idx: ArrayLike | jax.ShapeDtypeStruct, chms: Iterable["ChoiceMap"]
+    ) -> "ChoiceMap":
         """
         Creates a ChoiceMap that switches between multiple ChoiceMaps based on an index.
 
@@ -1051,7 +1056,7 @@ class ChoiceMap(Sample):
         acc = ChoiceMap.empty()
         for _idx, _chm in enumerate(chms):
             assert isinstance(_chm, ChoiceMap)
-            masked = _chm.mask(_idx == idx)
+            masked = _chm.mask(jnp.all(_idx == idx))
             acc ^= masked
         return acc
 

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -1268,6 +1268,8 @@ class ChoiceMap(Sample):
 
         Example:
             ```python exec="yes" html="true" source="material-block" session="choicemap"
+            from genjax import ChoiceMap
+
             chm = ChoiceMap.d({("x", "y"): 3.0, "z": 12.0})
             updated = chm.at["x", "y"].set(4.0)
 

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -1291,24 +1291,23 @@ class ChoiceMap(Sample):
         """
         return _pushdown_filters(self)
 
-    def validate(
+    def invalid_subset(
         self,
         gen_fn: "genjax.GenerativeFunction[Any]",
         args: tuple[Any, ...],
     ) -> "ChoiceMap | None":
         """
-        Validates the choice map against a generative function and its arguments.
+        Identifies the subset of choices that are invalid for a given generative function and its arguments.
 
         This method checks if all choices in the current ChoiceMap are valid for the given
-        generative function and its arguments. It identifies any extra choices that are not
-        possible in the function's trace.
+        generative function and its arguments.
 
         Args:
-            gen_fn: The generative function to validate against.
+            gen_fn: The generative function to check against.
             args: The arguments to the generative function.
 
         Returns:
-            A ChoiceMap containing any extra choices not possible in the function's trace, or None if no extra choices are found.
+            A ChoiceMap containing any extra choices not reachable in the course of `gen_fn`'s execution, or None if no extra choices are found.
 
         Example:
             ```python exec="yes" html="true" source="material-block" session="choicemap"
@@ -1319,7 +1318,7 @@ class ChoiceMap(Sample):
 
 
             chm = ChoiceMap.d({"y": 1, "z": 2})
-            extras = chm.validate(model, (1,))
+            extras = chm.invalid_subset(model, (1,))
             assert "z" in extras  # "z" is an extra choice not in the model
             ```
         """

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -1049,8 +1049,8 @@ class ChoiceMap(Sample):
             chm3 = ChoiceMap.d({"x": 5, "y": 6})
 
             switched = ChoiceMap.switch(1, [chm1, chm2, chm3])
-            assert switched["x"] == 3
-            assert switched["y"] == 4
+            assert switched["x"].unmask() == 3
+            assert switched["y"].unmask() == 4
             ```
         """
         acc = ChoiceMap.empty()

--- a/src/genjax/_src/core/generative/functional_types.py
+++ b/src/genjax/_src/core/generative/functional_types.py
@@ -157,7 +157,7 @@ def staged_choose(
         The selected value from the list.
     """
 
-    def inner(*vs):
+    def inner(*vs: ArrayLike) -> ArrayLike:
         # Computing `result` above the branch allows us to:
         # - catch incompatible types / shapes in the result
         # - in the case of compatible types requiring casts (like bool => int),

--- a/src/genjax/_src/core/generative/functional_types.py
+++ b/src/genjax/_src/core/generative/functional_types.py
@@ -157,7 +157,7 @@ def staged_choose(
         The selected value from the list.
     """
 
-    def inner(*vs: ArrayLike) -> ArrayLike:
+    def inner(*vs):
         # Computing `result` above the branch allows us to:
         # - catch incompatible types / shapes in the result
         # - in the case of compatible types requiring casts (like bool => int),

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -176,8 +176,8 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
         return v, scanned_out
 
     @staticmethod
-    def _static_broadcast_dim_length(xs: Any, length: int | None) -> int:
-        # We start by triggering a scan to force all JAX validations to run. If we get past this line we know we have compatible dimensions.
+    def _static_scan_length(xs: Any, length: int | None) -> int:
+        # We start by triggering a scan to force all JAX validations to run.
         jax.lax.scan(lambda c, x: (c, None), None, xs, length=length)
         return length or jtu.tree_leaves(xs)[0].shape[0]
 
@@ -222,7 +222,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
             args,
             (carried_out, scanned_out),
             jnp.sum(scores),
-            self._static_broadcast_dim_length(scanned_in, self.length),
+            self._static_scan_length(scanned_in, self.length),
         )
 
     def generate(
@@ -279,7 +279,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
                 args,
                 (carried_out, scanned_out),
                 jnp.sum(scores),
-                self._static_broadcast_dim_length(scanned_in, self.length),
+                self._static_scan_length(scanned_in, self.length),
             ),
             jnp.sum(ws),
         )

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -64,9 +64,7 @@ class ScanTrace(Generic[Carry, Y], Trace[tuple[Carry, Y]]):
         return self.retval
 
     def get_choices(self) -> ChoiceMap:
-        return jax.vmap(
-            lambda idx, subtrace: ChoiceMap.entry(subtrace.get_choices(), idx),
-        )(jnp.arange(self.scan_length), self.inner)
+        return self.inner.get_choices().extend(jnp.arange(self.scan_length))
 
     def get_sample(self) -> ChoiceMap:
         return self.get_choices()

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -19,6 +19,7 @@ This vectorization is implemented using `jax.vmap`, and the combinator expects t
 
 import jax
 import jax.numpy as jnp
+import jax.tree_util as jtu
 
 from genjax._src.core.generative import (
     Argdiffs,
@@ -40,7 +41,6 @@ from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
     Any,
     Callable,
-    FloatArray,
     Generic,
     InAxes,
     PRNGKey,
@@ -52,14 +52,13 @@ class VmapTrace(Generic[R], Trace[R]):
     gen_fn: GenerativeFunction[R]
     inner: Trace[R]
     args: tuple[Any, ...]
-    retval: R
-    score: FloatArray
+    broadcast_dim_length: int = Pytree.static()
 
     def get_args(self) -> tuple[Any, ...]:
         return self.args
 
     def get_retval(self):
-        return self.retval
+        return self.inner.get_retval()
 
     def get_gen_fn(self):
         return self.gen_fn
@@ -71,12 +70,12 @@ class VmapTrace(Generic[R], Trace[R]):
         return jax.vmap(
             lambda idx, subtrace: ChoiceMap.entry(subtrace.get_choices(), idx)
         )(
-            jnp.arange(len(self.inner.get_score())),
+            jnp.arange(self.broadcast_dim_length),
             self.inner,
         )
 
     def get_score(self):
-        return self.score
+        return jnp.sum(self.inner.get_score())
 
 
 @Pytree.dataclass
@@ -137,49 +136,37 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
 
         return jax.vmap(inner, in_axes=self.in_axes)(*args)
 
-    def _static_check_broadcastable(self, args: tuple[Any, ...]) -> None:
-        # Argument broadcast semantics must be fully specified
-        # in `in_axes`.
-        if self.in_axes is not None:
-            axes_length = 1 if isinstance(self.in_axes, int) else len(self.in_axes)
-            if not len(args) == axes_length:
-                raise Exception(
-                    f"VmapCombinator requires that length of the provided in_axes kwarg match the number of arguments provided to the invocation.\nA mismatch occured with len(args) = {len(args)} and len(self.in_axes) = {axes_length}"
-                )
+    @staticmethod
+    def _static_broadcast_dim_length(in_axes: InAxes, args: tuple[Any, ...]) -> int:
+        # We start by triggering a vmap to force all JAX validations to run. If we get past this line we know we have compatible dimensions.
+        jax.vmap(lambda *_: None, in_axes=in_axes)(*args)
 
-    def _static_broadcast_dim_length(self, args):
-        def find_axis_size(axis, x):
-            if axis is not None:
-                leaves = jax.tree_util.tree_leaves(x)
-                if leaves:
-                    return leaves[0].shape[axis]
-            return ()
+        if isinstance(in_axes, int):
+            in_axes = (in_axes,) * len(args)
+        elif isinstance(in_axes, list):
+            in_axes = tuple(in_axes)
+
+        def find_axis_size(axis, x) -> int | None:
+            if axis is not None and x is not None:
+                return x.shape[axis]
 
         axis_sizes = jax.tree_util.tree_map(
-            lambda x, y: None if x is None else find_axis_size(x, y),
-            self.in_axes,
+            find_axis_size,
+            in_axes,
             args,
             is_leaf=lambda x: x is None,
         )
-        axis_sizes = set(jax.tree_util.tree_leaves(axis_sizes))
-        if len(axis_sizes) == 1:
-            (d_axis_size,) = axis_sizes
-        else:
-            raise ValueError(f"Inconsistent batch axis sizes: {axis_sizes}")
-        return d_axis_size
+        return jtu.tree_leaves(axis_sizes)[0]
 
     def simulate(
         self,
         key: PRNGKey,
         args: tuple[Any, ...],
     ) -> VmapTrace[R]:
-        self._static_check_broadcastable(args)
-        broadcast_dim_length = self._static_broadcast_dim_length(args)
+        broadcast_dim_length = self._static_broadcast_dim_length(self.in_axes, args)
         sub_keys = jax.random.split(key, broadcast_dim_length)
         tr = jax.vmap(self.gen_fn.simulate, (0, self.in_axes))(sub_keys, args)
-        retval = tr.get_retval()
-        scores = tr.get_score()
-        map_tr = VmapTrace(self, tr, args, retval, jnp.sum(scores))
+        map_tr = VmapTrace(self, tr, args, broadcast_dim_length)
         return map_tr
 
     def generate(
@@ -189,12 +176,11 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         args: tuple[Any, ...],
     ) -> tuple[VmapTrace[R], Weight]:
         assert isinstance(constraint, ChoiceMapConstraint)
-        self._static_check_broadcastable(args)
-        broadcast_dim_length = self._static_broadcast_dim_length(args)
+        broadcast_dim_length = self._static_broadcast_dim_length(self.in_axes, args)
         idx_array = jnp.arange(0, broadcast_dim_length)
         sub_keys = jax.random.split(key, broadcast_dim_length)
 
-        def _importance(key, idx, choice_map, args):
+        def _generate(key, idx, choice_map, args):
             submap = choice_map(idx)
             tr, w = self.gen_fn.generate(
                 key,
@@ -203,13 +189,11 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
             )
             return tr, w
 
-        (tr, w) = jax.vmap(_importance, in_axes=(0, 0, None, self.in_axes))(
+        (tr, w) = jax.vmap(_generate, in_axes=(0, 0, None, self.in_axes))(
             sub_keys, idx_array, constraint, args
         )
         w = jnp.sum(w)
-        retval = tr.get_retval()
-        scores = tr.get_score()
-        map_tr = VmapTrace(self, tr, args, retval, jnp.sum(scores))
+        map_tr = VmapTrace(self, tr, args, broadcast_dim_length)
         return map_tr, w
 
     def project(
@@ -228,12 +212,11 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         argdiffs: Argdiffs,
     ) -> tuple[VmapTrace[R], Weight, Retdiff[R], EditRequest]:
         primals = Diff.tree_primal(argdiffs)
-        self._static_check_broadcastable(primals)
-        broadcast_dim_length = self._static_broadcast_dim_length(primals)
+        broadcast_dim_length = self._static_broadcast_dim_length(self.in_axes, primals)
         idx_array = jnp.arange(0, broadcast_dim_length)
         sub_keys = jax.random.split(key, broadcast_dim_length)
 
-        def _update(key, idx, subtrace, argdiffs):
+        def _edit(key, idx, subtrace, argdiffs):
             subconstraint = constraint(idx)
             assert isinstance(subconstraint, ChoiceMapConstraint), type(subconstraint)
             new_subtrace, w, retdiff, bwd_request = self.gen_fn.edit(
@@ -252,12 +235,10 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
             )
 
         new_subtraces, w, retdiff, bwd_constraints = jax.vmap(
-            _update, in_axes=(0, 0, 0, self.in_axes)
+            _edit, in_axes=(0, 0, 0, self.in_axes)
         )(sub_keys, idx_array, trace.inner, argdiffs)
         w = jnp.sum(w)
-        retval = new_subtraces.get_retval()
-        scores = new_subtraces.get_score()
-        map_tr = VmapTrace(self, new_subtraces, primals, retval, jnp.sum(scores))
+        map_tr = VmapTrace(self, new_subtraces, primals, broadcast_dim_length)
         return (
             map_tr,
             w,
@@ -288,8 +269,7 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         sample: ChoiceMap,
         args: tuple[Any, ...],
     ) -> tuple[Score, R]:
-        self._static_check_broadcastable(args)
-        broadcast_dim_length = self._static_broadcast_dim_length(args)
+        broadcast_dim_length = self._static_broadcast_dim_length(self.in_axes, args)
         idx_array = jnp.arange(0, broadcast_dim_length)
 
         def _assess(idx, args):

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -136,10 +136,6 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
 
         return jax.vmap(inner, in_axes=self.in_axes)(*args)
 
-    # TODO:
-    # - test that fails if the validations fail in various ways
-    # - test that the vmap works with different pytree depths
-    # - test that the vmap works with different pytree structures
     @staticmethod
     def _static_broadcast_dim_length(in_axes: InAxes, args: tuple[Any, ...]) -> int:
         # We start by triggering a vmap to force all JAX validations to run. If we get past this line we know we have compatible dimensions.
@@ -156,10 +152,9 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
             if axis is not None:
                 return x.shape[axis]
 
-        # tree_map uses in_axes as a template. To have passed vmap validation,
-        # Any non-None entry must bottom out in an array-shaped leaf,
-        # and all such leafs must have the same size for the specified
-        # dimension. Fetching the first is sufficient.
+        # tree_map uses in_axes as a template. To have passed vmap validation, Any non-None entry
+        # must bottom out in an array-shaped leaf, and all such leafs must have the same size for
+        # the specified dimension. Fetching the first is sufficient.
         axis_sizes = jax.tree_util.tree_map(
             find_axis_size,
             in_axes,

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -275,7 +275,7 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         args: tuple[Any, ...],
     ) -> tuple[Score, R]:
         broadcast_dim_length = self._static_broadcast_dim_length(self.in_axes, args)
-        idx_array = jnp.arange(0, broadcast_dim_length)
+        idx_array = jnp.arange(broadcast_dim_length)
 
         def _assess(idx, args):
             submap = sample(idx)

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -67,12 +67,7 @@ class VmapTrace(Generic[R], Trace[R]):
         return self.get_choices()
 
     def get_choices(self) -> ChoiceMap:
-        return jax.vmap(
-            lambda idx, subtrace: ChoiceMap.entry(subtrace.get_choices(), idx)
-        )(
-            jnp.arange(self.broadcast_dim_length),
-            self.inner,
-        )
+        return self.inner.get_choices().extend(jnp.arange(self.broadcast_dim_length))
 
     def get_score(self):
         return jnp.sum(self.inner.get_score())

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -67,6 +67,17 @@ class TestSelections:
         # none can't be extended
         assert Selection.none().extend("a", "b") == Selection.none()
 
+    def test_selection_leaf(self):
+        leaf_sel = Selection.leaf().extend("x", "y")
+        assert not leaf_sel["x"]
+        assert leaf_sel["x", "y"]
+
+        # only exact matches are allowed
+        assert not leaf_sel["x", "y", "z"]
+
+        # wildcards work
+        assert leaf_sel[..., "y"]
+
     def test_selection_complement(self):
         sel = S["x"] | S["y"]
         comp_sel = ~sel
@@ -105,6 +116,10 @@ class TestSelections:
         assert (none_sel & sel1) == none_sel
         assert (sel1 & none_sel) == none_sel
 
+        # idempotence
+        assert sel1 & sel1 == sel1
+        assert sel2 & sel2 == sel2
+
     def test_selection_or(self):
         sel1 = S["x"]
         sel2 = S["y"]
@@ -123,6 +138,10 @@ class TestSelections:
         none_sel = Selection.none()
         assert (none_sel | sel1) == sel1
         assert (sel1 | none_sel) == sel1
+
+        # idempotence
+        assert sel1 | sel1 == sel1
+        assert sel2 | sel2 == sel2
 
     def test_selection_mask(self):
         sel = S["x"] | S["y"]

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -15,6 +15,7 @@
 
 import jax
 import jax.numpy as jnp
+import jax.tree_util as jtu
 import pytest
 
 import genjax
@@ -700,3 +701,186 @@ class TestChoiceMap:
     def test_chm_roundtrip(self):
         chm = ChoiceMap.choice(3.0)
         assert chm == chm.__class__.from_attributes(**chm.attributes_dict())
+
+    def test_choicemap_validation(self):
+        @genjax.gen
+        def model(x):
+            y = genjax.normal(x, 1.0) @ "y"
+            z = genjax.bernoulli(0.5) @ "z"
+            return y + z
+
+        # Valid ChoiceMap
+        valid_chm = ChoiceMap.kw(y=1.0, z=1)
+        assert valid_chm.invalid_subset(model, (0.0,)) is None
+
+        # Invalid ChoiceMap - missing 'z'
+        invalid_chm1 = ChoiceMap.kw(x=1.0)
+        assert invalid_chm1.invalid_subset(model, (0.0,)) == invalid_chm1
+
+        # Invalid ChoiceMap - extra address
+        invalid_chm2 = ChoiceMap.kw(y=1.0, z=1, extra=0.5)
+        assert invalid_chm2.invalid_subset(model, (0.0,)) == ChoiceMap.kw(extra=0.5)
+
+    def test_choicemap_nested_validation(self):
+        @genjax.gen
+        def inner_model():
+            a = genjax.normal(0.0, 1.0) @ "a"
+            b = genjax.bernoulli(0.5) @ "b"
+            return a + b
+
+        @genjax.gen
+        def outer_model():
+            x = genjax.normal(0.0, 1.0) @ "x"
+            y = inner_model() @ "y"
+            return x + y
+
+        # Valid nested ChoiceMap
+        valid_nested_chm = ChoiceMap.kw(x=1.0, y=ChoiceMap.kw(a=0.5, b=1))
+        assert valid_nested_chm.invalid_subset(outer_model, ()) is None
+
+        # Invalid nested ChoiceMap - missing inner 'b'
+        invalid_nested_chm1 = ChoiceMap.kw(x=1.0, y=ChoiceMap.kw(a=0.5))
+        assert (
+            invalid_nested_chm1.invalid_subset(outer_model, ()) is None
+        ), "missing address is fine"
+
+        # Invalid nested ChoiceMap - extra address in inner model
+        invalid_nested_chm2 = ChoiceMap.kw(x=1.0, y=ChoiceMap.kw(a=0.5, b=1, c=2.0))
+        assert invalid_nested_chm2.invalid_subset(outer_model, ()) == ChoiceMap.kw(
+            y=ChoiceMap.kw(c=2.0)
+        )
+
+        # Invalid nested ChoiceMap - extra address in outer model
+        invalid_nested_chm3 = ChoiceMap.kw(x=1.0, y=ChoiceMap.kw(a=0.5, b=1), z=3.0)
+        assert invalid_nested_chm3.invalid_subset(outer_model, ()) == ChoiceMap.kw(
+            z=3.0
+        )
+
+    def test_choicemap_nested_vmap(self):
+        @genjax.gen
+        def inner_model(x):
+            a = genjax.normal(x, 1.0) @ "a"
+            b = genjax.bernoulli(0.5) @ "b"
+            return a + b
+
+        @genjax.gen
+        def outer_model():
+            x = genjax.normal(0.0, 1.0) @ "x"
+            y = inner_model.vmap(in_axes=(0,))(jnp.array([1.0, 2.0, 3.0])) @ "y"
+            return x + jnp.sum(y)
+
+        # Valid nested ChoiceMap with vmap
+        valid_vmap_chm = ChoiceMap.kw(
+            x=1.0,
+            y=C[jnp.arange(3)].set(
+                ChoiceMap.kw(a=jnp.array([0.5, 1.5, 2.5]), b=jnp.array([1, 0, 1]))
+            ),
+        )
+        assert valid_vmap_chm.invalid_subset(outer_model, ()) is None
+
+        # Invalid nested ChoiceMap - wrong shape for vmapped inner model
+        inner_chm = ChoiceMap.kw(a=jnp.array([0.5, 1.5, 2.5]), b=jnp.array([1, 0, 1]))
+        invalid_vmap_chm1 = ChoiceMap.kw(
+            x=1.0,
+            # missing the index nesting
+            y=inner_chm,
+        )
+        assert invalid_vmap_chm1.invalid_subset(outer_model, ()) == C["y"].set(
+            inner_chm
+        )
+
+        # Invalid nested ChoiceMap - extra address in vmapped inner model
+
+        invalid_vmap_chm2 = ChoiceMap.kw(
+            x=1.0,
+            y=C[jnp.arange(3)].set(
+                ChoiceMap.kw(
+                    a=jnp.array([0.5, 1.5, 2.5]),
+                    b=jnp.array([1, 0, 1]),
+                    c=jnp.array([0.1, 0.2, 0.3]),  # Extra address
+                )
+            ),
+        )
+        expected_result = C["y", jnp.arange(3), "c"].set(jnp.array([0.1, 0.2, 0.3]))
+        actual_result = invalid_vmap_chm2.invalid_subset(outer_model, ())
+        assert jax.tree_util.tree_structure(
+            actual_result
+        ) == jax.tree_util.tree_structure(expected_result)
+        assert jax.tree_util.tree_all(
+            jax.tree_map(
+                lambda x, y: jnp.allclose(x, y), actual_result, expected_result
+            )
+        )
+
+    def test_choicemap_switch(self):
+        @genjax.gen
+        def model1():
+            x = genjax.normal(0.0, 1.0) @ "x"
+            return x
+
+        @genjax.gen
+        def model2():
+            y = genjax.uniform(0.0, 1.0) @ "y"
+            return y
+
+        @genjax.gen
+        def model3():
+            z = genjax.normal(0.0, 1.0) @ "z"
+            return z
+
+        switch_model = genjax.switch(model1, model2, model3)
+
+        @genjax.gen
+        def outer_model():
+            choice = genjax.categorical([0.3, 0.3, 0.4]) @ "choice"
+            return switch_model(choice, (), (), ()) @ "out"
+
+        # Valid ChoiceMap for model1
+        valid_chm1 = ChoiceMap.kw(choice=0, out={"x": 0.5})
+        assert valid_chm1.invalid_subset(outer_model, ()) is None
+
+        # Valid ChoiceMap for model2
+        valid_chm2 = ChoiceMap.kw(choice=1, out={"y": 0.7})
+        assert valid_chm2.invalid_subset(outer_model, ()) is None
+
+        # Valid ChoiceMap for model3
+        valid_chm3 = ChoiceMap.kw(choice=2, out={"z": 1.2})
+        assert valid_chm3.invalid_subset(outer_model, ()) is None
+
+        # Valid ChoiceMap with entries for all models
+        valid_chm_all = ChoiceMap.kw(choice=0, out={"x": 0.5, "y": 0.7, "z": 1.2})
+        assert valid_chm_all.invalid_subset(outer_model, ()) is None
+
+        # Invalid ChoiceMap - extra address
+        invalid_chm2 = ChoiceMap.kw(choice=1, out={"q": 0.5})
+        assert invalid_chm2.invalid_subset(outer_model, ()) == C["out", "q"].set(0.5)
+        pass
+
+    def test_choicemap_scan(self):
+        @genjax.gen
+        def inner_model(mean):
+            return genjax.normal(mean, 1.0) @ "x"
+
+        outer_model = inner_model.iterate(n=4)
+
+        # Test valid ChoiceMap
+        valid_chm = C[jnp.arange(4), "x"].set(jnp.array([0.5, 1.2, 0.8, 0.9]))
+        assert valid_chm.invalid_subset(outer_model, (1.0,)) is None
+
+        # forgot the index layer
+        invalid_chm2 = C["x"].set(jnp.array([0.5, 1.2, 0.8, 0.9]))
+        assert invalid_chm2.invalid_subset(outer_model, (1.0,)) == invalid_chm2
+
+        xs = jnp.array([0.5, 1.2, 0.8, 0.9])
+        zs = jnp.array([0.5, 1.2, 0.8, 0.9])
+        invalid_chm3 = C[jnp.arange(4)].set({"x": xs, "z": zs})
+        invalid_subset = invalid_chm3.invalid_subset(outer_model, (1.0,))
+        expected_invalid = C[jnp.arange(4), "z"].set(zs)
+        assert jtu.tree_structure(invalid_subset) == jtu.tree_structure(
+            expected_invalid
+        )
+        assert jtu.tree_all(
+            jtu.tree_map(
+                lambda x, y: jnp.allclose(x, y), invalid_subset, expected_invalid
+            )
+        )

--- a/tests/generative_functions/test_mask_combinator.py
+++ b/tests/generative_functions/test_mask_combinator.py
@@ -187,7 +187,7 @@ class TestMaskCombinator:
         # inside or outside of a generative function. When inside, the array is
         # recast by JAX into a numpy array, since it appears in the literal pool of
         # a compiled function, but not when outside, where it escapes such treatment.
-        with pytest.raises(TypeError, match=r"flag.*violates type hint"):
+        with pytest.raises(TypeError, match=r"f.*violates type hint"):
             model_inside.simulate(key, ())
 
         tr = model_outside.simulate(key, ())

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -420,3 +420,22 @@ class TestScanWithParameters:
             trace.get_choices(),
             (2.0, 2.0 + jnp.arange(0, dtype=float)),
         )
+
+    def test_scan_validation(self):
+        @genjax.gen
+        def foo(shift, d):
+            loc = d["loc"]
+            scale = d["scale"]
+            x = genjax.normal(loc, scale) @ "x"
+            return x + shift, None
+
+        key = jax.random.PRNGKey(314159)
+        jax.lax.scan
+        d = {
+            "loc": jnp.array([10.0, 12.0]),
+            "scale": jnp.array([1.0]),
+        }
+        with pytest.raises(
+            ValueError, match="scan got values with different leading axis sizes: 2, 1."
+        ):
+            foo.scan().simulate(key, (jnp.array([1.0]), d))

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -439,3 +439,26 @@ class TestScanWithParameters:
             ValueError, match="scan got values with different leading axis sizes: 2, 1."
         ):
             foo.scan().simulate(key, (jnp.array([1.0]), d))
+
+    def test_vmap_key_scan(self):
+        @genjax.gen
+        def model(x, _):
+            y = genjax.normal(x, 1.0) @ "y"
+            return y, None
+
+        vmapped = model.scan()
+
+        key = jax.random.PRNGKey(314159)
+        keys = jax.random.split(key, 10)
+        xs = jnp.arange(5, dtype=float)
+        args = (jnp.array(1.0), xs)
+
+        results = jax.vmap(lambda k: vmapped.simulate(k, args))(jnp.array(keys))
+
+        chm = results.get_choices()
+
+        # the inner scan aggregates a score, while the outer vmap does not accumulate anything
+        assert results.get_score().shape == (10,)
+
+        # the inner scan has scanned over the y's
+        assert chm[..., "y"].shape == (10, 5)


### PR DESCRIPTION
This PR:

- adds an `invalid_subset` method to `ChoiceMap`. This takes a generative function and its args tuple and returns the statically-invalid subset of the choicemap — i.e., the subset of entries that could NEVER affect the generative function's execution — or None if the choicemap is fully valid.
- adds `Selection.leaf()`, for building selections that match a specific spot without matching the rest of the tail
- runs side-effecting `vmap` and `scan` calls while computing the dimension size — this has the lovely effect of triggering the very detailed validations provided by JAX on mismatched types, mismatched dimensions, invalid in_axes and all the rest.
- modifies `ScanTrace` and `VmapTrace` to statically compute the size of their scanned or vmapped dimensions for storage in the trace
- modifies `VmapTrace` to pre-compute the `score` and `chm` fields
- modifies `ScanTrace` to pre-compute the `chm` field

The latter two need to happen because an outer `jax.vmap` call adds a new dimension at all trace leaves — if we delay creating choicemaps in `get_choices` to do it on demand, and someone has added a new dimension, then we will vmap across the WRONG dimension here.

This PR does NOT wire in any warnings for the user in `update` or any of those methods. I'm going to propose that we do this in another issue.

Examples from the new choicemap tests:

```python
    def test_choicemap_validation(self):
        @genjax.gen
        def model(x):
            y = genjax.normal(x, 1.0) @ "y"
            z = genjax.bernoulli(0.5) @ "z"
            return y + z

        # Valid ChoiceMap
        valid_chm = ChoiceMap.kw(y=1.0, z=1)
        assert valid_chm.invalid_subset(model, (0.0,)) is None

        # Invalid ChoiceMap - missing 'z'
        invalid_chm1 = ChoiceMap.kw(x=1.0)
        assert invalid_chm1.invalid_subset(model, (0.0,)) == invalid_chm1

        # Invalid ChoiceMap - extra address
        invalid_chm2 = ChoiceMap.kw(y=1.0, z=1, extra=0.5)
        assert invalid_chm2.invalid_subset(model, (0.0,)) == ChoiceMap.kw(extra=0.5)

    def test_choicemap_nested_validation(self):
        @genjax.gen
        def inner_model():
            a = genjax.normal(0.0, 1.0) @ "a"
            b = genjax.bernoulli(0.5) @ "b"
            return a + b

        @genjax.gen
        def outer_model():
            x = genjax.normal(0.0, 1.0) @ "x"
            y = inner_model() @ "y"
            return x + y

        # Valid nested ChoiceMap
        valid_nested_chm = ChoiceMap.kw(x=1.0, y=ChoiceMap.kw(a=0.5, b=1))
        assert valid_nested_chm.invalid_subset(outer_model, ()) is None

        # Invalid nested ChoiceMap - missing inner 'b'
        invalid_nested_chm1 = ChoiceMap.kw(x=1.0, y=ChoiceMap.kw(a=0.5))
        assert (
            invalid_nested_chm1.invalid_subset(outer_model, ()) is None
        ), "missing address is fine"

        # Invalid nested ChoiceMap - extra address in inner model
        invalid_nested_chm2 = ChoiceMap.kw(x=1.0, y=ChoiceMap.kw(a=0.5, b=1, c=2.0))
        assert invalid_nested_chm2.invalid_subset(outer_model, ()) == ChoiceMap.kw(
            y=ChoiceMap.kw(c=2.0)
        )

        # Invalid nested ChoiceMap - extra address in outer model
        invalid_nested_chm3 = ChoiceMap.kw(x=1.0, y=ChoiceMap.kw(a=0.5, b=1), z=3.0)
        assert invalid_nested_chm3.invalid_subset(outer_model, ()) == ChoiceMap.kw(
            z=3.0
        )

    def test_choicemap_nested_vmap(self):
        @genjax.gen
        def inner_model(x):
            a = genjax.normal(x, 1.0) @ "a"
            b = genjax.bernoulli(0.5) @ "b"
            return a + b

        @genjax.gen
        def outer_model():
            x = genjax.normal(0.0, 1.0) @ "x"
            y = inner_model.vmap(in_axes=(0,))(jnp.array([1.0, 2.0, 3.0])) @ "y"
            return x + jnp.sum(y)

        # Valid nested ChoiceMap with vmap
        valid_vmap_chm = ChoiceMap.kw(
            x=1.0,
            y=C[jnp.arange(3)].set(
                ChoiceMap.kw(a=jnp.array([0.5, 1.5, 2.5]), b=jnp.array([1, 0, 1]))
            ),
        )
        assert valid_vmap_chm.invalid_subset(outer_model, ()) is None

        # Invalid nested ChoiceMap - wrong shape for vmapped inner model
        inner_chm = ChoiceMap.kw(a=jnp.array([0.5, 1.5, 2.5]), b=jnp.array([1, 0, 1]))
        invalid_vmap_chm1 = ChoiceMap.kw(
            x=1.0,
            # missing the index nesting
            y=inner_chm,
        )
        assert invalid_vmap_chm1.invalid_subset(outer_model, ()) == C["y"].set(
            inner_chm
        )

        # Invalid nested ChoiceMap - extra address in vmapped inner model

        invalid_vmap_chm2 = ChoiceMap.kw(
            x=1.0,
            y=C[jnp.arange(3)].set(
                ChoiceMap.kw(
                    a=jnp.array([0.5, 1.5, 2.5]),
                    b=jnp.array([1, 0, 1]),
                    c=jnp.array([0.1, 0.2, 0.3]),  # Extra address
                )
            ),
        )
        expected_result = C["y", jnp.arange(3), "c"].set(jnp.array([0.1, 0.2, 0.3]))
        actual_result = invalid_vmap_chm2.invalid_subset(outer_model, ())
        assert jax.tree_util.tree_structure(
            actual_result
        ) == jax.tree_util.tree_structure(expected_result)
        assert jax.tree_util.tree_all(
            jax.tree_map(
                lambda x, y: jnp.allclose(x, y), actual_result, expected_result
            )
        )

    def test_choicemap_switch(self):
        @genjax.gen
        def model1():
            x = genjax.normal(0.0, 1.0) @ "x"
            return x

        @genjax.gen
        def model2():
            y = genjax.uniform(0.0, 1.0) @ "y"
            return y

        @genjax.gen
        def model3():
            z = genjax.normal(0.0, 1.0) @ "z"
            return z

        switch_model = genjax.switch(model1, model2, model3)

        @genjax.gen
        def outer_model():
            choice = genjax.categorical([0.3, 0.3, 0.4]) @ "choice"
            return switch_model(choice, (), (), ()) @ "out"

        # Valid ChoiceMap for model1
        valid_chm1 = ChoiceMap.kw(choice=0, out={"x": 0.5})
        assert valid_chm1.invalid_subset(outer_model, ()) is None

        # Valid ChoiceMap for model2
        valid_chm2 = ChoiceMap.kw(choice=1, out={"y": 0.7})
        assert valid_chm2.invalid_subset(outer_model, ()) is None

        # Valid ChoiceMap for model3
        valid_chm3 = ChoiceMap.kw(choice=2, out={"z": 1.2})
        assert valid_chm3.invalid_subset(outer_model, ()) is None

        # Valid ChoiceMap with entries for all models
        valid_chm_all = ChoiceMap.kw(choice=0, out={"x": 0.5, "y": 0.7, "z": 1.2})
        assert valid_chm_all.invalid_subset(outer_model, ()) is None

        # Invalid ChoiceMap - extra address
        invalid_chm2 = ChoiceMap.kw(choice=1, out={"q": 0.5})
        assert invalid_chm2.invalid_subset(outer_model, ()) == C["out", "q"].set(0.5)
        pass

    def test_choicemap_scan(self):
        @genjax.gen
        def inner_model(mean):
            return genjax.normal(mean, 1.0) @ "x"

        outer_model = inner_model.iterate(n=4)

        # Test valid ChoiceMap
        valid_chm = C[jnp.arange(4), "x"].set(jnp.array([0.5, 1.2, 0.8, 0.9]))
        assert valid_chm.invalid_subset(outer_model, (1.0,)) is None

        # forgot the index layer
        invalid_chm2 = C["x"].set(jnp.array([0.5, 1.2, 0.8, 0.9]))
        assert invalid_chm2.invalid_subset(outer_model, (1.0,)) == invalid_chm2

        xs = jnp.array([0.5, 1.2, 0.8, 0.9])
        zs = jnp.array([0.5, 1.2, 0.8, 0.9])
        invalid_chm3 = C[jnp.arange(4)].set({"x": xs, "z": zs})
        invalid_subset = invalid_chm3.invalid_subset(outer_model, (1.0,))
        expected_invalid = C[jnp.arange(4), "z"].set(zs)
        assert jtu.tree_structure(invalid_subset) == jtu.tree_structure(
            expected_invalid
        )
        assert jtu.tree_all(
            jtu.tree_map(
                lambda x, y: jnp.allclose(x, y), invalid_subset, expected_invalid
            )
        )

```