### PR TITLE
Don't depend on removed jax.interpreters.ad code (GEN-896)

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,5 +18,5 @@ jobs:
 
     - uses: chartboost/ruff-action@v1
       with:
-        version: 0.7.3
+        version: 0.8.3
         args: check --output-format github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
       - id: poetry-check
       - id: poetry-install
         args: ["--with", "dev", "--all-extras"]
+        additional_dependencies: ['keyrings.google-artifactregistry-auth']
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     hooks:
       - id: poetry-check
       - id: poetry-install
+        args: ["--with", "dev", "--all-extras"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.3

--- a/src/genjax/_src/adev/primitives.py
+++ b/src/genjax/_src/adev/primitives.py
@@ -19,10 +19,10 @@ import jax._src.dtypes as jax_dtypes
 import jax.numpy as jnp
 from jax._src.ad_util import Zero
 from jax._src.core import (
-    AbstractValue,
     get_aval,
     raise_to_shaped,
 )
+from jax.interpreters.ad import zeros_like_aval
 from tensorflow_probability.substrates import jax as tfp
 
 from genjax._src.adev.core import (
@@ -34,7 +34,6 @@ from genjax._src.adev.core import (
 from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
     Any,
-    Array,
     Callable,
     PRNGKey,
 )
@@ -42,12 +41,6 @@ from genjax._src.core.typing import (
 tfd = tfp.distributions
 
 # These methods are pulled from jax.interpreters.ad:
-
-aval_zeros_likers: dict[type, Callable[[Any], Array]] = {}
-
-
-def zeros_like_aval(aval: AbstractValue) -> Array:
-    return aval_zeros_likers[type(aval)](aval)
 
 
 def instantiate_zeros(tangent):

--- a/src/genjax/_src/core/interpreters/forward.py
+++ b/src/genjax/_src/core/interpreters/forward.py
@@ -102,13 +102,13 @@ def initial_style_bind(prim, **params):
 
         def wrapped(*args, **kwargs):
             """Runs a function and binds it to a call primitive."""
-            _jaxpr, (flat_args, in_tree, out_tree) = stage(f)(*args, **kwargs)
+            jaxpr, (flat_args, in_tree, out_tree) = stage(f)(*args, **kwargs)
             outs = prim.bind(
-                *it.chain(_jaxpr.literals, flat_args),
-                _jaxpr=_jaxpr.jaxpr,
+                *it.chain(jaxpr.literals, flat_args),
+                _jaxpr=jaxpr.jaxpr,
                 in_tree=in_tree,
                 out_tree=out_tree,
-                num_consts=len(_jaxpr.literals),
+                num_consts=len(jaxpr.literals),
                 **params,
             )
             return tree_util.tree_unflatten(out_tree(), outs)
@@ -221,11 +221,11 @@ class ForwardInterpreter(Pytree):
         def _inner(*args):
             return fn(*args, **kwargs)
 
-        _closed_jaxpr, (flat_args, _, out_tree) = stage(_inner)(*args)
-        _jaxpr, consts = _closed_jaxpr.jaxpr, _closed_jaxpr.literals
+        closed_jaxpr, (flat_args, _, out_tree) = stage(_inner)(*args)
+        jaxpr, consts = closed_jaxpr.jaxpr, closed_jaxpr.literals
         flat_out = self._eval_jaxpr_forward(
             stateful_handler,
-            _jaxpr,
+            jaxpr,
             consts,
             flat_args,
         )

--- a/src/genjax/_src/core/interpreters/time_travel.py
+++ b/src/genjax/_src/core/interpreters/time_travel.py
@@ -252,11 +252,11 @@ class TimeTravelingDebugger(Pytree):
         frame = self.sequence[self.ptr]
         f, cont = frame.f, frame.cont
         local_retval = f(*args)
-        _, _debugger = _record(cont)(*args)
+        _, debugger = _record(cont)(*args)
         new_frame = FrameRecording(f, args, local_retval, cont)
         return TimeTravelingDebugger(
-            _debugger.final_retval,
-            [*self.sequence[: self.ptr], new_frame, *_debugger.sequence],
+            debugger.final_retval,
+            [*self.sequence[: self.ptr], new_frame, *debugger.sequence],
             self.jump_points,
             self.ptr,
         )

--- a/tests/generative_functions/test_static_gen_fn.py
+++ b/tests/generative_functions/test_static_gen_fn.py
@@ -440,7 +440,7 @@ class TestStaticGenFnUpdate:
         assert isinstance(discard, ChoiceMapConstraint)
 
         updated_choice = updated.get_sample()
-        _y1 = updated_choice["y1"]
+        y1 = updated_choice["y1"]
         _y2 = updated_choice["y2"]
         (_, score1) = genjax.normal.importance(
             key, updated_choice.get_submap("y1"), (0.0, 1.0)
@@ -458,10 +458,10 @@ class TestStaticGenFnUpdate:
         key, sub_key = jax.random.split(key)
         (updated, w, _, discard) = jitted(sub_key, tr, new, ())
         updated_choice = updated.get_sample()
-        _y1 = updated_choice.get_submap("y1")
-        _y2 = updated_choice.get_submap("y2")
-        (_, score1) = genjax.normal.importance(key, _y1, (0.0, 1.0))
-        (_, score2) = genjax.normal.importance(key, _y2, (0.0, 1.0))
+        y1 = updated_choice.get_submap("y1")
+        y2 = updated_choice.get_submap("y2")
+        (_, score1) = genjax.normal.importance(key, y1, (0.0, 1.0))
+        (_, score2) = genjax.normal.importance(key, y2, (0.0, 1.0))
         test_score = score1 + score2
         assert updated.get_score() == original_score + w
         assert updated.get_score() == pytest.approx(test_score, 0.01)


### PR DESCRIPTION
This PR

- copies some code from `jax.interpreters.ad` into genjax, allowing GenJAX to work with JAX >= 0.4.36
- fixes some errors that came from the new "ruff" version in pre-commit
- fixes the genstudio warnings that come from pre-commit not initializing the poetry env correctly