### PR TITLE
Add a "static" version of `Const` (GEN-852)

### DIFF
--- a/src/genjax/_src/core/pytree.py
+++ b/src/genjax/_src/core/pytree.py
@@ -270,8 +270,27 @@ class Const(Generic[R], Pytree):
         ), f"Wrapped `val` {self.val} is not Callable."
         return self.val(*args)
 
-    def unwrap(self):
-        return self.val
+    def unwrap(self: Any) -> R:
+        """Unwrap a constant value from a `Const` instance.
+
+        This method can be used as an instance method or as a static method. When used as a static method, it returns the input value unchanged if it is not a `Const` instance.
+
+        Returns:
+            R: The unwrapped value if self is a `Const`, otherwise returns self unchanged.
+
+        Examples:
+            ```python exec="yes" html="true" source="material-block" session="core"
+            c = Pytree.const(5)
+            val = c.unwrap()  # Returns 5
+
+            # Can also be used as static method
+            val = Const.unwrap(10)  # Returns 10 unchanged
+            ```
+        """
+        if isinstance(self, Const):
+            return self.val
+        else:
+            return self
 
 
 # Construct for a type of closure which closes over dynamic values.

--- a/src/genjax/_src/core/pytree.py
+++ b/src/genjax/_src/core/pytree.py
@@ -280,6 +280,8 @@ class Const(Generic[R], Pytree):
 
         Examples:
             ```python exec="yes" html="true" source="material-block" session="core"
+            from genjax import Pytree, Const
+
             c = Pytree.const(5)
             val = c.unwrap()  # Returns 5
 

--- a/tests/core/test_pytree.py
+++ b/tests/core/test_pytree.py
@@ -4,6 +4,13 @@ import genjax
 from genjax.typing import FloatArray
 
 
+class TestPytree:
+    def test_unwrap(self):
+        c = genjax.Pytree.const(5)
+        assert c.unwrap() == 5
+        assert genjax.Const.unwrap(10) == 10
+
+
 class TestPythonic:
     def test_pythonic(self):
         @genjax.Pytree.dataclass


### PR DESCRIPTION
This PR allows folks to pass non-consts into `Const.unwrap` (in addition to the existing `const_instance.unwrap()`