### PR TITLE
Remove type aliases

### DIFF
--- a/docs/library/core.md
+++ b/docs/library/core.md
@@ -55,7 +55,7 @@ For instance, JAX disallows usage of runtime values to resolve Python control fl
 
 In GenJAX, we take advantage of JAX's tracing to construct code which, when traced, produces specialized code _depending on static information_. At the same time, we are careful to encode Gen's interfaces to respect JAX's rules which govern how static / runtime values can be used.
 
-The most primitive way to encode _runtime uncertainty_ about a piece of data is to attach a `Bool` to it, which indicates whether the data is "on" or "off".
+The most primitive way to encode _runtime uncertainty_ about a piece of data is to attach a `bool` to it, which indicates whether the data is "on" or "off".
 
 GenJAX contains a system for tagging data with flags, to indicate if the data is valid or invalid during inference interface computations _at runtime_. The key data structure which supports this system is `genjax.core.Mask`.
 

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -35,13 +35,11 @@ from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
     Any,
     ArrayLike,
-    Bool,
     Callable,
     EllipsisType,
     Final,
     Flag,
     Generic,
-    String,
     TypeVar,
 )
 
@@ -52,7 +50,7 @@ if TYPE_CHECKING:
 # Address types #
 #################
 
-StaticAddressComponent = String
+StaticAddressComponent = str
 DynamicAddressComponent = ArrayLike
 AddressComponent = StaticAddressComponent | DynamicAddressComponent
 Address = tuple[()] | tuple[AddressComponent, ...]
@@ -1207,7 +1205,7 @@ class ChoiceMap(Sample):
         """
         return ChmSel.build(self)
 
-    def static_is_empty(self) -> Bool:
+    def static_is_empty(self) -> bool:
         """
         Returns True if this ChoiceMap is equal to `ChoiceMap.empty()`, False otherwise.
         """
@@ -1494,7 +1492,7 @@ class Static(ChoiceMap):
             acc ^= v.mask(check(k))
         return acc
 
-    def static_is_empty(self) -> Bool:
+    def static_is_empty(self) -> bool:
         return len(self.mapping) == 0
 
     def __treescope_repr__(self, path, subtree_renderer):

--- a/src/genjax/_src/core/generative/core.py
+++ b/src/genjax/_src/core/generative/core.py
@@ -133,7 +133,7 @@ class MaskedConstraint(Constraint):
     """
     A `MaskedConstraint` encodes a possible constraint.
 
-    Formally, `MaskedConstraint(f: Bool, c: Constraint)` represents the constraint `Option((x $\\mapsto$ x, x))`,
+    Formally, `MaskedConstraint(f: bool, c: Constraint)` represents the constraint `Option((x $\\mapsto$ x, x))`,
     where the None case is represented by `EmptyConstraint`.
     """
 

--- a/src/genjax/_src/core/generative/generative_function.py
+++ b/src/genjax/_src/core/generative/generative_function.py
@@ -38,10 +38,8 @@ from genjax._src.core.typing import (
     Callable,
     Generic,
     InAxes,
-    Int,
     PRNGKey,
     Self,
-    String,
     TypeVar,
 )
 
@@ -677,7 +675,7 @@ class GenerativeFunction(Generic[R], Pytree):
 
         return genjax.vmap(in_axes=in_axes)(self)
 
-    def repeat(self, /, *, n: Int) -> "GenerativeFunction[R]":
+    def repeat(self, /, *, n: int) -> "GenerativeFunction[R]":
         """
         Returns a [`genjax.GenerativeFunction`][] that samples from `self` `n` times, returning a vector of `n` results.
 
@@ -718,7 +716,7 @@ class GenerativeFunction(Generic[R], Pytree):
         self: "GenerativeFunction[tuple[Carry, Y]]",
         /,
         *,
-        n: Int | None = None,
+        n: int | None = None,
     ) -> "GenerativeFunction[tuple[Carry, Y]]":
         """
         When called on a [`genjax.GenerativeFunction`][] of type `(c, a) -> (c, b)`, returns a new [`genjax.GenerativeFunction`][] of type `(c, [a]) -> (c, [b])` where
@@ -913,7 +911,7 @@ class GenerativeFunction(Generic[R], Pytree):
         self,
         /,
         *,
-        n: Int,
+        n: int,
     ) -> "GenerativeFunction[R]":
         """
         When called on a [`genjax.GenerativeFunction`][] of type `a -> a`, returns a new [`genjax.GenerativeFunction`][] of type `a -> [a]` where
