### PR TITLE
Remove Xor, chip away at Or (GEN-774)

### DIFF
--- a/notebooks/_quarto.yml
+++ b/notebooks/_quarto.yml
@@ -48,7 +48,8 @@ website:
             - cookbook/expressivity/custom_distribution.ipynb
             - cookbook/expressivity/stochastic_probabilities.ipynb
             - cookbook/expressivity/stochastic_probabilities_math.ipynb
-            - cookbook/expressivity/ravi_stack.ipynb
+            # TODO: re-enable once we can support marginals as targets
+            # - cookbook/expressivity/ravi_stack.ipynb
         - section: "Inference"
           href: inference.qmd
           contents:

--- a/notebooks/cookbook/expressivity/ravi_stack.ipynb
+++ b/notebooks/cookbook/expressivity/ravi_stack.ipynb
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "marginal_model = model.marginal(\n",
-    "    selection=S[\"x\", \"y\"]\n",
+    "    selection=S[\"x\"] | S[\"y\"]\n",
     ")  # This means we are projection onto the variables x and y, marginalizing out the rest"
    ]
   },
@@ -120,18 +120,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@gen\n",
-    "def if_in_cluser_one(x_obs):\n",
-    "    y = genjax.normal(x_obs, 1.0) @ \"y\"\n",
-    "    return y\n",
-    "\n",
-    "\n",
-    "@gen\n",
-    "def if_in_cluser_two(x_obs):\n",
-    "    y = genjax.normal(x_obs, 3.0) @ \"y\"\n",
-    "    return y\n",
-    "\n",
-    "\n",
     "@gen\n",
     "def proposal(target: Target):\n",
     "    x_obs = target.constraint[\"x\"]\n",
@@ -210,6 +198,13 @@
     "\n",
     "alg.simulate(key, (target,))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -228,7 +223,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/notebooks/cookbook/expressivity/ravi_stack.ipynb
+++ b/notebooks/cookbook/expressivity/ravi_stack.ipynb
@@ -11,6 +11,8 @@
     "---\n",
     "title: Nested approximate marginalisation & RAVI stacks \n",
     "subtitle: How to be recursively wrong everywhere all the time yet correct at the end\n",
+    "execute:\n",
+    "    eval: false\n",
     "---"
    ]
   },

--- a/src/genjax/_src/adev/core.py
+++ b/src/genjax/_src/adev/core.py
@@ -245,11 +245,11 @@ class Dual(Pytree):
         return tuple(primals), tuple(tangents)
 
     @staticmethod
-    def static_check_is_dual(v):
+    def static_check_is_dual(v) -> bool:
         return isinstance(v, Dual)
 
     @staticmethod
