### PR TITLE
Fix assess in vmap (GEN-903)

### DIFF
--- a/tests/generative_functions/test_static_gen_fn.py
+++ b/tests/generative_functions/test_static_gen_fn.py
@@ -84,6 +84,34 @@ class TestStaticGenFnMetadata:
 
 
 class TestMisc:
+    def test_assess_vmap_masked(self):
+        """
+        Test case provided by George Matheos in GEN-903.
+        """
+        gf = genjax.flip.vmap(in_axes=(0,))
+
+        @jax.jit
+        def get_choicemap(idx):
+            return genjax.ChoiceMap.switch(
+                idx=idx,
+                chms=[
+                    C.set(jnp.array([0, 0, 1], dtype=bool)),
+                    C.set(jnp.array([1, 1, 1], dtype=bool)),
+                ],
+            )
+
+        chm = get_choicemap(1)
+
+        flipprobs = jnp.array([0.2, 0.4, 0.6])
+        tr, w = gf.importance(jax.random.key(0), chm, (flipprobs,))
+        # ^ This line runs.
+        # However, when I try to call assess in the exact
+        # same configuration, I get an error.
+        score, r = gf.assess(chm, (flipprobs,))
+        assert jnp.array_equal(tr.get_retval(), r)
+        assert tr.get_score() == score
+        assert score == w, "no weight change w/ same chm"
+
     def test_get_zero_trace(self):
         @genjax.gen
         def model(x):


### PR DESCRIPTION
This PR modifies `assess` in vmap to vmap over indices and query the choicemap for each, rather than vmapping over the `ChoiceMap` itself.

The error @georgematheos was hitting was that his choicemap had masks inside where a vmapped value was masked with a scalar bool. It's not possible to vmap over this because the scalar bool doesn't have the same leading dimension.