### PR TITLE
Tighten type bounds on Choice, see the consequences

### DIFF
--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -857,7 +857,7 @@ class ChoiceMap(Sample):
         return _empty
 
     @staticmethod
-    def choice(v: T) -> "Choice[T]":
+    def choice(v: ArrayLike | Mask[ArrayLike]) -> "ChoiceMap":
         """
         Creates a ChoiceMap containing a single value.
 
@@ -882,7 +882,7 @@ class ChoiceMap(Sample):
 
     @staticmethod
     @deprecated("Use ChoiceMap.choice() instead.")
-    def value(v: T) -> "Choice[T]":
+    def value(v: ArrayLike | Mask[ArrayLike]) -> "ChoiceMap":
         return ChoiceMap.choice(v)
 
     @staticmethod
@@ -1712,15 +1712,12 @@ def _pushdown_filters(chm: ChoiceMap) -> ChoiceMap:
                 return loop(c, selection(addr)).extend(addr)
 
             case Choice(v):
-                if v is None:
-                    return inner
+                sel_check = selection.check()
+                masked = Mask.maybe_none(v, sel_check)
+                if masked is None:
+                    return ChoiceMap.empty()
                 else:
-                    sel_check = selection.check()
-                    masked = Mask.maybe_none(v, sel_check)
-                    if masked is None:
-                        return ChoiceMap.empty()
-                    else:
-                        return ChoiceMap.choice(masked)
+                    return ChoiceMap.choice(masked)
 
             case Filtered(c, c_selection):
                 return loop(c, c_selection & selection)

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -40,7 +40,6 @@ from genjax._src.core.typing import (
     EllipsisType,
     Final,
     Flag,
-    Generic,
     String,
     TypeVar,
 )
@@ -1334,7 +1333,7 @@ class ChoiceMap(Sample):
 
 
 @Pytree.dataclass(match_args=True)
-class Choice(Generic[T], ChoiceMap):
+class Choice(ChoiceMap):
     """Represents a choice map with a single value.
 
     This class represents a choice map that contains a single value at the root level.
@@ -1351,9 +1350,9 @@ class Choice(Generic[T], ChoiceMap):
         ```
     """
 
-    v: T
+    v: ArrayLike | Mask[ArrayLike]
 
-    def get_value(self) -> T:
+    def get_value(self) -> ArrayLike | Mask[ArrayLike]:
         return self.v
 
     def get_submap(self, addr: ExtendedAddressComponent) -> ChoiceMap:


### PR DESCRIPTION
This PR explores what happens if we lock down the type bounds on `Choice` to be `ArrayLike | Mask[ArrayLike]`.

TODO:
- [ ] it looks like inference breaks, and we have code that assumes that we can have a choice that is itself another choicemap. Maybe this is a case, @MathieuHuot , where we are already supporting an arbitrary pytree.
- [ ] make yet another ticket discussing this
