### PR TITLE
remove ExactDensityFromCallables

### DIFF
--- a/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
+++ b/src/genjax/_src/generative_functions/distributions/tensorflow_probability/__init__.py
@@ -18,7 +18,7 @@ from tensorflow_probability.substrates import jax as tfp
 
 from genjax._src.core.typing import Array, Callable
 from genjax._src.generative_functions.distributions.distribution import (
-    ExactDensityFromCallables,
+    ExactDensity,
     exact_density,
 )
 
@@ -32,9 +32,9 @@ if TYPE_CHECKING:
 
 def tfp_distribution(
     dist: Callable[..., "dist.Distribution"],
-) -> ExactDensityFromCallables[Array]:
+) -> ExactDensity[Array]:
     """
-    Creates an ExactDensityFromCallables generative function from a TensorFlow Probability distribution.
+    Creates a generative function from a TensorFlow Probability distribution.
 
     Args:
         dist: A callable that returns a TensorFlow Probability distribution.
@@ -55,7 +55,7 @@ def tfp_distribution(
         d = dist(*args, **kwargs)
         return d.log_prob(v)
 
-    return exact_density(sampler, logpdf)
+    return exact_density(sampler, logpdf, dist.__name__)
 
 
 #####################
@@ -81,7 +81,7 @@ beta_quotient = tfp_distribution(tfd.BetaQuotient)
 A `tfp_distribution` generative function which wraps the [`tfd.BetaQuotient`](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/BetaQuotient) distribution from TensorFlow Probability distributions.
 """
 
-binomial: ExactDensityFromCallables[Array] = tfp_distribution(tfd.Binomial)
+binomial: ExactDensity[Array] = tfp_distribution(tfd.Binomial)
 """
 A `tfp_distribution` generative function which wraps the [`tfd.Binomial`](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/Binomial) distribution from TensorFlow Probability distributions.
 """

--- a/src/genjax/_src/inference/vi.py
+++ b/src/genjax/_src/inference/vi.py
@@ -59,8 +59,7 @@ tfd = tfp.distributions
 
 
 def adev_distribution(
-    adev_primitive: ADEVPrimitive,
-    differentiable_logpdf: Callable[..., Any],
+    adev_primitive: ADEVPrimitive, differentiable_logpdf: Callable[..., Any], name: str
 ) -> ExactDensity[Any]:
     """
     Return an [`ExactDensity`][genjax.ExactDensity] distribution whose sampler invokes an ADEV sampling primitive, with a provided differentiable log density function.
@@ -79,7 +78,7 @@ def adev_distribution(
         else:
             return lp
 
-    return exact_density(sampler, logpdf)
+    return exact_density(sampler, logpdf, name)
 
 
 def logpdf(gen_fn):
@@ -88,41 +87,32 @@ def logpdf(gen_fn):
 
 # We import ADEV specific sampling primitives, but then wrap them in
 # adev_distribution, for usage inside of generative functions.
-flip_enum = adev_distribution(
-    flip_enum,
-    logpdf(flip),
-)
+flip_enum = adev_distribution(flip_enum, logpdf(flip), "flip_enum")
 
-flip_mvd = adev_distribution(
-    flip_mvd,
-    logpdf(flip),
-)
+flip_mvd = adev_distribution(flip_mvd, logpdf(flip), "flip_mvd")
 
 categorical_enum = adev_distribution(
     categorical_enum_parallel,
     lambda v, probs: tfd.Categorical(probs=probs).log_prob(v),
+    "categorical_enum",
 )
 
 normal_reinforce = adev_distribution(
-    normal_reinforce,
-    logpdf(normal),
+    normal_reinforce, logpdf(normal), "normal_reinforce"
 )
 
-normal_reparam = adev_distribution(
-    normal_reparam,
-    logpdf(normal),
-)
+normal_reparam = adev_distribution(normal_reparam, logpdf(normal), "normal_reparam")
 
 mv_normal_diag_reparam = adev_distribution(
     mv_normal_diag_reparam,
     lambda v, loc, scale_diag: tfd.MultivariateNormalDiag(
         loc=loc, scale_diag=scale_diag
     ).log_prob(v),
+    "mv_normal_diag_reparam",
 )
 
 geometric_reinforce = adev_distribution(
-    geometric_reinforce,
-    logpdf(geometric),
+    geometric_reinforce, logpdf(geometric), "geometric_reinforce"
 )
 
 

--- a/src/genjax/generative_functions/distributions/__init__.py
+++ b/src/genjax/generative_functions/distributions/__init__.py
@@ -20,7 +20,6 @@ from genjax._src.generative_functions.distributions.custom.discrete_hmm import (
 from genjax._src.generative_functions.distributions.distribution import (
     Distribution,
     ExactDensity,
-    ExactDensityFromCallables,
     exact_density,
 )
 from genjax._src.generative_functions.distributions.tensorflow_probability import (
@@ -77,7 +76,6 @@ __all__ = [
     "DiscreteHMMConfiguration",
     "Distribution",
     "ExactDensity",
-    "ExactDensityFromCallables",
     "bernoulli",
     "beta",
     "beta_binomial",


### PR DESCRIPTION
- instead we let `exact_density` gin up a runtime type to hold the methods
- removed ExactDensity.handle_kwargs (nobody seems to be using it, and I added kwarg capability in the new type. Maybe that's good enough?