@@ -970,7 +968,7 @@ class GenerativeFunction(Generic[R], Pytree):
         self,
         /,
         *,
-        n: Int,
+        n: int,
     ) -> "GenerativeFunction[R]":
         """
         Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type `a -> a` and returns a new [`genjax.GenerativeFunction`][] of type `a -> a` where
@@ -1205,7 +1203,7 @@ class GenerativeFunction(Generic[R], Pytree):
         *,
         pre: Callable[..., ArgTuple],
         post: Callable[[ArgTuple, R], S],
-        info: String | None = None,
+        info: str | None = None,
     ) -> "GenerativeFunction[S]":
         """
         Returns a new [`genjax.GenerativeFunction`][] and applies pre- and post-processing functions to its arguments and return value.
@@ -1256,7 +1254,7 @@ class GenerativeFunction(Generic[R], Pytree):
         return genjax.dimap(pre=pre, post=post, info=info)(self)
 
     def map(
-        self, f: Callable[[R], S], *, info: String | None = None
+        self, f: Callable[[R], S], *, info: str | None = None
     ) -> "GenerativeFunction[S]":
         """
         Specialized version of [`genjax.dimap`][] where only the post-processing function is applied.
@@ -1297,7 +1295,7 @@ class GenerativeFunction(Generic[R], Pytree):
         return genjax.map(f=f, info=info)(self)
 
     def contramap(
-        self, f: Callable[..., ArgTuple], *, info: String | None = None
+        self, f: Callable[..., ArgTuple], *, info: str | None = None
     ) -> "GenerativeFunction[R]":
         """
         Specialized version of [`genjax.GenerativeFunction.dimap`][] where only the pre-processing function is applied.

--- a/src/genjax/_src/core/interpreters/forward.py
+++ b/src/genjax/_src/core/interpreters/forward.py
@@ -26,7 +26,7 @@ from jax.interpreters import partial_eval as pe
 
 from genjax._src.core.interpreters.staging import WrappedFunWithAux, stage
 from genjax._src.core.pytree import Pytree
-from genjax._src.core.typing import Any, Bool, Callable, Value
+from genjax._src.core.typing import Any, Callable, Value
 
 #########################
 # Custom JAX primitives #
@@ -189,7 +189,7 @@ class Environment(Pytree):
 
 class StatefulHandler:
     @abc.abstractmethod
-    def handles(self, primitive: jc.Primitive) -> Bool:
+    def handles(self, primitive: jc.Primitive) -> bool:
         pass
 
     @abc.abstractmethod

