### PR TITLE
(1 / N) Remove `ChoiceMapEditRequest`, replace with `StaticRequest`

### DIFF
--- a/src/genjax/_src/core/generative/__init__.py
+++ b/src/genjax/_src/core/generative/__init__.py
@@ -46,7 +46,6 @@ from .generative_function import (
     Update,
 )
 from .requests import (
-    ChoiceMapEditRequest,
     EmptyRequest,
     Regenerate,
 )
@@ -59,7 +58,6 @@ __all__ = [
     "ChoiceMap",
     "ChoiceMapBuilder",
     "ChoiceMapConstraint",
-    "ChoiceMapEditRequest",
     "Constraint",
     "EditRequest",
     "EmptyConstraint",

--- a/src/genjax/_src/core/generative/requests.py
+++ b/src/genjax/_src/core/generative/requests.py
@@ -16,7 +16,6 @@
 import jax.numpy as jnp
 
 from genjax._src.core.generative.choice_map import (
-    ChoiceMap,
     Selection,
 )
 from genjax._src.core.generative.core import (
@@ -51,20 +50,6 @@ class EmptyRequest(EditRequest):
 @Pytree.dataclass(match_args=True)
 class Regenerate(EditRequest):
     selection: Selection
-
-    def edit(
-        self,
-        key: PRNGKey,
-        tr: Trace[R],
-        argdiffs: Argdiffs,
-    ) -> tuple[Trace[R], Weight, Retdiff[R], "EditRequest"]:
-        gen_fn = tr.get_gen_fn()
-        return gen_fn.edit(key, tr, self, argdiffs)
-
-
-@Pytree.dataclass(match_args=True)
-class ChoiceMapEditRequest(EditRequest):
-    request_choice_map: ChoiceMap
 
     def edit(
         self,

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -41,6 +41,7 @@ IntArray = jtyping.Int[jtyping.Array, "..."]
 FloatArray = jtyping.Float[jtyping.Array, "..."]
 BoolArray = jtyping.Bool[jtyping.Array, "..."]
 Callable = btyping.Callable
+TypeAlias = btyping.TypeAlias
 Sequence = btyping.Sequence
 Iterable = btyping.Iterable
 Final = btyping.Final
@@ -123,6 +124,7 @@ __all__ = [
     "ScalarShaped",
     "Self",
     "Sequence",
+    "TypeAlias",
     "TypeVar",
     "Value",
     "static_check_is_array",

--- a/src/genjax/_src/generative_functions/distributions/distribution.py
+++ b/src/genjax/_src/generative_functions/distributions/distribution.py
@@ -24,7 +24,6 @@ from genjax._src.checkify import optional_check
 from genjax._src.core.generative import (
     Argdiffs,
     ChoiceMap,
-    ChoiceMapEditRequest,
     Constraint,
     EditRequest,
     EmptyConstraint,
@@ -382,13 +381,6 @@ class Distribution(Generic[R], GenerativeFunction[R]):
                     argdiffs,
                 )
 
-            case ChoiceMapEditRequest(requests_choice_map):
-                return self.edit_choice_map_edit_request(
-                    key,
-                    trace,
-                    requests_choice_map,
-                    argdiffs,
-                )
             case _:
                 raise NotSupportedEditRequest(edit_request)
 

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -132,7 +132,7 @@ class StaticTrace(Generic[R], Trace[R]):
 
 
 @Pytree.dataclass(match_args=True)
-class StaticEditRequest(EditRequest):
+class StaticRequest(EditRequest):
     addressed: dict[StaticAddressComponent | StaticAddress, EditRequest]
 
     def edit(
@@ -1014,7 +1014,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
             addresses = Pytree.tree_const_unwrap(addresses)
             addresses = map(collapse_address, addresses)
             bwd_addressed = dict(zip(addresses, subrequests))
-            return StaticEditRequest(bwd_addressed)
+            return StaticRequest(bwd_addressed)
 
         bwd_request = make_bwd_request(address_visitor, bwd_requests)
         return (
@@ -1067,7 +1067,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
             addresses = Pytree.tree_const_unwrap(addresses)
             addresses = map(collapse_address, addresses)
             bwd_addressed = dict(zip(addresses, subrequests))
-            return StaticEditRequest(bwd_addressed)
+            return StaticRequest(bwd_addressed)
 
         bwd_request = make_bwd_request(address_visitor, bwd_requests)
         return (
@@ -1101,7 +1101,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
                     argdiffs,
                 )
 
-            case StaticEditRequest(addressed):
+            case StaticRequest(addressed):
                 return self.edit_static_edit_request(
                     key,
                     trace,

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -59,6 +59,7 @@ from genjax._src.core.typing import (
     FloatArray,
     Generic,
     PRNGKey,
+    TypeAlias,
 )
 
 _WRAPPER_ASSIGNMENTS = (
@@ -85,7 +86,7 @@ class AddressVisitor(Pytree):
         return self.visited
 
 
-def collapse_address(addr):
+def collapse_address(addr: StaticAddressComponent | StaticAddress):
     return addr[0] if isinstance(addr, tuple) and len(addr) == 1 else addr
 
 
@@ -130,10 +131,12 @@ class StaticTrace(Generic[R], Trace[R]):
 # Static (trie-like) edit request  #
 ####################################
 
+StaticDict: TypeAlias = dict[StaticAddressComponent | StaticAddress, EditRequest]
+
 
 @Pytree.dataclass(match_args=True)
 class StaticRequest(EditRequest):
-    addressed: dict[StaticAddressComponent | StaticAddress, EditRequest]
+    addressed: StaticDict
 
     def edit(
         self,
@@ -570,7 +573,7 @@ def update_transform(source_fn):
 class StaticEditRequestHandler(StaticHandler):
     key: PRNGKey
     previous_trace: StaticTrace[Any]
-    addressed: dict[StaticAddressComponent | StaticAddress, EditRequest]
+    addressed: StaticDict
     address_visitor: AddressVisitor = Pytree.field(default_factory=AddressVisitor)
     score: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
     weight: FloatArray = Pytree.field(default_factory=lambda: jnp.zeros(()))
@@ -983,7 +986,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
         self,
         key: PRNGKey,
         trace: StaticTrace[R],
-        addressed: dict[StaticAddressComponent | StaticAddress, EditRequest],
+        addressed: StaticDict,
         argdiffs: Argdiffs,
     ) -> tuple[StaticTrace[R], Weight, Retdiff[R], EditRequest]:
         syntax_sugar_handled = push_trace_overload_stack(

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -85,6 +85,10 @@ class AddressVisitor(Pytree):
         return self.visited
 
 
+def collapse_address(addr):
+    return addr[0] if isinstance(addr, tuple) and len(addr) == 1 else addr
+
+
 #########
 # Trace #
 #########
@@ -594,7 +598,7 @@ class StaticEditRequestHandler(StaticHandler):
     def get_subrequest(
         self, addr: StaticAddressComponent | StaticAddress
     ) -> EditRequest:
-        addr = addr[0] if isinstance(addr, tuple) and len(addr) == 1 else addr
+        addr = collapse_address(addr)
         return self.addressed.get(addr, EmptyRequest())
 
     def get_subtrace(
@@ -1008,14 +1012,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
         ):
             addresses = visitor.get_visited()
             addresses = Pytree.tree_const_unwrap(addresses)
-            addresses = list(
-                map(
-                    lambda addr: addr[0]
-                    if isinstance(addr, tuple) and len(addr) == 1
-                    else addr,
-                    addresses,
-                )
-            )
+            addresses = map(collapse_address, addresses)
             bwd_addressed = dict(zip(addresses, subrequests))
             return StaticEditRequest(bwd_addressed)
 
@@ -1068,6 +1065,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
         ):
             addresses = visitor.get_visited()
             addresses = Pytree.tree_const_unwrap(addresses)
+            addresses = map(collapse_address, addresses)
             bwd_addressed = dict(zip(addresses, subrequests))
             return StaticEditRequest(bwd_addressed)
 

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -86,7 +86,9 @@ class AddressVisitor(Pytree):
         return self.visited
 
 
-def collapse_address(addr: StaticAddressComponent | StaticAddress):
+def collapse_address(
+    addr: StaticAddressComponent | StaticAddress,
+) -> StaticAddressComponent | StaticAddress:
     return addr[0] if isinstance(addr, tuple) and len(addr) == 1 else addr
 
 

--- a/src/genjax/core/requests.py
+++ b/src/genjax/core/requests.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from genjax._src.core.generative.requests import (
-    ChoiceMapEditRequest,
+    EmptyRequest,
     Regenerate,
 )
 
-__all__ = ["ChoiceMapEditRequest", "Regenerate"]
+__all__ = ["EmptyRequest", "Regenerate"]

--- a/src/genjax/generative_functions/static/__init__.py
+++ b/src/genjax/generative_functions/static/__init__.py
@@ -14,6 +14,7 @@
 
 from genjax._src.generative_functions.static import (
     AddressReuse,
+    StaticEditRequest,
     StaticGenerativeFunction,
     gen,
     trace,
@@ -22,6 +23,7 @@ from genjax._src.generative_functions.static import (
 
 __all__ = [
     "AddressReuse",
+    "StaticEditRequest",
     "StaticGenerativeFunction",
     "gen",
     "trace",

--- a/src/genjax/generative_functions/static/__init__.py
+++ b/src/genjax/generative_functions/static/__init__.py
@@ -14,8 +14,8 @@
 
 from genjax._src.generative_functions.static import (
     AddressReuse,
-    StaticEditRequest,
     StaticGenerativeFunction,
+    StaticRequest,
     gen,
     trace,
     trace_p,
@@ -23,8 +23,8 @@ from genjax._src.generative_functions.static import (
 
 __all__ = [
     "AddressReuse",
-    "StaticEditRequest",
     "StaticGenerativeFunction",
+    "StaticRequest",
     "gen",
     "trace",
     "trace_p",

--- a/tests/generative_functions/test_static_gen_fn.py
+++ b/tests/generative_functions/test_static_gen_fn.py
@@ -20,7 +20,7 @@ import pytest
 
 import genjax
 from genjax import ChoiceMapBuilder as C
-from genjax import Diff, Pytree, Regenerate, StaticEditRequest, Update
+from genjax import Diff, Pytree, Regenerate, StaticRequest, Update
 from genjax import Selection as S
 from genjax._src.core.generative.choice_map import ChoiceMapConstraint
 from genjax._src.core.typing import Array
@@ -759,7 +759,7 @@ class TestStaticEditRequest:
 
         key = jax.random.key(0)
         tr = simple_normal.simulate(key, ())
-        request = StaticEditRequest({
+        request = StaticRequest({
             "y1": Regenerate(S.all()),
             "y2": Update(C.v(3.0)),
         })

--- a/tests/generative_functions/test_static_gen_fn.py
+++ b/tests/generative_functions/test_static_gen_fn.py
@@ -772,6 +772,28 @@ class TestStaticEditRequest:
         assert w_ != 0.0
         assert w + w_ == 0.0
 
+    def test_static_edit_request_with_tuple_addr(self):
+        @genjax.gen
+        def simple_normal():
+            y1 = genjax.normal(0.0, 1.0) @ ("y1", "y3")
+            y2 = genjax.normal(0.0, 1.0) @ "y2"
+            return y1 + y2
+
+        key = jax.random.key(0)
+        tr = simple_normal.simulate(key, ())
+        request = StaticRequest({
+            ("y1", "y3"): Regenerate(S.all()),
+            "y2": Update(C.v(3.0)),
+        })
+        key, sub_key = jax.random.split(key)
+        new_tr, w, _, bwd_request = request.edit(key, tr, ())
+        assert new_tr.get_choices()["y2"] == 3.0
+        assert w != 0.0
+        old_tr, w_, _, _ = bwd_request.edit(sub_key, new_tr, ())
+        assert old_tr.get_choices()["y2"] == tr.get_choices()["y2"]
+        assert w_ != 0.0
+        assert w + w_ == 0.0
+
 
 class TestHandleKwargs:
     def test_handle_kwargs(self):

--- a/tests/generative_functions/test_static_gen_fn.py
+++ b/tests/generative_functions/test_static_gen_fn.py
@@ -765,7 +765,6 @@ class TestStaticEditRequest:
         })
         key, sub_key = jax.random.split(key)
         new_tr, w, _, bwd_request = request.edit(key, tr, ())
-        print(bwd_request)
         assert new_tr.get_choices()["y2"] == 3.0
         assert w != 0.0
         old_tr, w_, _, _ = bwd_request.edit(sub_key, new_tr, ())

--- a/tests/inference/test_requests.py
+++ b/tests/inference/test_requests.py
@@ -37,7 +37,8 @@ class TestRegenerate:
         assert fwd_w != 0.0
         new_v = new_tr.get_choices()["y1"]
         assert old_v != new_v
-        old_tr, bwd_w, _, bwd_request = bwd_request.edit(key, new_tr, ())
+        print(bwd_request)
+        old_tr, bwd_w, _, bwd_request = bwd_request.edit(sub_key, new_tr, ())
         assert bwd_w != 0.0
         assert (fwd_w + bwd_w) == 0.0
         old_old_v = old_tr.get_choices()["y1"]

--- a/tests/inference/test_requests.py
+++ b/tests/inference/test_requests.py
@@ -37,7 +37,6 @@ class TestRegenerate:
         assert fwd_w != 0.0
         new_v = new_tr.get_choices()["y1"]
         assert old_v != new_v
-        print(bwd_request)
         old_tr, bwd_w, _, bwd_request = bwd_request.edit(sub_key, new_tr, ())
         assert bwd_w != 0.0
         assert (fwd_w + bwd_w) == 0.0


### PR DESCRIPTION
Eliminate source of strife in the form of deleting `ChoiceMapEditRequest` -- add back in hierarchical `EditRequest` via `StaticRequest` (lives off `StaticGenerativeFunction`). Allows creating hierarchical (compositional!) edit requests:

```python
request = StaticRequest({
    "y1": Regenerate(S.all()),
    "y2": Update(C.v(3.0)),
})
```
