### PR TITLE
dimap's post-xform should accept the original args (GEN-781)

### DIFF
--- a/src/genjax/_src/core/generative/generative_function.py
+++ b/src/genjax/_src/core/generative/generative_function.py
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
     import genjax
 
 _C = TypeVar("_C", bound=Callable[..., Any])
-ArgTuple = TypeVar("ArgTuple", bound=tuple[Any, ...])
 
 # Generative Function type variables
 R = TypeVar("R")
@@ -1229,8 +1228,8 @@ class GenerativeFunction(Generic[R], Pytree):
         self,
         /,
         *,
-        pre: Callable[..., ArgTuple],
-        post: Callable[[ArgTuple, R], S],
+        pre: Callable[..., tuple[Any, ...]],
+        post: Callable[[tuple[Any, ...], R], S],
         info: str | None = None,
     ) -> "GenerativeFunction[S]":
         """
@@ -1323,7 +1322,7 @@ class GenerativeFunction(Generic[R], Pytree):
         return genjax.map(f=f, info=info)(self)
 
     def contramap(
-        self, f: Callable[..., ArgTuple], *, info: str | None = None
+        self, f: Callable[..., tuple[Any, ...]], *, info: str | None = None
     ) -> "GenerativeFunction[R]":
         """
         Specialized version of [`genjax.GenerativeFunction.dimap`][] where only the pre-processing function is applied.

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -770,7 +770,7 @@ def scan(
     return decorator
 
 
-def prepend_initial_acc(args: tuple[Carry, Any], ret: tuple[Carry, Carry]) -> Carry:
+def prepend_initial_acc(args: tuple[Carry, ...], ret: tuple[Carry, Carry]) -> Carry:
     """Prepends the initial accumulator value to the array of accumulated
     values.
 

--- a/tests/generative_functions/test_dimap_combinator.py
+++ b/tests/generative_functions/test_dimap_combinator.py
@@ -25,7 +25,7 @@ class TestDimapCombinator:
             return (x + 1, y * 2, y * 3)
 
         def post_process(args, retval):
-            assert len(args) == 3, "post_process has to receive transformed args."
+            assert len(args) == 2, "post_process has to receive pre-transformed args."
             return retval + 2
 
         def invert_post(x):


### PR DESCRIPTION
This PR modifies `DimapCombinator` to pass args to `retval_mapping` without the `argument_mapping` applied.