-    def static_check_dual_tree(v):
+    def static_check_dual_tree(v) -> bool:
         return all(
             map(
                 lambda v: isinstance(v, Dual),

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -1101,13 +1101,13 @@ class ChoiceMap(Pytree):
             ```
 
         Note:
-            If multiple pairs have the same address, the resulting ChoiceMap will error on lookup, as duplicate addresses are not allowed due to the `^` call internally.
+            If multiple pairs have the same address, later pairs will overwrite earlier ones.
         """
         acc = ChoiceMap.empty()
 
         for addr, v in pairs:
             addr = addr if isinstance(addr, tuple) else (addr,)
-            acc ^= ChoiceMap.entry(v, *addr)
+            acc |= ChoiceMap.entry(v, *addr)
 
         return acc
 
@@ -1271,9 +1271,9 @@ class ChoiceMap(Pytree):
             ```
 
         Note:
-            This method is equivalent to using the ^ operator between two ChoiceMaps.
+            This method is equivalent to using the | operator between two ChoiceMaps.
         """
-        return self ^ other
+        return self | other
 
     def get_selection(self) -> Selection:
         """
@@ -1305,9 +1305,12 @@ class ChoiceMap(Pytree):
     ###########
     # Dunders #
     ###########
-
+    @deprecated(
+        reason="TODO",
+        version="0.8.0",
+    )
     def __xor__(self, other: "ChoiceMap") -> "ChoiceMap":
-        return Xor.build(self, other)
+        return self | other
 
     def __or__(self, other: "ChoiceMap") -> "ChoiceMap":
         return Or.build(self, other)
@@ -1685,69 +1688,6 @@ class Switch(ChoiceMap):
 
 
 @Pytree.dataclass(match_args=True)
-class Xor(ChoiceMap):
-    """Represents a disjoint union of two choice maps.
-
-    This class combines two choice maps in a way that ensures their domains are disjoint.
-    It's used to merge two choice maps while preventing overlapping addresses.
-
-    Attributes:
-        c1: The first choice map.
-        c2: The second choice map.
-
-    Examples:
-        ```python exec="yes" html="true" source="material-block" session="choicemap"
-        chm1 = ChoiceMap.value(5).extend("x")
-        chm2 = ChoiceMap.value(10).extend("y")
-        xor_chm = chm1 ^ chm2
-        assert xor_chm.get_submap("x").get_value() == 5
-        assert xor_chm.get_submap("y").get_value() == 10
-        ```
-
-    Raises:
-        Exception: If there's a value collision between the two choice maps.
-    """
-
-    c1: ChoiceMap
-    c2: ChoiceMap
-
-    @staticmethod
-    def build(
-        c1: ChoiceMap,
-        c2: ChoiceMap,
-    ) -> ChoiceMap:
-        if c2.static_is_empty():
-            return c1
-        elif c1.static_is_empty():
-            return c2
-        else:
-            match (c1, c2):
-                case (Static(), Static()):
-                    return Static.merge_with(lambda a, b: a ^ b, c1, c2)
-                case _:
-                    return Xor(c1, c2)
-
-    def filter(self, selection: Selection) -> ChoiceMap:
-        return self.c1.filter(selection) ^ self.c2.filter(selection)
-
-    def get_value(self) -> Any:
-        match self.c1.get_value(), self.c2.get_value():
-            case None, b:
-                return b
-            case a, None:
-                return a
-            case a, b:
-                a = Mask.build(a)
-                b = Mask.build(b)
-                return (a ^ b).flatten()
-
-    def get_submap(self, addr: AddressComponent) -> ChoiceMap:
-        remaining_1 = self.c1.get_submap(addr)
-        remaining_2 = self.c2.get_submap(addr)
-        return remaining_1 ^ remaining_2
-
-
-@Pytree.dataclass(match_args=True)
 class Or(ChoiceMap):
     """Represents a choice map that combines two choice maps using an OR operation.
 
@@ -1828,7 +1768,7 @@ def _shape_selection(chm: ChoiceMap) -> Selection:
             case Choice():
                 return LeafSel()
 
-            case Xor(c1, c2) | Or(c1, c2):
+            case Or(c1, c2):
                 return loop(c1, selection) | loop(c2, selection)
 
             case Switch(_, chms):

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -1457,11 +1457,8 @@ class Choice(Generic[T], ChoiceMap):
 
     def filter(self, selection: Selection) -> ChoiceMap:
         sel_check = selection.check()
-        masked = Mask.maybe_mask(self.v, sel_check)
-        if masked is None:
-            return ChoiceMap.empty()
-        else:
-            return ChoiceMap.choice(masked)
+        masked = Mask.build(self.v, sel_check)
+        return Choice.build(masked)
 
     def get_value(self) -> T:
         return self.v

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -1728,6 +1728,12 @@ class Or(ChoiceMap):
             match (c1, c2):
                 case (Static(), Static()):
                     return Static.merge_with(or_, c1, c2)
+
+                case (Choice(a), Choice(b)):
+                    a = Mask.build(a)
+                    b = Mask.build(b)
+                    return Choice.build((a | b).flatten())
+
                 case _:
                     return Or(c1, c2)
 
@@ -1740,10 +1746,8 @@ class Or(ChoiceMap):
                 return b
             case a, None:
                 return a
-            case a, b:
-                a = Mask.build(a)
-                b = Mask.build(b)
-                return (a | b).flatten()
+            case _:
+                raise ValueError("Unreachable")
 
     def get_submap(self, addr: AddressComponent) -> ChoiceMap:
         submap1 = self.c1.get_submap(addr)
@@ -1780,7 +1784,7 @@ def _shape_selection(chm: ChoiceMap) -> Selection:
                 return acc
 
             case _:
-                return selection
+                raise ValueError(f"Unknown ChoiceMap type: {type(inner)}")
 
     return loop(chm, Selection.all())
 

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -1729,7 +1729,7 @@ class Or(ChoiceMap):
                 case (Choice(a), Choice(b)):
                     a = Mask.build(a)
                     b = Mask.build(b)
-                    return Choice.build((a | b).flatten())
+                    return Choice.build(a | b)
 
                 case _:
                     return Or(c1, c2)

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -1306,7 +1306,7 @@ class ChoiceMap(Pytree):
     # Dunders #
     ###########
     @deprecated(
-        reason="TODO",
+        reason="^ is deprecated, please use | or _.merge(...) instead.",
         version="0.8.0",
     )
     def __xor__(self, other: "ChoiceMap") -> "ChoiceMap":
@@ -1731,6 +1731,9 @@ class Or(ChoiceMap):
                     b = Mask.build(b)
                     return Choice.build(a | b)
 
+                case (Choice(), _) | (_, Choice()):
+                    raise Exception(f"Choice and non-Choice in Or: {c1}, {c2}")
+
                 case _:
                     return Or(c1, c2)
 
@@ -1738,13 +1741,7 @@ class Or(ChoiceMap):
         return self.c1.filter(selection) | self.c2.filter(selection)
 
     def get_value(self) -> Any:
-        match self.c1.get_value(), self.c2.get_value():
-            case None, b:
-                return b
-            case a, None:
-                return a
-            case _:
-                raise ValueError("Unreachable")
+        return None
 
     def get_submap(self, addr: AddressComponent) -> ChoiceMap:
         submap1 = self.c1.get_submap(addr)

--- a/src/genjax/_src/core/typing.py
+++ b/src/genjax/_src/core/typing.py
@@ -49,7 +49,7 @@ Generator = btyping.Generator
 Literal = btyping.Literal
 
 # JAX Type alias.
-InAxes = int | None | Sequence[Any]
+InAxes = int | Sequence[Any] | None
 
 Flag = bool | BoolArray
 

--- a/src/genjax/_src/inference/sp.py
+++ b/src/genjax/_src/inference/sp.py
@@ -26,9 +26,11 @@ from genjax._src.core.generative.core import Score
 from genjax._src.core.generative.generative_function import Trace
 from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
+    Annotated,
     Any,
     Callable,
     Generic,
+    Is,
     PRNGKey,
     TypeVar,
 )
@@ -39,6 +41,12 @@ R = TypeVar("R")
 ####################
 # Posterior target #
 ####################
+
+
+def validate_non_marginal(x):
+    if isinstance(x, Marginal):
+        raise TypeError("Target does not support Marginal generative functions.")
+    return True
 
 
 @Pytree.dataclass
@@ -68,7 +76,7 @@ class Target(Generic[R], Pytree):
         ```
     """
 
-    p: GenerativeFunction[R]
+    p: Annotated[GenerativeFunction[R], Is[validate_non_marginal]]
     args: tuple[Any, ...]
     constraint: ChoiceMap
 

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -490,7 +490,8 @@ class TestChoiceMap:
         with pytest.raises(ChoiceMapNoValueAtAddress):
             switched_array["z"]
 
-    def test_or_access(self):
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    def test_or_xor_access(self):
         # Create two choice maps with disjoint addresses
         left = ChoiceMap.kw(x=1, y=2)
         right = ChoiceMap.kw(z=3, w=4)
@@ -502,9 +503,19 @@ class TestChoiceMap:
         assert or_chm["z"] == 3  # Only in right
         assert or_chm["w"] == 4  # Only in right
 
+        # Test Xor
+        xor_chm = left ^ right
+        assert xor_chm["x"] == 1  # Only in left
+        assert xor_chm["y"] == 2  # Only in left
+        assert xor_chm["z"] == 3  # Only in right
+        assert xor_chm["w"] == 4  # Only in right
+
         # Test that non-existent addresses still raise
         with pytest.raises(ChoiceMapNoValueAtAddress):
             or_chm["does_not_exist"]
+
+        with pytest.raises(ChoiceMapNoValueAtAddress):
+            xor_chm["does_not_exist"]
 
     def test_nested_static_choicemap(self):
         # Create a nested static ChoiceMap
@@ -565,6 +576,10 @@ class TestChoiceMap:
         xyz = ChoiceMap.d({"x": 1, "y": 2, "z": 3})
         or_chm = xyz.filter(S["x"]) | xyz.filter(S["y"].mask(jnp.array(True)))
 
+        xor_chm = xyz.filter(S["x"]) ^ xyz.filter(S["y"].mask(jnp.array(True)))
+
+        assert or_chm.simplify() == xor_chm.simplify(), "filters pushed down"
+
         assert or_chm["x"] == 1
         assert or_chm["y"] == maskv
         with pytest.raises(ChoiceMapNoValueAtAddress, match="z"):
@@ -619,6 +634,20 @@ class TestChoiceMap:
     def test_static_is_empty(self):
         assert ChoiceMap.empty().static_is_empty()
         assert not ChoiceMap.kw(x=1).static_is_empty()
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    def test_xor(self):
+        chm1 = ChoiceMap.kw(x=1)
+        chm2 = ChoiceMap.kw(y=2)
+        xor_chm = chm1 ^ chm2
+        assert xor_chm["x"] == 1
+        assert xor_chm["y"] == 2
+
+        # Optimization: XorChm.build should return EmptyChm for empty inputs
+        assert (ChoiceMap.empty() ^ ChoiceMap.empty()).static_is_empty()
+
+        assert (chm1 ^ ChoiceMap.empty()) == chm1
+        assert (ChoiceMap.empty() ^ chm1) == chm1
 
     def test_or(self):
         chm1 = ChoiceMap.kw(x=1)

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -380,6 +380,9 @@ class TestChoiceMap:
         masked_v = Mask(42.0, jnp.array(False))
         assert ChoiceMap.choice(masked_v).get_value() == masked_v
 
+        empty_array = jnp.ones((0,))
+        assert ChoiceMap.choice(empty_array).static_is_empty()
+
     def test_kv(self):
         chm = ChoiceMap.kw(x=1, y=2)
         assert chm["x"] == 1

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -666,6 +666,9 @@ class TestChoiceMap:
         y_masked = ChoiceMap.choice(3.0).mask(jnp.asarray(True))
         assert (x_masked | y_masked).get_value().unmask() == 2.0
 
+        with pytest.raises(Exception, match="Choice and non-Choice in Or"):
+            _ = C["x"].set(1.0) | C["x", "y"].set(2.0)
+
     def test_and(self):
         chm1 = ChoiceMap.kw(x=1, y=2, z=3)
         chm2 = ChoiceMap.kw(y=20, z=30, w=40)


### PR DESCRIPTION
This PR:

- removes `Xor` in favor of only using `Or` (my next PR will push `Or` down into `Choice`)
- modifies `from_mapping` to use `|=` instead of `^=`
- bans `|` between a `Choice` and a non-`Choice`. This should never occur EXCEPT in `Switch` and we handle that separately with a `SwitchChm`
- `|` between two choices pushes the `|` call down into the values
- throws a `TypeError` if a marginal is supplied to a `Target`; this is not supported!
- removes the `ravi_stack.ipynb` notebook from the docs site, as this was hitting that error