### PR TITLE
Add slicing support to ChoiceMap and ChoiceMapBuilder (GEN-424, GEN-587 )

### DIFF
--- a/notebooks/active/intro.ipynb
+++ b/notebooks/active/intro.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jrand.PRNGKey(0)\n",
+    "key = jrand.key(0)\n",
     "tr = model.simulate(key, ())\n",
     "tr"
    ]
@@ -137,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sub_keys = jrand.split(jrand.PRNGKey(0), 1000)\n",
+    "sub_keys = jrand.split(jrand.key(0), 1000)\n",
     "tr = jit(vmap(model.simulate, in_axes=(0, None)))(sub_keys, ())\n",
     "tr"
    ]
@@ -465,7 +465,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/notebooks/cookbook/basics/choicemap_creation_selection.ipynb
+++ b/notebooks/cookbook/basics/choicemap_creation_selection.ipynb
@@ -40,7 +40,7 @@
     ")\n",
     "\n",
     "pretty()\n",
-    "key = random.PRNGKey(0)"
+    "key = random.key(0)"
    ]
   },
   {
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.PRNGKey(0)\n",
+    "key = jax.random.key(0)\n",
     "trace = jax.jit(beta_bernoulli_process.simulate)(key, (0.5,))"
    ]
   },

--- a/notebooks/cookbook/basics/choicemap_creation_selection.ipynb
+++ b/notebooks/cookbook/basics/choicemap_creation_selection.ipynb
@@ -272,34 +272,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But because of the nested `vmap`, the address hierarchy can sometimes lead to unintuitive results. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "chm = chm ^ C[1, 3, \"new_pixel\"].set(1.0)  # seemingly adding a new constraint\n",
-    "tr, w = jax.jit(sample_image.importance)(key, chm, (image,))\n",
-    "w  # Yet we obtain the same weight as before"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO this is broken, since we need to set a proper matrix at the bottom.\n",
-    "chm3 = C[:, :, \"new_pixel\"].set(1.0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Accessing the right elements in the trace can become non-trivial when one creates hierarchical generative functions. \n",
     "Here are minimal examples and solutions for selection."
    ]
@@ -493,7 +465,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/notebooks/cookbook/basics/choicemap_creation_selection.ipynb
+++ b/notebooks/cookbook/basics/choicemap_creation_selection.ipynb
@@ -40,7 +40,7 @@
     ")\n",
     "\n",
     "pretty()\n",
-    "key = random.key(0)"
+    "key = random.PRNGKey(0)"
    ]
   },
   {
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key = jax.random.key(0)\n",
+    "key = jax.random.PRNGKey(0)\n",
     "trace = jax.jit(beta_bernoulli_process.simulate)(key, (0.5,))"
    ]
   },
@@ -223,7 +223,7 @@
     "for i in range(10):\n",
     "    chm = chm ^ C[\"p\" + str(i)].set(i)\n",
     "# A more JAX-friendly way to do this\n",
-    "chm = jax.vmap(lambda idx: C[idx].set(idx.astype(float)))(jnp.arange(10))\n",
+    "chm = C[:].set(jnp.arange(10.0))\n",
     "chm"
    ]
   },
