### PR TITLE
Restrict Selection to static addresses only (GEN-964)

### DIFF
--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -351,7 +351,7 @@ class Selection(Projection["ChoiceMap"], Pytree):
 
     def __call__(
         self,
-        addr: AddressComponent | Address,
+        addr: StaticAddressComponent | StaticAddress,
     ) -> "Selection":
         addr = addr if isinstance(addr, tuple) else (addr,)
         subselection = self
@@ -361,14 +361,14 @@ class Selection(Projection["ChoiceMap"], Pytree):
 
     def __getitem__(
         self,
-        addr: AddressComponent | Address,
+        addr: StaticAddressComponent | StaticAddress,
     ) -> Flag:
         subselection = self(addr)
         return subselection.check()
 
     def __contains__(
         self,
-        addr: AddressComponent | Address,
+        addr: StaticAddressComponent | StaticAddress,
     ) -> Flag:
         return self[addr]
 
@@ -377,7 +377,7 @@ class Selection(Projection["ChoiceMap"], Pytree):
         pass
 
     @abstractmethod
-    def get_subselection(self, addr: AddressComponent) -> "Selection":
+    def get_subselection(self, addr: StaticAddressComponent) -> "Selection":
         pass
 
 
@@ -533,7 +533,7 @@ class ComplementSel(Selection):
     def check(self) -> Flag:
         return FlagOp.not_(self.s.check())
 
-    def get_subselection(self, addr: AddressComponent) -> Selection:
+    def get_subselection(self, addr: StaticAddressComponent) -> Selection:
         remaining = self.s(addr)
         return ~remaining
 
@@ -584,7 +584,7 @@ class StaticSel(Selection):
             return self.s.mask(addr == self.addr)
 
         else:
-            return Selection.none()
+            return self
 
 
 @Pytree.dataclass(match_args=True)
@@ -633,7 +633,7 @@ class AndSel(Selection):
     def check(self) -> Flag:
         return FlagOp.and_(self.s1.check(), self.s2.check())
 
-    def get_subselection(self, addr: AddressComponent) -> Selection:
+    def get_subselection(self, addr: StaticAddressComponent) -> Selection:
         remaining1 = self.s1(addr)
         remaining2 = self.s2(addr)
         return remaining1 & remaining2
@@ -687,7 +687,7 @@ class OrSel(Selection):
     def check(self) -> Flag:
         return FlagOp.or_(self.s1.check(), self.s2.check())
 
-    def get_subselection(self, addr: AddressComponent) -> Selection:
+    def get_subselection(self, addr: StaticAddressComponent) -> Selection:
         remaining1 = self.s1(addr)
         remaining2 = self.s2(addr)
         return remaining1 | remaining2
@@ -1557,7 +1557,7 @@ class Indexed(ChoiceMap):
 
     def filter(self, selection: Selection) -> ChoiceMap:
         addr = _full_slice if self.addr is None else self.addr
-        return self.c.filter(selection(addr)).extend(addr)
+        return self.c.filter(selection).extend(addr)
 
     def get_value(self) -> Any:
         return None
@@ -1820,7 +1820,7 @@ def _shape_selection(chm: ChoiceMap) -> Selection:
                 return acc
 
             case Indexed(c, addr):
-                return loop(c, selection(_full_slice)).extend(...)
+                return loop(c, selection).extend(...)
 
             case Choice():
                 return LeafSel()

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -320,11 +320,9 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
         ) -> tuple[tuple[PRNGKey, IntArray], Weight]:
             key, idx = carry
             key = jax.random.fold_in(key, idx)
-            subprojection = projection(idx)
-            assert isinstance(subprojection, Selection)
             w = subtrace.project(
                 key,
-                subprojection,
+                projection,
             )
 
             return (key, idx + 1), w
@@ -481,11 +479,10 @@ class ScanCombinator(Generic[Carry, Y], GenerativeFunction[tuple[Carry, Y]]):
             key, idx, carried_value = carry
             subtrace, scanned_in = scanned_over
             key = jax.random.fold_in(key, idx)
-            subselection = selection(idx)
             (
                 (carried_out, score),
                 (new_subtrace, scanned_out, w, inner_bwd_request),
-            ) = _inner_edit(key, subtrace, subselection, carried_value, scanned_in)
+            ) = _inner_edit(key, subtrace, selection, carried_value, scanned_in)
 
             return (key, idx + 1, carried_out), (
                 new_subtrace,

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -222,14 +222,12 @@ class VmapCombinator(Generic[R], GenerativeFunction[R]):
         assert isinstance(projection, Selection)
 
         dim_length = trace.dim_length
-        idx_array = jnp.arange(dim_length)
         sub_keys = jax.random.split(key, dim_length)
 
-        def _project(key, idx, subtrace):
-            subprojection = projection(idx)
-            return subtrace.project(key, subprojection)
+        def _project(key, subtrace):
+            return subtrace.project(key, projection)
 
-        weights = jax.vmap(_project)(sub_keys, idx_array, trace.inner)
+        weights = jax.vmap(_project)(sub_keys, trace.inner)
         return jnp.sum(weights)
 
     def edit_choice_map(

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -275,7 +275,6 @@ class TestSelections:
         xy_sel = Selection.at["x", "y"]
         assert not xy_sel[()]
         assert xy_sel["x", "y"]
-        assert not xy_sel[0]
         assert not xy_sel["other_address"]
 
         # Test nested StaticSel


### PR DESCRIPTION
With the demise of Indexed, let's kill dynamic indices in `Selection` (as these weren't handled well anyway). This fixes a bug where projecting against a selection like `S["x", "y"]` in a model with a scan or vmap would send `Selection.none()` down to the subtraces.