### PR TITLE
Pypi genstudio, publish, bump python to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
 
       - name: Install nox-poetry
         run: pip install nox-poetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     strategy:
       matrix:
-        runner: [ubuntu-latest, ParallelHoss]
+        runner: [ubuntu-22.04, ParallelHoss]
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
 
       - name: Install nox-poetry
         run: pip install nox-poetry

--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Checking the actor will prevent your Action run failing on non-Dependabot
     # PRs but also ensures that it only does work for Dependabot PRs.
     if: ${{ github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
 
       - name: Install nox-poetry
         run: pip install nox-poetry

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   labeler:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
 
       - name: Install nox-poetry
         run: pip install nox-poetry

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   notebooks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
 
       - run: poetry self update && poetry self add keyrings.google-artifactregistry-auth
 

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   pyright:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
 
       - name: Configure deploy keys
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Add "id-token" with the intended permissions.
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,6 @@ jobs:
         with:
           credentials_json: "${{ secrets.ARTIFACT_REGISTRY_KEY }}"
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Display gcloud info
-        run: gcloud info
-
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
 
@@ -43,16 +37,9 @@ jobs:
         run: |
           poetry self add poetry-dynamic-versioning[plugin]
           poetry config pypi-token.pypi ${{ secrets.PYPI_API_KEY }}
-          poetry self add keyrings.google-artifactregistry-auth
-          poetry config repositories.gcp https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/
 
       - name: Install deps
         run: poetry install
 
-      # NOTE: re-enable this once we deploy publicly and remove the artifact
-      # registry options.
-      # - name: Deploy to PyPI
-      #   run: poetry publish --build
-
-      - name: Deploy to Artifact Registry
-        run: poetry publish --build --repository gcp
+      - name: Deploy to PyPI
+        run: poetry publish --build

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,5 +18,5 @@ jobs:
 
     - uses: chartboost/ruff-action@v1
       with:
-        version: 0.8.3
+        version: 0.8.4
         args: check --output-format github

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ruff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -30,8 +30,13 @@ jobs:
       - name: Setup Nox
         uses: daisylb/setup-nox@v2.1.0
 
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
+
       - name: Install poetry/nox-poetry
-        run: pip install poetry nox-poetry
+        run: pip install nox-poetry
 
       - name: Cache Nox environments
         uses: actions/cache@v4

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   safety:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -48,6 +48,9 @@ jobs:
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
+
 
       - name: Install nox-poetry
         run: pip install nox-poetry

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: nbstripout
 
   - repo: https://github.com/python-poetry/poetry
-    rev: 1.8.0
+    rev: 1.8.5
     hooks:
       - id: poetry-check
       - id: poetry-install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ Here is a list of important resources for contributors:
 - [Code of Conduct]
 
 [apache 2.0 license]: https://opensource.org/licenses/Apache-2.0
-[source code]: https://github.com/probcomp/genjax
+[source code]: https://github.com/chi-collective/genjax
 [documentation]: https://genjax.gen.dev
-[issue tracker]: https://github.com/probcomp/genjax/issues
+[issue tracker]: https://github.com/chi-collective/genjax/issues
 
 ## How to report a bug
 
@@ -100,7 +100,7 @@ Feel free to submit early, though—we can always iterate on this.
 It is recommended to open an issue before starting work on anything.
 This will allow a chance to talk it over with the owners and validate your approach.
 
-[pull request]: https://github.com/probcomp/genjax/pulls
+[pull request]: https://github.com/chi-collective/genjax/pulls
 
 <!-- github-only -->
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <div align="center">
 
 [![PyPI](https://img.shields.io/pypi/v/genjax)](https://pypi.org/project/GenJAX/)
-[![codecov](https://codecov.io/gh/probcomp/genjax/graph/badge.svg?token=I9TAV92KN7)](https://codecov.io/gh/probcomp/genjax)
+[![codecov](https://codecov.io/gh/chi-collective/genjax/graph/badge.svg?token=I9TAV92KN7)](https://codecov.io/gh/chi-collective/genjax)
 [![][jax_badge]](https://github.com/google/jax)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Public API: beartyped](https://raw.githubusercontent.com/beartype/beartype-assets/main/badge/bear-ified.svg?style=flat-square)](https://beartype.readthedocs.io)
@@ -42,7 +42,7 @@ GenJAX is an implementation of Gen on top of [JAX](https://github.com/google/jax
 > [!IMPORTANT]
 > GenJAX is currently private. To configure your machine to access the package,
 > - Run `\invite-genjax <google-account-email>` in any channel in the the probcomp Slack, or [file a ticket requesting access to the GenJAX-Users
-> group](https://github.com/probcomp/genjax/issues/new?assignees=sritchie&projects=&template=access.md&title=%5BACCESS%5D)
+> group](https://github.com/chi-collective/genjax/issues/new?assignees=sritchie&projects=&template=access.md&title=%5BACCESS%5D)
 > - [install the Google Cloud command line tools](https://cloud.google.com/sdk/docs/install)
 > - follow the instructions on the [installation page](https://cloud.google.com/sdk/docs/install)
 > - run `gcloud auth application-default login` as described [in this guide](https://cloud.google.com/sdk/docs/initializing).
@@ -166,17 +166,17 @@ The maintainers of this library would like to acknowledge the JAX and Oryx maint
 Created and maintained by the <a href="http://probcomp.csail.mit.edu/">MIT Probabilistic Computing Project</a>. All code is licensed under the <a href="LICENSE">Apache 2.0 License</a>.
 </div>
 
-[actions]: https://github.com/probcomp/genjax/actions
+[actions]: https://github.com/chi-collective/genjax/actions
 [adev]: https://arxiv.org/abs/2212.06386
 [cookbook]: https://genjax.gen.dev/cookbook/
-[coverage_badge]: https://github.com/probcomp/genjax/coverage.svg
+[coverage_badge]: https://github.com/chi-collective/genjax/coverage.svg
 [effect_handling_interp]: https://colab.research.google.com/drive/1HGs59anVC2AOsmt7C4v8yD6v8gZSJGm6#scrollTo=ukjVJ2Ls_6Q3
 [equinox]: https://github.com/patrick-kidger/equinox
 [gen_jl]: https://github.com/probcomp/Gen.jl
 [gen_sp]: https://github.com/probcomp/GenSP.jl
 [jax_badge]: https://img.shields.io/badge/JAX-Accelerated-9cf.svg?style=flat-square&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC0AAAAaCAYAAAAjZdWPAAAIx0lEQVR42rWWBVQbWxOAkefur%2B7u3les7u7F3ZIQ3N2tbng8aXFC0uAuKf2hmlJ3AapIgobMv7t0w%2Ba50JzzJdlhlvNldubeq%2FY%2BXrTS1z%2B6sttrKfQOOY4ns13ecFImb47pVvIkukNe4y3Junr1kSZ%2Bb3Na248tx7rKiHlPo6Ryse%2F11NKQuk%2FV3tfL52yHtXm8TGYS1wk4J093wrPQPngRJH9HH1x2fAjMhcIeIaXKQCmd2Gn7IqSvG83BueT0CMkTyESUqm3vRRggTdOBIb1HFDaNl8Gdg91AFGkO7QXe8gJInpoDjEXC9gbhtWH3rjZ%2F9yK6t42Y9zyiC1iLhZA8JQe4eqKXklrJF0MqfPv2bc2wzPZjpnEyMEVlEZCKQzYCJhE8QEtIL1RaXEVFEGmEaTn96VuLDzWflLFbgvqUec3BPVBmeBnNwUiakq1I31UcPaTSR8%2B1LnditsscaB2A48K6D9SoZDD2O6bELvA0JGhl4zIYZzcWtD%2BMfdvdHNsDOHciXwBPN18lj7sy79qQCTNK3nxBZXakqbZFO2jHskA7zBs%2BJhmDmr0RhoadIZjYxKIVHpCZngPMZUKoQKrfEoz1PfZZdKAe2CvP4XnYE8k2LLMdMumwrLaNlomyVqK0UdwN%2BD7AAz73dYBpPg6gPiCN8TXFHCI2s7AWYesJgTabD%2FS5uXDTuwVaAvvghncTdk1DYGkL0daAs%2BsLiutLrn0%2BRMNXpunC7mgkCpshfbw4OhrUvMkYo%2F0c4XtHS1waY4mlG6To8oG1TKjs78xV5fAkSgqcZSL0GoszfxEAW0fUludRNWlIhGsljzVjctr8rJOkCpskKaDYIlgkVoCmF0kp%2FbW%2FU%2F%2B8QNdXPztbAc4kFxIEmNGwKuI9y5gnBMH%2BakiZxlfGaLP48kyj4qPFkeIPh0Q6lt861zZF%2BgBpDcAxT3gEOjGxMDLQRSn9XaDzPWdOstkEN7uez6jmgLOYilR7NkFwLh%2B4G0SQMnMwRp8jaCrwEs8eEmFW2VsNd07HQdP4TgWxNTYcFcKHPhRYFOWLfJJBE5FefTQsWiKRaOw6FBr6ob1RP3EoqdbHsWFDwAYvaVI28DaK8AHs51tU%2BA3Z8CUXvZ1jnSR7SRS2SnwKw4O8B1rCjwrjgt1gSrjXnWhBxjD0Hidm4vfj3e3riUP5PcUCYlZxsYFDK41XnLlUANwVeeILFde%2BGKLhk3zgyZNeQjcSHPMEKSyPPQKfIcKfIqCf8yN95MGZZ1bj98WJ%2BOorQzxsPqcYdX9orw8420jBQNfJVVmTOStEUqFz5dq%2F2tHUY3LbjMh0qYxCwCGxRep8%2FK4ZnldzuUkjJLPDhkzrUFBoHYBjk3odtNMYoJVGx9BG2JTNVehksmRaGUwMbYQITk3Xw9gOxbNoGaA8RWjwuQdsXdGvpdty7Su2%2Fqn0qbzWsXYp0nqVpet0O6zzugva1MZHUdwHk9G8aH7raHua9AIxzzjxDaw4w4cpvEQlM84kwdI0hkpsPpcOtUeaVM8hQT2Qtb4ckUbaYw4fXzGAqSVEd8CGpqamj%2F9Q2pPX7miW0NlHlDE81AxLSI2wyK6xf6vfrcgEwb0PAtPaHM1%2BNXzGXAlMRcUIrMpiE6%2Bxv0cyxSrC6FmjzvkWJE3OxpY%2BzmpsANFBxK6RuIJvXe7bUHNd4zfCwvPPh9unSO%2BbIL2JY53QDqvdbsEi2%2BuwEEHPsfFRdOqjHcjTaCLmWdBewtKzHEwKZynSGgtTaSqx7dwMeBLRhR1LETDhu76vgTFfMLi8zc8F7hoRPpAYjAWCp0Jy5dzfSEfltGU6M9oVCIATnPoGKImDUJNfK0JS37QTc9yY7eDKzIX5wR4wN8RTya4jETAvZDCmFeEPwhNXoOlQt5JnRzqhxLZBpY%2BT5mZD3M4MfLnDW6U%2Fy6jkaDXtysDm8vjxY%2FXYnLebkelXaQtSSge2IhBj9kjMLF41duDUNRiDLHEzfaigsoxRzWG6B0kZ2%2BoRA3dD2lRa44ZrM%2FBW5ANziVApGLaKCYucXOCEdhoew5Y%2Btu65VwJqxUC1j4lav6UwpIJfnRswQUIMawPSr2LGp6WwLDYJ2TwoMNbf6Tdni%2FEuNvAdEvuUZAwFERLVXg7pg9xt1djZgqV7DmuHFGQI9Sje2A9dR%2FFDd0osztIRYnln1hdW1dff%2B1gtNLN1u0ViZy9BBlu%2BzBNUK%2BrIaP9Nla2TG%2BETHwq2kXzmS4XxXmSVan9KMYUprrbgFJqCndyIw9fgdh8dMvzIiW0sngbxoGlniN6LffruTEIGE9khBw5T2FDmWlTYqrnEPa7aF%2FYYcPYiUE48Ul5jhP82tj%2FiESyJilCeLdQRpod6No3xJNNHeZBpOBsiAzm5rg2dBZYSyH9Hob0EOFqqh3vWOuHbFR5eXcORp4OzwTUA4rUzVfJ4q%2FIa1GzCrzjOMxQr5uqLAWUOwgaHOphrgF0r2epYh%2FytdjBmUAurfM6CxruT3Ee%2BDv2%2FHAwK4RUIPskqK%2Fw4%2FR1F1bWfHjbNiXcYl6RwGJcMOMdXZaEVxCutSN1SGLMx3JfzCdlU8THZFFC%2BJJuB2964wSGdmq3I2FEcpWYVfHm4jmXd%2BRn7agFn9oFaWGYhBmJs5v5a0LZUjc3Sr4Ep%2FmFYlX8OdLlFYidM%2B731v7Ly4lfu85l3SSMTAcd5Bg2Sl%2FIHBm3RuacVx%2BrHpFcWjxztavOcOBcTnUhwekkGlsfWEt2%2FkHflB7WqKomGvs9F62l7a%2BRKQQQtRBD9VIlZiLEfRBRfQEmDb32cFQcSjznUP3um%2FkcbV%2BjmNEvqhOQuonjoQh7QF%2BbK811rduN5G6ICLD%2BnmPbi0ur2hrDLKhQYiwRdQrvKjcp%2F%2BL%2BnTz%2Fa4FgvmakvluPMMxbL15Dq5MTYAhOxXM%2FmvEpsoWmtfP9RxnkAIAr%2F5pVxqPxH93msKodRSXIct2l0OU0%2FL4eY506L%2B3GyJ6UMEZfjjCDbysNcWWmFweJP0Jz%2FA0g2gk80pGkYAAAAAElFTkSuQmCC
-[main_build_action_badge]: https://github.com/probcomp/genjax/actions/workflows/ci.yml/badge.svg?style=flat-square&branch=main
-[main_build_status_url]: https://github.com/probcomp/genjax/actions/workflows/ci.yml?query=branch%3Amain
+[main_build_action_badge]: https://github.com/chi-collective/genjax/actions/workflows/ci.yml/badge.svg?style=flat-square&branch=main
+[main_build_status_url]: https://github.com/chi-collective/genjax/actions/workflows/ci.yml?query=branch%3Amain
 [marco_thesis]: https://www.mct.dev/assets/mct-thesis.pdf
 [oryx]: https://github.com/jax-ml/oryx
 [ravi]: https://arxiv.org/abs/2203.02836

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,9 +17,9 @@ Here is a list of important resources for contributors:
 - [Code of Conduct]
 
 [apache 2.0 license]: https://opensource.org/licenses/Apache-2.0
-[source code]: https://github.com/probcomp/genjax
+[source code]: https://github.com/chi-collective/genjax
 [documentation]: https://genjax.gen.dev
-[issue tracker]: https://github.com/probcomp/genjax/issues
+[issue tracker]: https://github.com/chi-collective/genjax/issues
 
 ## How to report a bug
 
@@ -105,4 +105,4 @@ Feel free to submit early, though—we can always iterate on this.
 It is recommended to open an issue before starting work on anything.
 This will allow a chance to talk it over with the owners and validate your approach.
 
-[pull request]: https://github.com/probcomp/genjax/pulls
+[pull request]: https://github.com/chi-collective/genjax/pulls

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -58,7 +58,7 @@ conda create --name genjax-py311 python=3.11 --channel=conda-forge
 conda activate genjax-py311
 pip install nox
 pip install nox-poetry
-git clone https://github.com/probcomp/genjax
+git clone https://github.com/chi-collective/genjax
 cd genjax
 poetry self add "poetry-dynamic-versioning[plugin]"
 poetry install
@@ -170,7 +170,7 @@ GenJAX.
 
 Published GenJAX artifacts live [on PyPI](https://pypi.org/project/genjax/) and
 are published automatically by GitHub with each new
-[release](https://github.com/probcomp/genjax/releases).
+[release](https://github.com/chi-collective/genjax/releases).
 
 ### Release checklist
 
@@ -182,7 +182,7 @@ Before cutting a new release:
 
 ### Releasing via GitHub
 
-- Visit https://github.com/probcomp/genjax/releases/new to create a new release.
+- Visit https://github.com/chi-collective/genjax/releases/new to create a new release.
 - From the "Choose a tag" dropdown, type the new version (using the format
   `v<MAJOR>.<MINOR>.<INCREMENTAL>`, like `v0.1.0`) and select "Create new tag
   on publish"

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ GenJAX is an implementation of Gen on top of [JAX](https://github.com/google/jax
 GenJAX is currently private. To configure your machine to access the package,
 
 - Run `/invite-genjax <google-account-email>` in any channel in the the probcomp Slack, or [file a ticket requesting access to the GenJAX-Users
-group](https://github.com/probcomp/genjax/issues/new?assignees=sritchie&projects=&template=access.md&title=%5BACCESS%5D)
+group](https://github.com/chi-collective/genjax/issues/new?assignees=sritchie&projects=&template=access.md&title=%5BACCESS%5D)
 - [install the Google Cloud command line tools](https://cloud.google.com/sdk/docs/install)
 - follow the instructions on the [installation page](https://cloud.google.com/sdk/docs/install)
 - run `gcloud auth application-default login` as described [in this guide](https://cloud.google.com/sdk/docs/initializing).
@@ -159,17 +159,17 @@ The maintainers of this library would like to acknowledge the JAX and Oryx maint
 Created and maintained by the <a href="http://probcomp.csail.mit.edu/">MIT Probabilistic Computing Project</a>. All code is licensed under the <a href="LICENSE">Apache 2.0 License</a>.
 </div>
 
-[actions]: https://github.com/probcomp/genjax/actions
+[actions]: https://github.com/chi-collective/genjax/actions
 [adev]: https://arxiv.org/abs/2212.06386
 [cookbook]: https://genjax.gen.dev/cookbook/
-[coverage_badge]: https://github.com/probcomp/genjax/coverage.svg
+[coverage_badge]: https://github.com/chi-collective/genjax/coverage.svg
 [effect_handling_interp]: https://colab.research.google.com/drive/1HGs59anVC2AOsmt7C4v8yD6v8gZSJGm6#scrollTo=ukjVJ2Ls_6Q3
 [equinox]: https://github.com/patrick-kidger/equinox
 [gen_jl]: https://github.com/probcomp/Gen.jl
 [gen_sp]: https://github.com/probcomp/GenSP.jl
 [jax_badge]: https://img.shields.io/badge/JAX-Accelerated-9cf.svg?style=flat-square&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC0AAAAaCAYAAAAjZdWPAAAIx0lEQVR42rWWBVQbWxOAkefur%2B7u3les7u7F3ZIQ3N2tbng8aXFC0uAuKf2hmlJ3AapIgobMv7t0w%2Ba50JzzJdlhlvNldubeq%2FY%2BXrTS1z%2B6sttrKfQOOY4ns13ecFImb47pVvIkukNe4y3Junr1kSZ%2Bb3Na248tx7rKiHlPo6Ryse%2F11NKQuk%2FV3tfL52yHtXm8TGYS1wk4J093wrPQPngRJH9HH1x2fAjMhcIeIaXKQCmd2Gn7IqSvG83BueT0CMkTyESUqm3vRRggTdOBIb1HFDaNl8Gdg91AFGkO7QXe8gJInpoDjEXC9gbhtWH3rjZ%2F9yK6t42Y9zyiC1iLhZA8JQe4eqKXklrJF0MqfPv2bc2wzPZjpnEyMEVlEZCKQzYCJhE8QEtIL1RaXEVFEGmEaTn96VuLDzWflLFbgvqUec3BPVBmeBnNwUiakq1I31UcPaTSR8%2B1LnditsscaB2A48K6D9SoZDD2O6bELvA0JGhl4zIYZzcWtD%2BMfdvdHNsDOHciXwBPN18lj7sy79qQCTNK3nxBZXakqbZFO2jHskA7zBs%2BJhmDmr0RhoadIZjYxKIVHpCZngPMZUKoQKrfEoz1PfZZdKAe2CvP4XnYE8k2LLMdMumwrLaNlomyVqK0UdwN%2BD7AAz73dYBpPg6gPiCN8TXFHCI2s7AWYesJgTabD%2FS5uXDTuwVaAvvghncTdk1DYGkL0daAs%2BsLiutLrn0%2BRMNXpunC7mgkCpshfbw4OhrUvMkYo%2F0c4XtHS1waY4mlG6To8oG1TKjs78xV5fAkSgqcZSL0GoszfxEAW0fUludRNWlIhGsljzVjctr8rJOkCpskKaDYIlgkVoCmF0kp%2FbW%2FU%2F%2B8QNdXPztbAc4kFxIEmNGwKuI9y5gnBMH%2BakiZxlfGaLP48kyj4qPFkeIPh0Q6lt861zZF%2BgBpDcAxT3gEOjGxMDLQRSn9XaDzPWdOstkEN7uez6jmgLOYilR7NkFwLh%2B4G0SQMnMwRp8jaCrwEs8eEmFW2VsNd07HQdP4TgWxNTYcFcKHPhRYFOWLfJJBE5FefTQsWiKRaOw6FBr6ob1RP3EoqdbHsWFDwAYvaVI28DaK8AHs51tU%2BA3Z8CUXvZ1jnSR7SRS2SnwKw4O8B1rCjwrjgt1gSrjXnWhBxjD0Hidm4vfj3e3riUP5PcUCYlZxsYFDK41XnLlUANwVeeILFde%2BGKLhk3zgyZNeQjcSHPMEKSyPPQKfIcKfIqCf8yN95MGZZ1bj98WJ%2BOorQzxsPqcYdX9orw8420jBQNfJVVmTOStEUqFz5dq%2F2tHUY3LbjMh0qYxCwCGxRep8%2FK4ZnldzuUkjJLPDhkzrUFBoHYBjk3odtNMYoJVGx9BG2JTNVehksmRaGUwMbYQITk3Xw9gOxbNoGaA8RWjwuQdsXdGvpdty7Su2%2Fqn0qbzWsXYp0nqVpet0O6zzugva1MZHUdwHk9G8aH7raHua9AIxzzjxDaw4w4cpvEQlM84kwdI0hkpsPpcOtUeaVM8hQT2Qtb4ckUbaYw4fXzGAqSVEd8CGpqamj%2F9Q2pPX7miW0NlHlDE81AxLSI2wyK6xf6vfrcgEwb0PAtPaHM1%2BNXzGXAlMRcUIrMpiE6%2Bxv0cyxSrC6FmjzvkWJE3OxpY%2BzmpsANFBxK6RuIJvXe7bUHNd4zfCwvPPh9unSO%2BbIL2JY53QDqvdbsEi2%2BuwEEHPsfFRdOqjHcjTaCLmWdBewtKzHEwKZynSGgtTaSqx7dwMeBLRhR1LETDhu76vgTFfMLi8zc8F7hoRPpAYjAWCp0Jy5dzfSEfltGU6M9oVCIATnPoGKImDUJNfK0JS37QTc9yY7eDKzIX5wR4wN8RTya4jETAvZDCmFeEPwhNXoOlQt5JnRzqhxLZBpY%2BT5mZD3M4MfLnDW6U%2Fy6jkaDXtysDm8vjxY%2FXYnLebkelXaQtSSge2IhBj9kjMLF41duDUNRiDLHEzfaigsoxRzWG6B0kZ2%2BoRA3dD2lRa44ZrM%2FBW5ANziVApGLaKCYucXOCEdhoew5Y%2Btu65VwJqxUC1j4lav6UwpIJfnRswQUIMawPSr2LGp6WwLDYJ2TwoMNbf6Tdni%2FEuNvAdEvuUZAwFERLVXg7pg9xt1djZgqV7DmuHFGQI9Sje2A9dR%2FFDd0osztIRYnln1hdW1dff%2B1gtNLN1u0ViZy9BBlu%2BzBNUK%2BrIaP9Nla2TG%2BETHwq2kXzmS4XxXmSVan9KMYUprrbgFJqCndyIw9fgdh8dMvzIiW0sngbxoGlniN6LffruTEIGE9khBw5T2FDmWlTYqrnEPa7aF%2FYYcPYiUE48Ul5jhP82tj%2FiESyJilCeLdQRpod6No3xJNNHeZBpOBsiAzm5rg2dBZYSyH9Hob0EOFqqh3vWOuHbFR5eXcORp4OzwTUA4rUzVfJ4q%2FIa1GzCrzjOMxQr5uqLAWUOwgaHOphrgF0r2epYh%2FytdjBmUAurfM6CxruT3Ee%2BDv2%2FHAwK4RUIPskqK%2Fw4%2FR1F1bWfHjbNiXcYl6RwGJcMOMdXZaEVxCutSN1SGLMx3JfzCdlU8THZFFC%2BJJuB2964wSGdmq3I2FEcpWYVfHm4jmXd%2BRn7agFn9oFaWGYhBmJs5v5a0LZUjc3Sr4Ep%2FmFYlX8OdLlFYidM%2B731v7Ly4lfu85l3SSMTAcd5Bg2Sl%2FIHBm3RuacVx%2BrHpFcWjxztavOcOBcTnUhwekkGlsfWEt2%2FkHflB7WqKomGvs9F62l7a%2BRKQQQtRBD9VIlZiLEfRBRfQEmDb32cFQcSjznUP3um%2FkcbV%2BjmNEvqhOQuonjoQh7QF%2BbK811rduN5G6ICLD%2BnmPbi0ur2hrDLKhQYiwRdQrvKjcp%2F%2BL%2BnTz%2Fa4FgvmakvluPMMxbL15Dq5MTYAhOxXM%2FmvEpsoWmtfP9RxnkAIAr%2F5pVxqPxH93msKodRSXIct2l0OU0%2FL4eY506L%2B3GyJ6UMEZfjjCDbysNcWWmFweJP0Jz%2FA0g2gk80pGkYAAAAAElFTkSuQmCC
-[main_build_action_badge]: https://github.com/probcomp/genjax/actions/workflows/ci.yml/badge.svg?style=flat-square&branch=main
-[main_build_status_url]: https://github.com/probcomp/genjax/actions/workflows/ci.yml?query=branch%3Amain
+[main_build_action_badge]: https://github.com/chi-collective/genjax/actions/workflows/ci.yml/badge.svg?style=flat-square&branch=main
+[main_build_status_url]: https://github.com/chi-collective/genjax/actions/workflows/ci.yml?query=branch%3Amain
 [marco_thesis]: https://www.mct.dev/assets/mct-thesis.pdf
 [oryx]: https://github.com/jax-ml/oryx
 [ravi]: https://arxiv.org/abs/2203.02836

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,8 +14,8 @@
 
 site_name: GenJAX
 site_url: https://genjax.gen.dev/
-repo_url: https://github.com/probcomp/genjax
-repo_name: probcomp/genjax
+repo_url: https://github.com/chi-collective/genjax
+repo_name: chi-collective/genjax
 edit_uri: edit/main/docs/
 copyright: Copyright &copy; 2023 MIT Probabilistic Computing Project
 

--- a/notebooks/_quarto.yml
+++ b/notebooks/_quarto.yml
@@ -14,7 +14,7 @@ website:
       type: overlay
   favicon: small_logo.png
   image: small_logo.png
-  repo-url: https://github.com/probcomp/genjax/
+  repo-url: https://github.com/chi-collective/genjax/
   repo-branch: main
   repo-subdir: notebooks
   repo-actions: [issue, source]

--- a/noxfile.py
+++ b/noxfile.py
@@ -83,7 +83,7 @@ def prepare(session, *with_strs):
     install_jaxlib(session)
 
 
-@session(python=["3.11", "3.12"])
+@session(python=python_version)
 def tests(session):
     prepare(session)
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -83,7 +83,7 @@ def prepare(session, *with_strs):
     install_jaxlib(session)
 
 
-@session(python=["3.10", "3.11"])
+@session(python=["3.11", "3.12"])
 def tests(session):
     prepare(session)
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -185,6 +185,12 @@ def safety(session) -> None:
         "70612",
         "--ignore",
         "73456",
+        # tornado, dev dependency
+        "--ignore",
+        "74439",
+        # jinja2, dev dependency
+        "--ignore",
+        "74735",
         "--full-report",
         f"--file={requirements}",
         external=True,

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,10 +23,8 @@ files = [
 ]
 
 [package.dependencies]
-exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
-typing-extensions = {version = ">=4.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
@@ -37,7 +35,7 @@ trio = ["trio (>=0.23)"]
 name = "anywidget"
 version = "0.9.13"
 description = "custom jupyter widgets made easy"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "anywidget-0.9.13-py3-none-any.whl", hash = "sha256:43d1658f1043b8c95cd350b2f5deccb123fd37810a36f656d6163aefe8163705"},
@@ -183,9 +181,6 @@ files = [
     {file = "async_lru-2.0.4-py3-none-any.whl", hash = "sha256:ff02944ce3c288c5be660c42dbcca0742b32c3b279d6dceda655190240b99224"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
-
 [[package]]
 name = "attrs"
 version = "24.1.0"
@@ -218,17 +213,6 @@ files = [
 
 [package.extras]
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
-
-[[package]]
-name = "backports-strenum"
-version = "1.3.1"
-description = "Base class for creating enumerated constants that are also subclasses of str"
-optional = false
-python-versions = ">=3.8.6,<3.11"
-files = [
-    {file = "backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83"},
-    {file = "backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414"},
-]
 
 [[package]]
 name = "beartype"
@@ -306,8 +290,6 @@ mypy-extensions = ">=0.4.3"
 packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -844,13 +826,6 @@ files = [
     {file = "dm_tree-0.1.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fa42a605d099ee7d41ba2b5fb75e21423951fd26e5d50583a00471238fb3021d"},
     {file = "dm_tree-0.1.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b7764de0d855338abefc6e3ee9fe40d301668310aa3baea3f778ff051f4393"},
     {file = "dm_tree-0.1.8-cp311-cp311-win_amd64.whl", hash = "sha256:a5d819c38c03f0bb5b3b3703c60e4b170355a0fc6b5819325bf3d4ceb3ae7e80"},
-    {file = "dm_tree-0.1.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ea9e59e0451e7d29aece402d9f908f2e2a80922bcde2ebfd5dcb07750fcbfee8"},
-    {file = "dm_tree-0.1.8-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:94d3f0826311f45ee19b75f5b48c99466e4218a0489e81c0f0167bda50cacf22"},
-    {file = "dm_tree-0.1.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:435227cf3c5dc63f4de054cf3d00183790bd9ead4c3623138c74dde7f67f521b"},
-    {file = "dm_tree-0.1.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09964470f76a5201aff2e8f9b26842976de7889300676f927930f6285e256760"},
-    {file = "dm_tree-0.1.8-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:75c5d528bb992981c20793b6b453e91560784215dffb8a5440ba999753c14ceb"},
-    {file = "dm_tree-0.1.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0a94aba18a35457a1b5cd716fd7b46c5dafdc4cf7869b4bae665b91c4682a8e"},
-    {file = "dm_tree-0.1.8-cp312-cp312-win_amd64.whl", hash = "sha256:96a548a406a6fb15fe58f6a30a57ff2f2aafbf25f05afab00c8f5e5977b6c715"},
     {file = "dm_tree-0.1.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8c60a7eadab64c2278861f56bca320b2720f163dca9d7558103c3b77f2416571"},
     {file = "dm_tree-0.1.8-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:af4b3d372f2477dcd89a6e717e4a575ca35ccc20cc4454a8a4b6f8838a00672d"},
     {file = "dm_tree-0.1.8-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:de287fabc464b8734be251e46e06aa9aa1001f34198da2b6ce07bd197172b9cb"},
@@ -888,25 +863,10 @@ files = [
 
 [package.dependencies]
 packaging = "*"
-tomli = {version = "*", markers = "python_version < \"3.11\""}
 
 [package.extras]
 conda = ["pyyaml"]
 pipenv = ["pipenv (<=2022.12.19)"]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.2.2"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
-    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
-]
-
-[package.extras]
-test = ["pytest (>=6)"]
 
 [[package]]
 name = "execnet"
@@ -1049,18 +1009,19 @@ description = "Python AST that abstracts the underlying Python version"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 files = [
+    {file = "gast-0.6.0-py3-none-any.whl", hash = "sha256:52b182313f7330389f72b069ba00f174cfe2a06411099547288839c6cbafbd54"},
     {file = "gast-0.6.0.tar.gz", hash = "sha256:88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb"},
 ]
 
 [[package]]
 name = "genstudio"
-version = "2024.11.15"
+version = "2025.1.9"
 description = ""
-optional = true
-python-versions = ">=3.10,<3.13"
+optional = false
+python-versions = "<3.13,>=3.11"
 files = [
-    {file = "genstudio-2024.11.15-py3-none-any.whl", hash = "sha256:f7b11103f66d07bba828fbc770fdda624bdff33946c32aaf16f4f8863423940d"},
-    {file = "genstudio-2024.11.15.tar.gz", hash = "sha256:fd5d4dfe93cfaaea5e5f6b5bbd9756046fe9d3e83f7025aaab5120ff987487d0"},
+    {file = "genstudio-2025.1.9-py3-none-any.whl", hash = "sha256:4c96b97e7ede81cc89869c9351394a35115dea33b1c9e0d9d46fdd842a00764a"},
+    {file = "genstudio-2025.1.9.tar.gz", hash = "sha256:d0b1e22905952e4dc9b3ed5c404e60147dbc03b5905ad8fbc2d891ca3da83597"},
 ]
 
 [package.dependencies]
@@ -1069,11 +1030,6 @@ html2image = ">=2.0.4.3,<3.0.0.0"
 orjson = ">=3.10.6,<4.0.0"
 pillow = ">=10.4.0,<11.0.0"
 traitlets = ">=5.14.3,<6.0.0"
-
-[package.source]
-type = "legacy"
-url = "https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/simple"
-reference = "gcp"
 
 [[package]]
 name = "ghp-import"
@@ -1136,7 +1092,6 @@ files = [
 ]
 
 [package.dependencies]
-backports-strenum = {version = ">=1.3", markers = "python_version < \"3.11\""}
 colorama = ">=0.4"
 
 [[package]]
@@ -1154,7 +1109,7 @@ files = [
 name = "html2image"
 version = "2.0.4.3"
 description = "Package acting as a wrapper around the headless mode of existing web browsers to generate images from URLs and from HTML+CSS strings or files."
-optional = true
+optional = false
 python-versions = ">=3.6,<4.0"
 files = [
     {file = "html2image-2.0.4.3-py3-none-any.whl", hash = "sha256:e39bc1be8cb39bd36a1b9412d22f5db88d56e762f9ad3461124fa05fa7982945"},
@@ -1279,7 +1234,6 @@ files = [
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 decorator = "*"
-exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 jedi = ">=0.16"
 matplotlib-inline = "*"
 pexpect = {version = ">4.3", markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""}
@@ -1307,7 +1261,7 @@ test-extra = ["curio", "ipython[test]", "matplotlib (!=3.2.0)", "nbformat", "num
 name = "ipywidgets"
 version = "8.1.3"
 description = "Jupyter interactive widgets"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "ipywidgets-8.1.3-py3-none-any.whl", hash = "sha256:efafd18f7a142248f7cb0ba890a68b96abd4d6e88ddbda483c9130d12667eaf2"},
@@ -1677,7 +1631,6 @@ jupyterlab-server = ">=2.27.1,<3"
 notebook-shim = ">=0.2"
 packaging = "*"
 setuptools = ">=40.1.0"
-tomli = {version = ">=1.2.2", markers = "python_version < \"3.11\""}
 tornado = ">=6.2.0"
 traitlets = "*"
 
@@ -1728,7 +1681,7 @@ test = ["hatch", "ipykernel", "openapi-core (>=0.18.0,<0.19.0)", "openapi-spec-v
 name = "jupyterlab-widgets"
 version = "3.0.11"
 description = "Jupyter interactive widgets for JupyterLab"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "jupyterlab_widgets-3.0.11-py3-none-any.whl", hash = "sha256:78287fd86d20744ace330a61625024cf5521e1c012a352ddc0a3cdc2348becd0"},
@@ -1752,7 +1705,6 @@ mdit-py-plugins = "*"
 nbformat = "*"
 packaging = "*"
 pyyaml = "*"
-tomli = {version = "*", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["autopep8", "black", "flake8", "gitpython", "ipykernel", "isort", "jupyter-fs (>=1.0)", "jupyter-server (!=2.11)", "nbconvert", "pre-commit", "pytest", "pytest-cov (>=2.6.1)", "pytest-randomly", "pytest-xdist", "sphinx-gallery (<0.8)"]
@@ -1958,9 +1910,13 @@ files = [
     {file = "lxml-5.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:edcfa83e03370032a489430215c1e7783128808fd3e2e0a3225deee278585196"},
     {file = "lxml-5.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:28bf95177400066596cdbcfc933312493799382879da504633d16cf60bba735b"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a745cc98d504d5bd2c19b10c79c61c7c3df9222629f1b6210c0368177589fb8"},
+    {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b590b39ef90c6b22ec0be925b211298e810b4856909c8ca60d27ffbca6c12e6"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b336b0416828022bfd5a2e3083e7f5ba54b96242159f83c7e3eebaec752f1716"},
+    {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:c2faf60c583af0d135e853c86ac2735ce178f0e338a3c7f9ae8f622fd2eb788c"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:4bc6cb140a7a0ad1f7bc37e018d0ed690b7b6520ade518285dc3171f7a117905"},
+    {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7ff762670cada8e05b32bf1e4dc50b140790909caa8303cfddc4d702b71ea184"},
     {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:57f0a0bbc9868e10ebe874e9f129d2917750adf008fe7b9c1598c0fbbfdde6a6"},
+    {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:a6d2092797b388342c1bc932077ad232f914351932353e2e8706851c870bca1f"},
     {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:60499fe961b21264e17a471ec296dcbf4365fbea611bf9e303ab69db7159ce61"},
     {file = "lxml-5.2.2-cp37-cp37m-win32.whl", hash = "sha256:d9b342c76003c6b9336a80efcc766748a333573abf9350f4094ee46b006ec18f"},
     {file = "lxml-5.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b16db2770517b8799c79aa80f4053cd6f8b716f21f8aca962725a9565ce3ee40"},
@@ -2524,7 +2480,6 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-    {version = ">=1.21.2", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.23.3", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
 ]
 
@@ -2572,7 +2527,6 @@ files = [
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
@@ -2732,7 +2686,6 @@ files = [
 argcomplete = ">=1.9.4,<4.0"
 colorlog = ">=2.6.1,<7.0.0"
 packaging = ">=20.9"
-tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 virtualenv = ">=20.14.1"
 
 [package.extras]
@@ -2836,7 +2789,7 @@ dev = ["black", "mypy", "pytest"]
 name = "orjson"
 version = "3.10.7"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "orjson-3.10.7-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:74f4544f5a6405b90da8ea724d15ac9c36da4d72a738c64685003337401f5c12"},
@@ -2971,7 +2924,6 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
@@ -3268,7 +3220,7 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 name = "psygnal"
 version = "0.11.1"
 description = "Fast python callback/event system modeled after Qt Signals"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "psygnal-0.11.1-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:8d9187700fc608abefeb287bf2e0980a26c62471921ffd1a3cd223ccc554181b"},
@@ -3423,11 +3375,9 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -3572,7 +3522,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4353,17 +4302,6 @@ doc = ["sphinx", "sphinx_rtd_theme"]
 test = ["pytest", "ruff"]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-
-[[package]]
 name = "tomlkit"
 version = "0.13.0"
 description = "Style preserving TOML library"
@@ -4629,7 +4567,7 @@ test = ["websockets"]
 name = "widgetsnbextension"
 version = "4.0.11"
 description = "Jupyter interactive widgets for Jupyter Notebook"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "widgetsnbextension-4.0.11-py3-none-any.whl", hash = "sha256:55d4d6949d100e0d08b94948a42efc3ed6dfdc0e9468b2c4b128c9a2ce3a7a36"},
@@ -4744,5 +4682,5 @@ genstudio = ["genstudio"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10,<3.13"
-content-hash = "ab002003ed60331d85f91582de45c91ea2a994699be48a1a072a2ca69c71c1a0"
+python-versions = ">=3.11,<3.13"
+content-hash = "367156047b990a7fdb966021828e9314659b089a870c94e708b8850ccb34ef9a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ maintainers = [
 ]
 license = "Apache 2.0"
 readme = "README_pypi.md"
-homepage = "https://github.com/probcomp/genjax"
-repository = "https://github.com/probcomp/genjax"
+homepage = "https://github.com/chi-collective/genjax"
+repository = "https://github.com/chi-collective/genjax"
 documentation = "https://genjax.gen.dev/"
 keywords = [
     "artificial-intelligence",
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 [tool.poetry.urls]
-Changelog = "https://github.com/probcomp/genjax/releases"
+Changelog = "https://github.com/chi-collective/genjax/releases"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 Changelog = "https://github.com/probcomp/genjax/releases"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.11,<3.13"
 jax = "^0.4.24"
 tensorflow-probability = "^0.23.0"
 jaxtyping = "^0.2.24"
@@ -48,7 +48,7 @@ treescope = "^0.1.5"
 # Numpy <2.0.0 is due to tfp issues: https://github.com/tensorflow/probability/issues/1814
 # remove this constraint when that issue is closed.
 numpy = ">=1.22,<2.0.0"
-genstudio = { version = "2024.11.015", source = "gcp", optional = true }
+genstudio = ">=2025.1.5"
 
 [tool.poetry.group.dev]
 optional = true
@@ -86,11 +86,6 @@ black = "^24.4.2"
 [tool.poetry.extras]
 genstudio = ["genstudio"]
 all = ["genstudio"]
-
-[[tool.poetry.source]]
-name = "gcp"
-url = "https://us-west1-python.pkg.dev/probcomp-caliban/probcomp/simple/"
-priority = "explicit"
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import re
+
 import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
@@ -1089,7 +1091,9 @@ class TestChoiceMap:
         # querying array-shaped indices with a slice is not allowed:
         with pytest.raises(
             AssertionError,
-            match="Slices are not allowed against array-shaped dynamic addresses.",
+            match=re.escape(
+                "Slices are not allowed against array-shaped dynamic addresses."
+            ),
         ):
             chm["z", :]
 

--- a/tests/generative_functions/test_scan_combinator.py
+++ b/tests/generative_functions/test_scan_combinator.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -430,7 +432,8 @@ class TestScanWithParameters:
             "scale": jnp.array([1.0]),
         }
         with pytest.raises(
-            ValueError, match="scan got values with different leading axis sizes: 2, 1."
+            ValueError,
+            match=re.escape("scan got values with different leading axis sizes: 2, 1."),
         ):
             jax.jit(foo.scan().simulate)(key, (jnp.array([1.0]), d))
 

--- a/tests/generative_functions/test_vmap_combinator.py
+++ b/tests/generative_functions/test_vmap_combinator.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -178,7 +180,9 @@ class TestVmapCombinator:
         # in_axes doesn't match args
         with pytest.raises(
             TypeError,
-            match="Found incompatible dtypes, <class 'numpy.float32'> and <class 'numpy.int32'>",
+            match=re.escape(
+                "Found incompatible dtypes, <class 'numpy.float32'> and <class 'numpy.int32'>"
+            ),
         ):
             jax.jit(foo.vmap(in_axes=(None, 0)).simulate)(key, (10.0, jnp.arange(3)))
 


### PR DESCRIPTION
This PR:

- changes the genstudio dependency to pypi
- modifies `release.yml` to publish to pypi
- bumps the minimum python version to 3.11 (colab is now on 3.11, studio requires this)
- noxfile now tests 3.11 and 3.12