### PR TITLE
Add all, none, leaf and S[()] == S.none (GEN-945)

### DIFF
--- a/docs/cookbook/active/debugging.ipynb
+++ b/docs/cookbook/active/debugging.ipynb
@@ -1,13 +1,12 @@
 {
  "cells": [
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
-    "title: Debugging\n",
-    "subtitle: How can I debug my code? I want to add break points or print statements in my Jax/GenJax code but it doesn't seem to work because of traced values and/or jit compilation. \n",
-    "---"
+    "# Debugging\n",
+    "\n",
+    "How can I debug my code? I want to add break points or print statements in my Jax/GenJax code but it  doesn't seem to work because of traced values and/or jit compilation. "
    ]
   },
   {

--- a/docs/cookbook/inactive/generative_fun.ipynb
+++ b/docs/cookbook/inactive/generative_fun.ipynb
@@ -2,7 +2,11 @@
  "cells": [
   {
    "cell_type": "raw",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
    "source": [
     "---\n",
     "title: Generative functions\n",

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -109,7 +109,7 @@ class _SelectionBuilder:
     ) -> "Selection":
         addr = addr if isinstance(addr, tuple) else (addr,)
         if addr == ():
-            return Selection.none()
+            return Selection.leaf()
         else:
             return Selection.all().extend(*addr)
 

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -71,12 +71,47 @@ _full_slice = slice(None, None, None)
 
 
 class _SelectionBuilder:
+    @property
+    def all(self) -> "Selection":
+        """
+        Returns a Selection that selects all addresses.
+
+        Returns:
+            A Selection that selects everything.
+        """
+        return Selection.all()
+
+    @property
+    def none(self) -> "Selection":
+        """
+        Returns a Selection that selects no addresses.
+
+        Returns:
+            A Selection that selects nothing.
+        """
+        return Selection.none()
+
+    @property
+    def leaf(self) -> "Selection":
+        """
+        Returns a Selection that selects only leaf addresses.
+
+        A leaf address is an address that doesn't have any sub-addresses.
+        This selection is useful when you want to target only the final elements in a nested structure.
+
+        Returns:
+            A Selection that selects only leaf addresses.
+        """
+        return Selection.leaf()
+
     def __getitem__(
         self, addr: ExtendedStaticAddressComponent | ExtendedStaticAddress
     ) -> "Selection":
         addr = addr if isinstance(addr, tuple) else (addr,)
-
-        return Selection.all().extend(*addr)
+        if addr == ():
+            return Selection.none()
+        else:
+            return Selection.all().extend(*addr)
 
 
 SelectionBuilder = _SelectionBuilder()

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -74,6 +74,30 @@ class TestSelections:
         # none can't be extended
         assert Selection.none().extend("a", "b") == Selection.none()
 
+    def test_selection_builder_properties(self):
+        # Test S.all
+        assert S.all == Selection.all()
+        assert S.all["x"]
+        assert S.all["y", "z"]
+        assert S.all[()]
+
+        # Test S.none
+        assert S.none == Selection.none()
+        assert not S.none["x"]
+        assert not S.none["y", "z"]
+        assert not S.none[()]
+
+        # Test S.leaf
+        leaf_sel = S.leaf
+        assert leaf_sel == Selection.leaf()
+        leaf_sel = leaf_sel.extend("a", "b")
+        assert leaf_sel["a", "b"]
+        assert not leaf_sel["a"]
+        assert not leaf_sel["a", "b", "c"]
+
+        # Test empty tuple selection
+        assert S[()] == Selection.none()
+
     def test_selection_leaf(self):
         leaf_sel = Selection.leaf().extend("x", "y")
         assert not leaf_sel["x"]

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -96,7 +96,8 @@ class TestSelections:
         assert not leaf_sel["a", "b", "c"]
 
         # Test empty tuple selection
-        assert S[()] == Selection.none()
+        assert S[()] == Selection.leaf()
+        assert () in S[()]
 
     def test_selection_leaf(self):
         leaf_sel = Selection.leaf().extend("x", "y")


### PR DESCRIPTION
This PR

- adds `all`, `none` and `leaf` properties to `SelectionBuilder`
- sets `S[()]` to return `Selection.none()`