--- a/src/genjax/_src/core/interpreters/staging.py
+++ b/src/genjax/_src/core/interpreters/staging.py
@@ -32,7 +32,6 @@ from genjax._src.core.typing import (
     ArrayLike,
     Callable,
     Flag,
-    Int,
     Iterable,
     Sequence,
     TypeVar,
@@ -168,7 +167,7 @@ def tree_choose(
         # - in the case of compatible types requiring casts (like bool => int),
         #   result's dtype tells us the final type.
         result = jnp.choose(idx, vs, mode="wrap")
-        if isinstance(idx, Int):
+        if isinstance(idx, int):
             return jnp.asarray(vs[idx % len(vs)], dtype=result.dtype)
         else:
             return result

--- a/src/genjax/_src/core/interpreters/time_travel.py
+++ b/src/genjax/_src/core/interpreters/time_travel.py
@@ -31,8 +31,6 @@ from genjax._src.core.typing import (
     ArrayLike,
     Callable,
     Generic,
-    Int,
-    String,
     TypeVar,
 )
 
@@ -53,7 +51,7 @@ class FrameRecording(Generic[R, S], Pytree):
 @Pytree.dataclass
 class RecordPoint(Generic[R, S], Pytree):
     callable: Closure[R]
-    debug_tag: String | None = Pytree.static()
+    debug_tag: str | None = Pytree.static()
 
     def default_call(self, *args) -> R:
         return self.callable(*args)
@@ -81,7 +79,7 @@ class RecordPoint(Generic[R, S], Pytree):
 
 def rec(
     callable: Callable[..., R],
-    debug_tag: String | None = None,
+    debug_tag: str | None = None,
 ):
     if not isinstance(callable, Closure):
         callable = Pytree.partial()(callable)
@@ -203,21 +201,21 @@ class TimeTravelingDebugger(Pytree):
     final_retval: Any
     sequence: list[FrameRecording[Any, Any]]
     jump_points: dict[Any, Any] = Pytree.static()
-    ptr: Int = Pytree.static()
+    ptr: int = Pytree.static()
 
-    def frame(self) -> tuple[String | None, FrameRecording[Any, Any]]:
+    def frame(self) -> tuple[str | None, FrameRecording[Any, Any]]:
         frame = self.sequence[self.ptr]
         reverse_jump_points = {v: k for (k, v) in self.jump_points.items()}
         jump_tag = reverse_jump_points.get(self.ptr, None)
         return jump_tag, frame
 
-    def summary(self) -> tuple[Any, tuple[String | None, FrameRecording[Any, Any]]]:
+    def summary(self) -> tuple[Any, tuple[str | None, FrameRecording[Any, Any]]]:
         frame = self.sequence[self.ptr]
         reverse_jump_points = {v: k for (k, v) in self.jump_points.items()}
         jump_tag = reverse_jump_points.get(self.ptr, None)
         return self.final_retval, (jump_tag, frame)
 
-    def jump(self, debug_tag: String) -> "TimeTravelingDebugger":
+    def jump(self, debug_tag: str) -> "TimeTravelingDebugger":
         jump_pt = self.jump_points[debug_tag]
         return TimeTravelingDebugger(
             self.final_retval,

--- a/src/genjax/_src/core/pytree.py
+++ b/src/genjax/_src/core/pytree.py
@@ -30,7 +30,6 @@ from genjax._src.core.typing import (
     Any,
     Callable,
     Generic,
-    Int,
     TypeVar,
     static_check_is_concrete,
 )
@@ -314,7 +313,7 @@ class Closure(Generic[R], Pytree):
         return self.fn(*self.dyn_args, *args, **kwargs)
 
 
-def nth(x: Pytree, idx: Int | slice):
+def nth(x: Pytree, idx: int | slice):
     """Returns a Pytree in which `[idx]` has been applied to every leaf."""
     return jtu.tree_map(lambda v: v[idx], x)
 

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -49,12 +49,7 @@ Generator = btyping.Generator
 # JAX Type alias.
 InAxes = int | None | Sequence[Any]
 
-# Types of Python literals.
-Int = int
-Float = float
-Bool = bool
-Flag = Bool | BoolArray
-String = str
+Flag = bool | BoolArray
 
 Value = Any
 
@@ -80,7 +75,7 @@ ParamSpec = btyping.ParamSpec
 #################
 
 
-def static_check_is_array(v: Any) -> Bool:
+def static_check_is_array(v: Any) -> bool:
     return (
         isinstance(v, jnp.ndarray)
         or isinstance(v, np.ndarray)
@@ -98,7 +93,7 @@ def static_check_supports_grad(v):
     return static_check_is_array(v) and v.dtype == np.float32
 
 
-def static_check_shape_dtype_equivalence(vs: list[Array]) -> Bool:
+def static_check_shape_dtype_equivalence(vs: list[Array]) -> bool:
     shape_dtypes = [(v.shape, v.dtype) for v in vs]
     num_unique = set(shape_dtypes)
     return len(num_unique) == 1
@@ -109,18 +104,15 @@ __all__ = [
     "Any",
     "Array",
     "ArrayLike",
-    "Bool",
     "BoolArray",
     "Callable",
     "EllipsisType",
     "Final",
     "Flag",
-    "Float",
     "FloatArray",
     "Generator",
     "Generic",
     "InAxes",
-    "Int",
     "IntArray",
     "Is",
     "Iterable",

--- a/src/genjax/_src/generative_functions/combinators/dimap.py
+++ b/src/genjax/_src/generative_functions/combinators/dimap.py
@@ -35,7 +35,6 @@ from genjax._src.core.typing import (
     Callable,
     Generic,
     PRNGKey,
-    String,
     TypeVar,
 )
 
@@ -114,7 +113,7 @@ class DimapCombinator(Generic[ArgTuple, R, S], GenerativeFunction[S]):
     inner: GenerativeFunction[R]
     argument_mapping: Callable[[tuple[Any, ...]], ArgTuple] = Pytree.static()
     retval_mapping: Callable[[ArgTuple, R], S] = Pytree.static()
-    info: String | None = Pytree.static(default=None)
+    info: str | None = Pytree.static(default=None)
 
     def simulate(
         self,
@@ -226,7 +225,7 @@ def dimap(
     *,
     pre: Callable[..., ArgTuple] = lambda *args: args,
     post: Callable[[ArgTuple, R], S] = lambda _, retval: retval,
-    info: String | None = None,
+    info: str | None = None,
 ) -> Callable[[GenerativeFunction[R]], DimapCombinator[ArgTuple, R, S]]:
     """
     Returns a decorator that wraps a [`genjax.GenerativeFunction`][] and applies pre- and post-processing functions to its arguments and return value.
@@ -280,7 +279,7 @@ def dimap(
 def map(
     f: Callable[[R], S],
     *,
-    info: String | None = None,
+    info: str | None = None,
 ) -> Callable[[GenerativeFunction[R]], DimapCombinator[tuple[Any, ...], R, S]]:
     """
     Returns a decorator that wraps a [`genjax.GenerativeFunction`][] and applies a post-processing function to its return value.
@@ -328,7 +327,7 @@ def map(
 def contramap(
     f: Callable[..., ArgTuple],
     *,
-    info: String | None = None,
+    info: str | None = None,
 ) -> Callable[[GenerativeFunction[R]], DimapCombinator[ArgTuple, R, R]]:
     """
     Returns a decorator that wraps a [`genjax.GenerativeFunction`][] and applies a pre-processing function to its arguments.

--- a/src/genjax/_src/generative_functions/combinators/repeat.py
+++ b/src/genjax/_src/generative_functions/combinators/repeat.py
@@ -19,7 +19,6 @@ from genjax._src.core.generative import (
 )
 from genjax._src.core.typing import (
     Callable,
-    Int,
     TypeVar,
 )
 
@@ -27,7 +26,7 @@ R = TypeVar("R")
 
 
 def RepeatCombinator(
-    gen_fn: GenerativeFunction[R], /, *, n: Int
+    gen_fn: GenerativeFunction[R], /, *, n: int
 ) -> GenerativeFunction[R]:
     """
     A combinator that samples from a supplied [`genjax.GenerativeFunction`][] `gen_fn` a fixed number of times, returning a vector of `n` results.
@@ -41,7 +40,7 @@ def RepeatCombinator(
     )
 
 
-def repeat(*, n: Int) -> Callable[[GenerativeFunction[R]], GenerativeFunction[R]]:
+def repeat(*, n: int) -> Callable[[GenerativeFunction[R]], GenerativeFunction[R]]:
     """
     Returns a decorator that wraps a [`genjax.GenerativeFunction`][] `gen_fn` of type `a -> b` and returns a new `GenerativeFunction` of type `a -> [b]` that samples from `gen_fn `n` times, returning a vector of `n` results.
 

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -38,7 +38,6 @@ from genjax._src.core.typing import (
     Callable,
     FloatArray,
     Generic,
-    Int,
     IntArray,
     PRNGKey,
     TypeVar,
@@ -174,7 +173,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
     kernel_gen_fn: GenerativeFunction[tuple[Carry, Y]]
 
     # Only required for `None` carry inputs
-    length: Int | None = Pytree.static()
+    length: int | None = Pytree.static()
 
     # To get the type of return value, just invoke
     # the scanned over source (with abstract tracer arguments).
@@ -494,7 +493,7 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
 
 
 def scan(
-    *, n: Int | None = None
+    *, n: int | None = None
 ) -> Callable[
     [GenerativeFunction[tuple[Carry, Y]]], GenerativeFunction[tuple[Carry, Y]]
 ]:
@@ -735,7 +734,7 @@ def reduce() -> Callable[[GenerativeFunction[Carry]], GenerativeFunction[Carry]]
     return decorator
 
 
-def iterate(*, n: Int) -> Callable[[GenerativeFunction[Y]], GenerativeFunction[Y]]:
+def iterate(*, n: int) -> Callable[[GenerativeFunction[Y]], GenerativeFunction[Y]]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `a -> a` and returns a new [`genjax.GenerativeFunction`][] of type `a ->
     [a]` where.
@@ -797,7 +796,7 @@ def iterate(*, n: Int) -> Callable[[GenerativeFunction[Y]], GenerativeFunction[Y
 
 
 def iterate_final(
-    *, n: Int
+    *, n: int
 ) -> Callable[[GenerativeFunction[Y]], GenerativeFunction[Y]]:
     """Returns a decorator that wraps a [`genjax.GenerativeFunction`][] of type
     `a -> a` and returns a new [`genjax.GenerativeFunction`][] of type `a -> a`

--- a/src/genjax/_src/inference/exact_testbed.py
+++ b/src/genjax/_src/inference/exact_testbed.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 
 from genjax._src.core.generative import SelectionBuilder
 from genjax._src.core.pytree import Pytree
-from genjax._src.core.typing import FloatArray, Int, IntArray, PRNGKey
+from genjax._src.core.typing import FloatArray, IntArray, PRNGKey
 from genjax._src.generative_functions.combinators.scan import (
     scan,
 )
@@ -43,7 +43,7 @@ class DiscreteHMMInferenceProblem(Pytree):
 
 
 def build_test_against_exact_inference(
-    max_length: Int,
+    max_length: int,
     state_space_size: IntArray,
     transition_distance_truncation: IntArray,
     observation_distance_truncation: IntArray,

--- a/src/genjax/_src/inference/smc.py
+++ b/src/genjax/_src/inference/smc.py
@@ -36,7 +36,6 @@ from genjax._src.core.typing import (
     BoolArray,
     FloatArray,
     Generic,
-    Int,
     PRNGKey,
     TypeVar,
 )
@@ -283,12 +282,12 @@ class Importance(Generic[R], SMCAlgorithm[R]):
 @Pytree.dataclass
 class ImportanceK(Generic[R], SMCAlgorithm[R]):
     """Given a `target: Target` and a proposal `q: SampleDistribution`, as well as the
-    number of particles `k_particles: Int`, initialize a particle collection using
+    number of particles `k_particles: int`, initialize a particle collection using
     importance sampling."""
 
     target: Target[R]
     q: SampleDistribution | None = Pytree.field(default=None)
-    k_particles: Int = Pytree.static(default=2)
+    k_particles: int = Pytree.static(default=2)
 
     def get_num_particles(self):
         return self.k_particles

--- a/src/genjax/_src/inference/vi.py
+++ b/src/genjax/_src/inference/vi.py
@@ -36,7 +36,6 @@ from genjax._src.core.typing import (
     Any,
     Callable,
     FloatArray,
-    Int,
     PRNGKey,
 )
 from genjax._src.generative_functions.distributions.distribution import (
@@ -165,7 +164,7 @@ def ELBO(
 def IWELBO(
     proposal: SampleDistribution,
     make_target: Callable[[Any], Target[Any]],
-    N: Int,
+    N: int,
 ) -> Callable[[PRNGKey, Arguments], GradientEstimate]:
     """
     Return a function that computes the gradient estimate of the IWELBO loss term.

--- a/tests/generative_functions/test_mask_combinator.py
+++ b/tests/generative_functions/test_mask_combinator.py
@@ -137,7 +137,7 @@ class TestMaskCombinator:
             def scan_step_post(_unused_args, masked_retval):
                 return masked_retval.value, None
 
-            # scan_step: (a, Bool) -> a
+            # scan_step: (a, bool) -> a
             scan_step = step.mask().dimap(pre=scan_step_pre, post=scan_step_post)
             return scan_step.scan(**scan_kwargs)
 

--- a/tests/generative_functions/test_static_gen_fn.py
+++ b/tests/generative_functions/test_static_gen_fn.py
@@ -23,7 +23,7 @@ from genjax import ChoiceMapBuilder as C
 from genjax import ChoiceMapConstraint, Diff, Pytree, Update
 from genjax._src.core.typing import Array
 from genjax.generative_functions.static import AddressReuse
-from genjax.typing import Float, FloatArray
+from genjax.typing import FloatArray
 
 #############
 # Datatypes #
@@ -586,8 +586,8 @@ class TestStaticGenFnUpdate:
     def test_update_pytree_argument(self):
         @Pytree.dataclass
         class SomePytree(genjax.Pytree):
-            x: Float | FloatArray
-            y: Float | FloatArray
+            x: float | FloatArray
+            y: float | FloatArray
 
         @genjax.gen
         def simple_linked_normal_with_tree_argument(tree):


### PR DESCRIPTION
This PR:
* Removes aliases `Int`, `Float`, `Bool`, and `String` from `typing.py` (and elsewhere).