### PR TITLE
Fix Codecov integration

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,5 +41,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
+          disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.json
+          files: ./coverage.json


### PR DESCRIPTION
Looks like `file` was removed in favor of `files`.