### PR TITLE
Second reference, ignore

### DIFF
--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -88,7 +88,7 @@ SelectionBuilder = _SelectionBuilder()
 """Deprecated! please use `Selection.at`."""
 
 
-class Selection(Projection["ChoiceMap"]):
+class Selection(Projection["ChoiceMap"], Pytree):
     """
     A class representing a selection of addresses in a ChoiceMap.
 
@@ -355,7 +355,7 @@ class Selection(Projection["ChoiceMap"]):
 #######################
 
 
-@Pytree.dataclass(match_args=True)
+@Pytree.dataclass
 class AllSel(Selection):
     """Represents a selection that includes all addresses.
 
@@ -377,7 +377,7 @@ class AllSel(Selection):
         return self
 
 
-@Pytree.dataclass(match_args=True)
+@Pytree.dataclass
 class NoneSel(Selection):
     """Represents a selection that includes no addresses.
 

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -138,7 +138,7 @@ class MaskedConstraint(Constraint):
 ###############
 
 
-class Projection(Generic[S], Pytree):
+class Projection(Generic[S]):
     @abstractmethod
     def filter(self, sample: S) -> S:
         pass

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -64,7 +64,7 @@ Value = Any
 
 ScalarShaped = Is[lambda arr: jnp.array(arr, copy=False).shape == ()]
 ScalarFlag = Annotated[Flag, ScalarShaped]
-
+ScalarInt = Annotated[IntArray, ScalarShaped]
 
 ############
 # Generics #

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -67,7 +67,7 @@ class ScanTrace(Generic[Carry, Y], Trace[tuple[Carry, Y]]):
         score: FloatArray,
         scan_length: int,
     ) -> "ScanTrace[Carry, Y]":
-        chm = inner.get_choices().extend(jnp.arange(scan_length))
+        chm = inner.get_choices().extend(slice(None, None, None))
         return ScanTrace(scan_gen_fn, inner, args, retval, score, chm, scan_length)
 
     def get_args(self) -> tuple[Any, ...]:

--- a/src/genjax/_src/generative_functions/combinators/switch.py
+++ b/src/genjax/_src/generative_functions/combinators/switch.py
@@ -171,13 +171,10 @@ class SwitchCombinator(Generic[R], GenerativeFunction[R]):
 
     branches: tuple[GenerativeFunction[R], ...]
 
-    def _indices(self):
-        return range(len(self.branches))
-
     def __abstract_call__(self, *args) -> R:
-        idx, args = args[0], args[1:]
+        idx, branch_args = args[0], args[1:]
         retvals = list(
-            f.__abstract_call__(*f_args) for f, f_args in zip(self.branches, args)
+            f.__abstract_call__(*args) for f, args in zip(self.branches, branch_args)
         )
         return staged_choose(idx, retvals)
 

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -66,7 +66,7 @@ class VmapTrace(Generic[R], Trace[R]):
         gen_fn: "VmapCombinator[R]", tr: Trace[R], args: tuple[Any, ...], length: int
     ) -> "VmapTrace[R]":
         score = jnp.sum(tr.get_score())
-        chm = tr.get_choices().extend(jnp.arange(length))
+        chm = tr.get_choices().extend(slice(None, None, None))
 
         return VmapTrace(gen_fn, tr, args, score, chm, length)
 

--- a/tests/generative_functions/test_vmap_combinator.py
+++ b/tests/generative_functions/test_vmap_combinator.py
@@ -43,9 +43,7 @@ class TestVmapCombinator:
 
         key = jax.random.PRNGKey(314159)
         map_over = jnp.arange(0, 3, dtype=float)
-        chm = jax.vmap(lambda idx, v: C[idx, "z"].set(v))(
-            jnp.arange(3), jnp.array([3.0, 2.0, 3.0])
-        )
+        chm = C[:, "z"].set(jnp.array([3.0, 2.0, 3.0]))
 
         (_, w) = jax.jit(kernel.importance)(key, chm, (map_over,))
         assert (
@@ -71,7 +69,7 @@ class TestVmapCombinator:
 
         key, sub_key = jax.random.split(key)
         zv = jnp.array([3.0, -1.0, 2.0])
-        chm = jax.vmap(lambda idx, v: C[idx, "z"].set(v))(jnp.arange(3), zv)
+        chm = C[:, "z"].set(zv)
         (tr, _) = kernel.importance(sub_key, chm, (map_over,))
         for i in range(0, 3):
             v = tr.get_choices()[i, "z"]


### PR DESCRIPTION
# TODO

- validation where we only allow ALL full slices or ALL numbers, nothing else, no mix at all.

```
# NOTES:
# TODO, notes:
# - then only allow full slices and ints for lookup...
# - but this is still busted if I try to do a full slice followed by an index.
# - one idea is to take the __getitem__ list, filter out all of the non-string things and then pass them in to the array AFTER. That would remove the need for indexed, and the location of slices would not matter...
# except for the get_submap case, where I build C[0, "x"].set(1.0) and specifically want to override that value. But C[:, "x", 2] will fail too for overrides. That shows that we are busted here and we need to find some other way of specifying these things.

#
# what if .get_submap for static simply pushed numbers down the line? And indexed caught it? So we can be loosey-goosey with our Indexed, and then Indexed becomes a filter for specific indices... and that's the only sort of thing we support. I think that will work.
#
# The problem is... when I build... C[:, "x", 2].set(???), what do I put in there?
```