@@ -292,13 +292,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "N = 4\n",
-    "F = 4\n",
-    "\n",
-    "\n",
-    "chm3 = C[\n",
-    "    jnp.arange(F), jnp.repeat(jnp.arange(N)[jnp.newaxis], F, axis=0), \"new_pixel\"\n",
-    "].set(1.0)"
+    "# TODO this is broken, since we need to set a proper matrix at the bottom.\n",
+    "chm3 = C[:, :, \"new_pixel\"].set(1.0)"
    ]
   },
   {

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -84,7 +84,7 @@ SelectionBuilder = _SelectionBuilder()
 """Deprecated! please use `Selection.at`."""
 
 
-class Selection(Projection["ChoiceMap"]):
+class Selection(Projection["ChoiceMap"], Pytree):
     """
     A class representing a selection of addresses in a ChoiceMap.
 
@@ -737,6 +737,37 @@ class _ChoiceMapBuilder:
         else:
             return chm + self.choice_map
 
+    def update(
+        self, f: Callable[..., "dict[K_addr, Any] | ChoiceMap | Any"]
+    ) -> "ChoiceMap":
+        """
+        Updates an existing value or ChoiceMap at the current address.
+        This method allows updating a value or ChoiceMap at the address specified by the builder.
+        The provided function `f` is called with the current value or ChoiceMap at that address.
+        Args:
+            f: A callable that takes the current value (or None) and returns a new value,
+               dict, or ChoiceMap to be set at the current address.
+        Returns:
+            A new ChoiceMap with the updated value at the specified address.
+        Example:
+            ```python exec="yes" html="true" source="material-block" session="choicemap"
+            chm = ChoiceMap.d({"x": 5, "y": {"z": 10}})
+            updated = chm.at["y", "z"].update(lambda v: v * 2)
+            assert updated["y", "z"] == 20
+            # Updating a non-existent address
+            new_chm = chm.at["w"].update(lambda _: 42)
+            assert new_chm["w"] == 42
+            ```
+        """
+        if self.choice_map is None:
+            return self.set(f(None))
+        else:
+            submap = self.choice_map(tuple(self.addrs))
+            if submap.has_value():
+                return self.set(f(submap.get_value()))
+            else:
+                return self.set(f(submap))
+
     def n(self) -> "ChoiceMap":
         """
         Returns an empty ChoiceMap. Alias for `ChoiceMap.none()`.
@@ -857,7 +888,7 @@ class ChoiceMap(Pytree):
         return _empty
 
     @staticmethod
-    def choice(v: T) -> "Choice[T]":
+    def choice(v: Any) -> "ChoiceMap":
         """
         Creates a ChoiceMap containing a single value.
 
@@ -878,11 +909,11 @@ class ChoiceMap(Pytree):
             assert value_chm.get_value() == 42
             ```
         """
-        return Choice(v)
+        return Choice.build(v)
 
     @staticmethod
     @deprecated("Use ChoiceMap.choice() instead.")
-    def value(v: T) -> "Choice[T]":
+    def value(v: Any) -> "ChoiceMap":
         return ChoiceMap.choice(v)
 
     @staticmethod
@@ -1350,6 +1381,15 @@ class Choice(Generic[T], ChoiceMap):
     """
 
     v: T
+
+    @staticmethod
+    def build(v: T) -> ChoiceMap:
+        if isinstance(v, Array) and v.shape == (0,):
+            return ChoiceMap.empty()
+        elif isinstance(v, Mask) and FlagOp.concrete_false(v.primal_flag()):
+            return ChoiceMap.empty()
+        else:
+            return Choice(v)
 
     def get_value(self) -> T:
         return self.v

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -760,7 +760,7 @@ class _ChoiceMapBuilder:
             ```
         """
         if self.choice_map is None:
-            return self.set(f(None))
+            return self.set(f(_empty))
         else:
             submap = self.choice_map(tuple(self.addrs))
             if submap.has_value():

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 #################
 
 StaticAddressComponent = str
-DynamicAddressComponent = int | IntArray
+DynamicAddressComponent = int | IntArray | slice
 AddressComponent = StaticAddressComponent | DynamicAddressComponent
 Address = tuple[AddressComponent, ...]
 StaticAddress = tuple[StaticAddressComponent, ...]
@@ -61,6 +61,8 @@ ExtendedAddress = tuple[ExtendedAddressComponent, ...]
 T = TypeVar("T")
 K_addr = TypeVar("K_addr", bound=AddressComponent | Address)
 
+_full_slice = slice(None, None, None)
+
 ##############
 # Selections #
 ##############
@@ -70,7 +72,6 @@ K_addr = TypeVar("K_addr", bound=AddressComponent | Address)
 ###############################
 
 
-@Pytree.dataclass(match_args=True)
 class _SelectionBuilder(Pytree):
     def __getitem__(
         self, addr: ExtendedStaticAddressComponent | ExtendedStaticAddress

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -123,7 +123,7 @@ class MaskedConstraint(Constraint):
 ###############
 
 
-class Projection(Generic[S], Pytree):
+class Projection(Generic[S]):
     @abstractmethod
     def filter(self, sample: S) -> S:
         pass

--- a/src/genjax/_src/core/generative/generative_function.py
+++ b/src/genjax/_src/core/generative/generative_function.py
@@ -221,7 +221,6 @@ class GenerativeFunction(Generic[R], Pytree):
         ```python exec="yes" html="true" source="material-block" session="core"
         import jax
         from jax.scipy.special import logsumexp
-        from jax.random import PRNGKey
         import jax.tree_util as jtu
         from genjax import ChoiceMapBuilder as C
         from genjax import gen, uniform, flip, categorical
@@ -246,7 +245,7 @@ class GenerativeFunction(Generic[R], Pytree):
             return jtu.tree_map(lambda v: v[idx], tr.get_sample())
 
 
-        sub_keys = jax.random.split(PRNGKey(0), 50)
+        sub_keys = jax.random.split(jax.random.key(0), 50)
         samples = jax.jit(jax.vmap(importance_sampling, in_axes=(0, None)))(
             sub_keys, C.kw(f1=True, f2=True)
         )
@@ -294,7 +293,7 @@ class GenerativeFunction(Generic[R], Pytree):
                 return x + y + z
 
 
-            key = jax.random.PRNGKey(0)
+            key = jax.random.key(0)
             kw_model = model.handle_kwargs()
 
             tr = kw_model.simulate(key, ((1.0, 2.0), {"z": 3.0}))
@@ -358,8 +357,8 @@ class GenerativeFunction(Generic[R], Pytree):
         Examples:
             ```python exec="yes" html="true" source="material-block" session="core"
             import genjax
+            import jax
             from jax import vmap, jit
-            from jax.random import PRNGKey
             from jax.random import split
 
 
@@ -369,7 +368,7 @@ class GenerativeFunction(Generic[R], Pytree):
                 return x
 
 
-            key = PRNGKey(0)
+            key = jax.random.key(0)
             tr = model.simulate(key, ())
             print(tr.render_html())
             ```
@@ -382,14 +381,14 @@ class GenerativeFunction(Generic[R], Pytree):
                 return x
 
 
-            key = PRNGKey(0)
+            key = jax.random.key(0)
             tr = model.repeat(n=10).simulate(key, ())
             print(tr.render_html())
             ```
 
             (**Fun, flirty, fast ... parallel?**) Feel free to use `jax.jit` and `jax.vmap`!
             ```python exec="yes" html="true" source="material-block" session="core"
-            key = PRNGKey(0)
+            key = jax.random.key(0)
             sub_keys = split(key, 10)
             sim = model.repeat(n=10).simulate
             tr = jit(vmap(sim, in_axes=(0, None)))(sub_keys, ())
@@ -473,13 +472,10 @@ class GenerativeFunction(Generic[R], Pytree):
         Examples:
             Updating a trace in response to a request for a [`Target`][genjax.inference.Target] change induced by a change to the arguments:
             ```python exec="yes" source="material-block" session="core"
-            from genjax import gen
-            from genjax import normal
-            from genjax import Diff
-            from genjax import Update
-            from genjax import ChoiceMap as C
+            import jax
+            from genjax import gen, normal, Diff, Update, ChoiceMap as C
 
-            key = PRNGKey(0)
+            key = jax.random.key(0)
 
 
             @gen
@@ -606,11 +602,11 @@ class GenerativeFunction(Generic[R], Pytree):
         Examples:
             (**Full constraints**) A simple example using the `importance` interface on distributions:
             ```python exec="yes" html="true" source="material-block" session="core"
+            import jax
             from genjax import normal
             from genjax import ChoiceMapBuilder as C
-            from jax.random import PRNGKey
 
-            key = PRNGKey(0)
+            key = jax.random.key(0)
 
             tr, w = normal.importance(key, C.v(1.0), (0.0, 1.0))
             print(tr.get_sample().render_html())

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -59,7 +59,7 @@ Value = Any
 
 ScalarShaped = Is[lambda arr: jnp.array(arr, copy=False).shape == ()]
 ScalarFlag = Annotated[Flag, ScalarShaped]
-
+ScalarInt = Annotated[IntArray, ScalarShaped]
 
 ############
 # Generics #
@@ -119,6 +119,7 @@ __all__ = [
     "PRNGKey",
     "ParamSpec",
     "ScalarFlag",
+    "ScalarInt",
     "ScalarShaped",
     "Self",
     "Sequence",

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -66,7 +66,7 @@ class ScanTrace(Generic[Carry, Y], Trace[tuple[Carry, Y]]):
         score: FloatArray,
         scan_length: int,
     ) -> "ScanTrace[Carry, Y]":
-        chm = inner.get_choices().extend(jnp.arange(scan_length))
+        chm = inner.get_choices().extend(slice(None, None, None))
         return ScanTrace(scan_gen_fn, inner, args, retval, score, chm, scan_length)
 
     def get_args(self) -> tuple[Any, ...]:

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -110,7 +110,7 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
             return x + noise1 + noise2
 
 
-        key = jax.random.PRNGKey(314159)
+        key = jax.random.key(314159)
         arr = jnp.ones(100)
 
         tr = jax.jit(mapped.simulate)(key, (arr,))
@@ -314,7 +314,7 @@ def vmap(
             return genjax.normal(v, 0.01) @ "q"
 
 
-        key = jax.random.PRNGKey(314159)
+        key = jax.random.key(314159)
         arr = jnp.ones(100)
 
         # `vmapped_model` accepts an array of numbers:

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -63,7 +63,7 @@ class VmapTrace(Generic[R], Trace[R]):
         gen_fn: "VmapCombinator[R]", tr: Trace[R], args: tuple[Any, ...], length: int
     ) -> "VmapTrace[R]":
         score = jnp.sum(tr.get_score())
-        chm = tr.get_choices().extend(jnp.arange(length))
+        chm = tr.get_choices().extend(slice(None, None, None))
 
         return VmapTrace(gen_fn, tr, args, score, chm, length)
 

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -523,7 +523,7 @@ class TestChoiceMap:
 
     def test_simplify(self):
         chm = ChoiceMap.choice(jnp.asarray([2.3, 4.4, 3.3]))
-        extended = chm.extend(jnp.array([0, 1, 2]))
+        extended = chm.extend(slice(None, None, None))
         assert extended.simplify() == extended, "no-op with no filters"
 
         filtered = C["x", "y"].set(2.0).mask(jnp.array(True))
@@ -551,14 +551,14 @@ class TestChoiceMap:
 
     def test_extend_dynamic(self):
         chm = ChoiceMap.choice(jnp.asarray([2.3, 4.4, 3.3]))
-        extended = chm.extend(jnp.array([0, 1, 2]))
+        extended = chm.extend(slice(None, None, None))
         assert extended.get_value() is None
         assert extended.get_submap("x").static_is_empty()
-        assert extended[0] == genjax.Mask(2.3, True)
-        assert extended[1] == genjax.Mask(4.4, True)
-        assert extended[2] == genjax.Mask(3.3, True)
+        assert extended[0] == 2.3
+        assert extended[1] == 4.4
+        assert extended[2] == 3.3
 
-        assert ChoiceMap.empty().extend(jnp.array([0, 1, 2])).static_is_empty()
+        assert ChoiceMap.empty().extend(slice(None, None, None)).static_is_empty()
 
     def test_access_dynamic(self):
         # out of order input arrays
@@ -680,7 +680,7 @@ class TestChoiceMap:
         xs = jnp.array([1.0, 2.0, 3.0])
         ys = jnp.array([4.0, 5.0, 6.0])
         # Create a ChoiceMap with values at 'x' and 'y' addresses
-        chm = C[jnp.arange(3)].set({"x": xs, "y": ys})
+        chm = C[:].set({"x": xs, "y": ys})
 
         # Create a Selection with a wildcard for 'x'
         sel = S[..., "x"]
@@ -696,9 +696,9 @@ class TestChoiceMap:
             filtered_chm[..., "y"]
 
         # Assert that the structure of the filtered ChoiceMap is preserved
-        assert filtered_chm[0, "x"] == genjax.Mask(1.0, True)
-        assert filtered_chm[1, "x"] == genjax.Mask(2.0, True)
-        assert filtered_chm[2, "x"] == genjax.Mask(3.0, True)
+        assert filtered_chm[0, "x"] == 1.0
+        assert filtered_chm[1, "x"] == 2.0
+        assert filtered_chm[2, "x"] == 3.0
 
     def test_filtered_chm_update(self):
         @genjax.gen
@@ -712,7 +712,7 @@ class TestChoiceMap:
 
         xs = jnp.ones(4)
         ys = 5 * jnp.ones(4)
-        constraint = C[jnp.arange(4)].set({"x": xs, "y": ys})
+        constraint = C[:].set({"x": xs, "y": ys})
         only_xs = constraint.filter(S[..., "x"])
         only_ys = constraint.filter(S[..., "y"])
 
@@ -809,7 +809,7 @@ class TestChoiceMap:
         # Valid nested ChoiceMap with vmap
         valid_vmap_chm = ChoiceMap.kw(
             x=1.0,
-            y=C[jnp.arange(3)].set(
+            y=C[:].set(
                 ChoiceMap.kw(a=jnp.array([0.5, 1.5, 2.5]), b=jnp.array([1, 0, 1]))
             ),
         )
@@ -830,7 +830,7 @@ class TestChoiceMap:
 
         invalid_vmap_chm2 = ChoiceMap.kw(
             x=1.0,
-            y=C[jnp.arange(3)].set(
+            y=C[:].set(
                 ChoiceMap.kw(
                     a=jnp.array([0.5, 1.5, 2.5]),
                     b=jnp.array([1, 0, 1]),
@@ -838,7 +838,7 @@ class TestChoiceMap:
                 )
             ),
         )
-        expected_result = C["y", jnp.arange(3), "c"].set(jnp.array([0.1, 0.2, 0.3]))
+        expected_result = C["y", :, "c"].set(jnp.array([0.1, 0.2, 0.3]))
         actual_result = invalid_vmap_chm2.invalid_subset(outer_model, ())
         assert jtu.tree_structure(actual_result) == jtu.tree_structure(expected_result)
         assert jtu.tree_all(
@@ -899,7 +899,7 @@ class TestChoiceMap:
         outer_model = inner_model.iterate(n=4)
 
         # Test valid ChoiceMap
-        valid_chm = C[jnp.arange(4), "x"].set(jnp.array([0.5, 1.2, 0.8, 0.9]))
+        valid_chm = C[:, "x"].set(jnp.array([0.5, 1.2, 0.8, 0.9]))
         assert valid_chm.invalid_subset(outer_model, (1.0,)) is None
 
         # forgot the index layer
@@ -908,9 +908,9 @@ class TestChoiceMap:
 
         xs = jnp.array([0.5, 1.2, 0.8, 0.9])
         zs = jnp.array([0.5, 1.2, 0.8, 0.9])
-        invalid_chm3 = C[jnp.arange(4)].set({"x": xs, "z": zs})
+        invalid_chm3 = C[:].set({"x": xs, "z": zs})
         invalid_subset = invalid_chm3.invalid_subset(outer_model, (1.0,))
-        expected_invalid = C[jnp.arange(4), "z"].set(zs)
+        expected_invalid = C[:, "z"].set(zs)
         assert jtu.tree_structure(invalid_subset) == jtu.tree_structure(
             expected_invalid
         )
@@ -919,3 +919,76 @@ class TestChoiceMap:
                 lambda x, y: jnp.allclose(x, y), invalid_subset, expected_invalid
             )
         )
+
+    def test_choicemap_slice(self):
+        # partial slices are not allowed when setting:
+        with pytest.raises(ValueError):
+            C[:3, "x"].set(jnp.array([1, 2]))
+
+        with pytest.raises(ValueError):
+            C[0:3, "x"].set(jnp.array([1, 2]))
+
+        with pytest.raises(ValueError):
+            C[0:3:1, "x"].set(jnp.array([1, 2]))
+
+        # set with a full slice
+        vals = jnp.arange(10)
+        chm = C[:, "x"].set(vals)
+
+        # Full lookup:
+        assert jnp.array_equal(chm[:, "x"], jnp.arange(10))
+
+        # single int index:
+        assert chm[1, "x"] == vals[1]
+
+        # single array index:
+        assert chm[jnp.array(5), "x"] == vals[5]
+
+        # one non-full slices is allowed:
+        assert jnp.array_equal(chm[0:4, "x"], vals[0:4])
+
+        assert jnp.array_equal(chm[0:4, "x"], vals[0:4])
+
+    def test_choicemap_slice_validation(self):
+        # Test full slices mixed with strings
+        C[:, "x"].set(jnp.arange(5))
+        C[:, "x", :].set(jnp.ones((3, 3)))
+        C["y", :, "z"].set(jnp.zeros((4, 2)))
+
+        # Test arrays or ints mixed with strings
+        C["y", 5].set(10)
+
+        # with pytest.raises(ValueError):
+        #     C[0, "z", jnp.array([1, 2, 3])].set(jnp.ones(3))
+
+        # Test mixing slices with arrays/ints (should fail)
+        with pytest.raises(ValueError):
+            C[:, jnp.array([0, 1]), "x"].set(jnp.zeros((2, 2)))
+
+        with pytest.raises(ValueError):
+            C[0, :, "y"].set(jnp.ones(3))
+
+        # Test partial slices (should fail)
+        with pytest.raises(ValueError):
+            C[1:3, "x"].set(jnp.arange(2))
+
+        with pytest.raises(ValueError):
+            C["y", :3].set(jnp.ones(3))
+
+        with pytest.raises(ValueError):
+            C[::-1, "z"].set(jnp.arange(5))
+
+        # Test more complex combinations
+        with pytest.raises(ValueError):
+            C[:, "x", 1:3, :].set(jnp.ones((3, 2, 4)))
+
+        # test 2d
+        vals_2d = jnp.array([jnp.arange(0, 3), jnp.arange(3, 6)])
+        chm_2d = C[:, "x", :].set(vals_2d)
+
+        # single values are fine:
+        assert chm_2d[jnp.array(0), "x", 2] == vals_2d[0, 2]
+
+        with pytest.raises(ValueError):
+            # partial slices are not allowed:
+            chm_2d[:, "x", jnp.array(2)]

--- a/tests/generative_functions/test_repeat_combinator.py
+++ b/tests/generative_functions/test_repeat_combinator.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import jax
 import jax.numpy as jnp
-from jax.random import PRNGKey
 
 from genjax import ChoiceMapBuilder as C
 from genjax import gen, normal
@@ -25,7 +25,7 @@ class TestRepeatCombinator:
         def model():
             return normal(0.0, 1.0) @ "x"
 
-        key = PRNGKey(314)
+        key = jax.random.key(314)
         tr, w = model.repeat(n=10).importance(key, C[1, "x"].set(3.0), ())
         assert normal.assess(C.v(tr.get_choices()[1, "x"]), (0.0, 1.0))[0] == w
 
@@ -34,7 +34,7 @@ class TestRepeatCombinator:
         def square(x):
             return x * x
 
-        key = PRNGKey(314)
+        key = jax.random.key(314)
         repeat_retval = square.repeat(n=10)(2)(key)
 
         assert repeat_retval.shape == (10,), "We asked for and received 10 squares"

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -53,8 +53,8 @@ class TestIterateSimpleNormal:
         for i in range(1, 5):
             tr, w = jax.jit(scanner.importance)(sub_key, C[i, "z"].set(0.5), (0.01,))
             value = tr.get_sample()[i, "z"]
-            assert value == genjax.Mask(0.5, True)
-            prev = tr.get_sample()[i - 1, "z"].unmask()
+            assert value == 0.5
+            prev = tr.get_sample()[i - 1, "z"]
             assert w == genjax.normal.assess(C.v(value), (prev, 1.0))[0]
 
     def test_iterate_simple_normal_update(self, key):
@@ -73,7 +73,7 @@ class TestIterateSimpleNormal:
                 C[i, "z"].set(1.0),
                 Diff.no_change((0.01,)),
             )
-            assert new_tr.get_sample()[i, "z"] == genjax.Mask(1.0, True)
+            assert new_tr.get_sample()[i, "z"] == 1.0
 
 
 @genjax.gen

--- a/tests/generative_functions/test_static_gen_fn.py
+++ b/tests/generative_functions/test_static_gen_fn.py
@@ -690,10 +690,10 @@ class TestGenFnClosure:
             return genjax.normal(1.0, 0.001) @ "x"
 
         gfc = model()
-        tr = gfc.simulate(jax.random.PRNGKey(0), ())
+        tr = gfc.simulate(jax.random.key(0), ())
         assert tr.get_score() == genjax.normal.logpdf(tr.get_retval(), 1.0, 0.001)
         # This failed in GEN-420
-        tr_u, w = gfc.importance(jax.random.PRNGKey(1), C.kw(x=1.1), ())
+        tr_u, w = gfc.importance(jax.random.key(1), C.kw(x=1.1), ())
         assert tr_u.get_score() == genjax.normal.logpdf(tr_u.get_retval(), 1.0, 0.001)
         assert w == tr_u.get_score()
 
@@ -706,7 +706,7 @@ class TestGenFnClosure:
             _sampled = genjax.normal(x + y, z) @ "sampled"
             return z
 
-        key = jax.random.PRNGKey(0)
+        key = jax.random.key(0)
 
         # show that we error with z missing:
         with pytest.raises(ValueError, match="z must be provided"):
@@ -761,7 +761,7 @@ class TestHandleKwargs:
         # handle_kwargs produces a new model capable of handling keyword args.
         kwm = model.handle_kwargs()
 
-        key = jax.random.PRNGKey(0)
+        key = jax.random.key(0)
         kwm_tr = kwm.simulate(key, ((1.0,), {"y": 2.0, "z": 3.0}))
         model_tr = model.simulate(key, (1.0, 2.0, 3.0))
 

--- a/tests/generative_functions/test_vmap_combinator.py
+++ b/tests/generative_functions/test_vmap_combinator.py
@@ -210,7 +210,7 @@ class TestVmapCombinator:
             return (new_x, new_x + 1)
 
         trace = step.vmap(in_axes=(None, 0)).simulate(
-            jax.random.PRNGKey(20), (2.0, jnp.arange(0, dtype=float))
+            jax.random.key(20), (2.0, jnp.arange(0, dtype=float))
         )
 
         assert (

--- a/tests/generative_functions/test_vmap_combinator.py
+++ b/tests/generative_functions/test_vmap_combinator.py
@@ -75,7 +75,7 @@ class TestVmapCombinator:
         (tr, _) = kernel.importance(sub_key, chm, (map_over,))
         for i in range(0, 3):
             v = tr.get_choices()[i, "z"]
-            assert v == genjax.Mask(zv[i], True)
+            assert v == zv[i]
 
     def test_vmap_combinator_nested_indexed_choice_map_importance(self):
         @genjax.vmap(in_axes=(0,))


### PR DESCRIPTION
This PR:

- replaces remaining `PRNGKey` uses with `jax.random.key`
- adds `:` support to `ChoiceMap`, both in the `C[:, "x", :]` builder notation and in lookups, like `chm[:, "x", :]`
- adds a validation for making sure that users don't provide invalid selection sequences.

The validation applies to the address supplied in `ChoiceMap` creation via `C[<address>]`, and selection via `chm[<address>]`.

The rules are, after filtering out string addresses:
- you are allowed any number of `int` or `ScalarInt` address components, because drop a dimension at each `get_submap` call.
- afterward, you are allowed a single non-scalar array. (On lookup, this single entry could also be a partial slice, like `1:3`)
- the tail of the address must be all full slices, i.e. `:`

that is not FULL slice support, but it's pretty general and should help our users figure out how to create 2d slices!

```python
C[:, "x", :].set(<2d array>)
```