### PR TITLE
make `genjax.flip` return a boolean (GEN-869)

### DIFF
--- a/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
+++ b/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import jax.numpy as jnp
 from tensorflow_probability.substrates import jax as tfp
 
 from genjax._src.core.typing import Array, Callable
@@ -77,7 +78,7 @@ bernoulli = tfp_distribution(lambda logits: tfd.Bernoulli(logits=logits))
 A `tfp_distribution` generative function which wraps the [`tfd.Bernoulli`](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/Bernoulli) distribution from TensorFlow Probability distributions.
 """
 
-flip = tfp_distribution(lambda p: tfd.Bernoulli(probs=p))
+flip = tfp_distribution(lambda p: tfd.Bernoulli(probs=p, dtype=jnp.bool_))
 """
 A `tfp_distribution` generative function which wraps the [`tfd.Bernoulli`](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/Bernoulli) distribution from TensorFlow Probability distributions, but is constructed using a probability value and not a logit.
 """

--- a/tests/generative_functions/test_or_else.py
+++ b/tests/generative_functions/test_or_else.py
@@ -14,7 +14,6 @@
 
 import jax
 import pytest
-from jax import numpy as jnp
 
 import genjax
 
@@ -42,7 +41,7 @@ class TestOrElse:
 
         @genjax.gen
         def f():
-            flip = jnp.bool_(genjax.flip(p) @ "flip")
+            flip = genjax.flip(p) @ "flip"
             return (
                 genjax.normal(0.0, 1.0).or_else(genjax.normal(2.0, 1.0))(flip, (), ())
                 @ "value"


### PR DESCRIPTION
This PR modifies `genjax.flip` to return `True`, `False` instead of `1`, `0`.