### PR TITLE
Skip work in __abstract_call__ with to_shape_fn (4/N)

### DIFF
--- a/src/genjax/_src/generative_functions/distributions/distribution.py
+++ b/src/genjax/_src/generative_functions/distributions/distribution.py
@@ -45,7 +45,7 @@ from genjax._src.core.generative import (
 )
 from genjax._src.core.generative.choice_map import Filtered
 from genjax._src.core.interpreters.incremental import Diff
-from genjax._src.core.interpreters.staging import FlagOp
+from genjax._src.core.interpreters.staging import FlagOp, to_shape_fn
 from genjax._src.core.pytree import Closure, Pytree
 from genjax._src.core.typing import (
     Any,
@@ -408,6 +408,8 @@ class Distribution(Generic[R], GenerativeFunction[R]):
 # ExactDensity #
 ################
 
+_fake_key = jnp.array([0, 0], dtype=jnp.uint32)
+
 
 class ExactDensity(Generic[R], Distribution[R]):
     @abstractmethod
@@ -419,8 +421,7 @@ class ExactDensity(Generic[R], Distribution[R]):
         pass
 
     def __abstract_call__(self, *args):
-        key = jax.random.PRNGKey(0)
-        return self.sample(key, *args)
+        return to_shape_fn(self.sample, jnp.zeros)(_fake_key, *args)
 
     def handle_kwargs(self) -> GenerativeFunction[R]:
         @Pytree.partial(self)

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -51,6 +51,7 @@ from genjax._src.core.interpreters.incremental import (
     Diff,
     incremental,
 )
+from genjax._src.core.interpreters.staging import to_shape_fn
 from genjax._src.core.pytree import Closure, Const, Pytree
 from genjax._src.core.typing import (
     Any,
@@ -794,7 +795,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
     # To get the type of return value, just invoke
     # the source (with abstract tracer arguments).
     def __abstract_call__(self, *args) -> Any:
-        return self.source(*args)
+        return to_shape_fn(self.source, jnp.zeros)(*args)
 
     def __post_init__(self):
         wrapped = self.source.fn


### PR DESCRIPTION
This PR uses `to_shape_fn` for the `__abstract_call__` implementations of `StaticGenerativeFunction` and `Distribution`, skipping any FLOPs that might have been spent in these calls.