### PR TITLE
Fix Switch choicemap `|` behavior with static chms (GEN-908)

### DIFF
--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -1738,6 +1738,12 @@ class Or(ChoiceMap):
                     b = Mask.build(b)
                     return Choice.build(a | b)
 
+                case (Switch(idx, chms), Static()):
+                    return Switch.build(idx, [c1 | c2 for c1 in chms])
+
+                case (Static(), Switch(idx, chms)):
+                    return Switch.build(idx, [c1 | c2 for c2 in chms])
+
                 case (Choice(), _) | (_, Choice()):
                     raise Exception(f"Choice and non-Choice in Or: {c1}, {c2}")
 

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -1738,10 +1738,15 @@ class Or(ChoiceMap):
                     b = Mask.build(b)
                     return Choice.build(a | b)
 
-                case (Switch(idx, chms), Static()):
+                case (Switch(), Switch()):
+                    raise Exception(
+                        f"We can't currently handle two switches in an Or: {c1}, {c2}"
+                    )
+
+                case (Switch(idx, chms), _):
                     return Switch.build(idx, [c1 | c2 for c1 in chms])
 
-                case (Static(), Switch(idx, chms)):
+                case (_, Switch(idx, chms)):
                     return Switch.build(idx, [c1 | c2 for c2 in chms])
 
                 case (Choice(), _) | (_, Choice()):

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -22,7 +22,11 @@ import genjax
 from genjax import ChoiceMap, Selection
 from genjax import ChoiceMapBuilder as C
 from genjax import SelectionBuilder as S
-from genjax._src.core.generative.choice_map import ChoiceMapNoValueAtAddress, Static
+from genjax._src.core.generative.choice_map import (
+    ChoiceMapNoValueAtAddress,
+    Static,
+    Switch,
+)
 from genjax._src.core.generative.functional_types import Mask
 
 
@@ -492,6 +496,47 @@ class TestChoiceMap:
         # any statically missing address still raises:
         with pytest.raises(ChoiceMapNoValueAtAddress):
             switched_array["z"]
+
+    def test_or_with_switch(self):
+        # Create a switch and a static choice map
+        chm1 = ChoiceMap.kw(x=1, y=2)
+        chm2 = ChoiceMap.kw(x=3, y=4)
+        switch_chm = ChoiceMap.switch(jnp.array(1), [chm1, chm2])
+        static_chm = ChoiceMap.kw(z=5)
+
+        # Test Or with switch on left
+        or_chm = switch_chm | static_chm
+
+        # Should be a Switch with the static Or'd into each branch
+        assert isinstance(or_chm, Switch)
+        assert len(or_chm.chms) == 2
+
+        # First branch should have original values masked false
+        assert or_chm.chms[0]["x"] == Mask(1, jnp.array(False))
+        assert or_chm.chms[0]["y"] == Mask(2, jnp.array(False))
+        assert or_chm.chms[0]["z"] == Mask(5, jnp.array(False))
+
+        # Second branch should have original values masked true
+        assert or_chm.chms[1]["x"] == Mask(3, jnp.array(True))
+        assert or_chm.chms[1]["y"] == Mask(4, jnp.array(True))
+        assert or_chm.chms[1]["z"] == Mask(5, jnp.array(True))
+
+        # Test Or with switch on right
+        or_chm_2 = static_chm | switch_chm
+
+        # Should be a Switch with the static Or'd into each branch
+        assert isinstance(or_chm_2, Switch)
+        assert len(or_chm_2.chms) == 2
+
+        # First branch should have original values masked false
+        assert or_chm_2.chms[0]["x"] == Mask(1, jnp.array(False))
+        assert or_chm_2.chms[0]["y"] == Mask(2, jnp.array(False))
+        assert or_chm_2.chms[0]["z"] == Mask(5, jnp.array(False))
+
+        # Second branch should have original values masked true
+        assert or_chm_2.chms[1]["x"] == Mask(3, jnp.array(True))
+        assert or_chm_2.chms[1]["y"] == Mask(4, jnp.array(True))
+        assert or_chm_2.chms[1]["z"] == Mask(5, jnp.array(True))
 
     @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_or_xor_access(self):


### PR DESCRIPTION
This PR modifies `Or` to push `Static` and `Choice` into the choicemaps entry of a `Switch`. The guards we have against `Or` between `Static` and `Choice` still apply internally.