### PR TITLE
remove info parameter from DimapCombinator

### DIFF
--- a/docs/cookbook/inactive/library_author/dimap_combinator.ipynb
+++ b/docs/cookbook/inactive/library_author/dimap_combinator.ipynb
@@ -57,9 +57,7 @@
     "        return (idx, if_args, else_args)\n",
     "\n",
     "    # The `contramap` method is used to map the input arguments to the expected input of the generative function, and then call the switch combinator\n",
-    "    return if_gen_fn.switch(else_gen_fn).contramap(\n",
-    "        argument_mapping, info=\"Derived combinator (OrElse)\"\n",
-    "    )"
+    "    return if_gen_fn.switch(else_gen_fn).contramap(argument_mapping)"
    ]
   },
   {

--- a/src/genjax/_src/core/generative/generative_function.py
+++ b/src/genjax/_src/core/generative/generative_function.py
@@ -1375,9 +1375,7 @@ class GenerativeFunction(Generic[R], Pytree):
                 return genjax.normal(x, y) @ "z"
 
 
-            dimap_model = model.dimap(
-                pre=pre_process, post=post_process, info="Square of normal"
-            )
+            dimap_model = model.dimap(pre=pre_process, post=post_process)
 
             # Use the dimap model
             key = jax.random.key(0)

--- a/src/genjax/_src/core/generative/generative_function.py
+++ b/src/genjax/_src/core/generative/generative_function.py
@@ -1342,7 +1342,6 @@ class GenerativeFunction(Generic[R], Pytree):
         *,
         pre: Callable[..., ArgTuple],
         post: Callable[[tuple[Any, ...], ArgTuple, R], S],
-        info: str | None = None,
     ) -> "GenerativeFunction[S]":
         """
         Returns a new [`genjax.GenerativeFunction`][] and applies pre- and post-processing functions to its arguments and return value.
@@ -1353,7 +1352,6 @@ class GenerativeFunction(Generic[R], Pytree):
         Args:
             pre: A callable that preprocesses the arguments before passing them to the wrapped function. Note that `pre` must return a _tuple_ of arguments, not a bare argument. Default is the identity function.
             post: A callable that postprocesses the return value of the wrapped function. Default is the identity function.
-            info: An optional string providing additional information about the `dimap` operation.
 
         Returns:
             A new [`genjax.GenerativeFunction`][] with `pre` and `post` applied.
@@ -1390,17 +1388,14 @@ class GenerativeFunction(Generic[R], Pytree):
         """
         import genjax
 
-        return genjax.dimap(pre=pre, post=post, info=info)(self)
+        return genjax.dimap(pre=pre, post=post)(self)
 
-    def map(
-        self, f: Callable[[R], S], *, info: str | None = None
-    ) -> "GenerativeFunction[S]":
+    def map(self, f: Callable[[R], S]) -> "GenerativeFunction[S]":
         """
         Specialized version of [`genjax.dimap`][] where only the post-processing function is applied.
 
         Args:
             f: A callable that postprocesses the return value of the wrapped function.
-            info: An optional string providing additional information about the `map` operation.
 
         Returns:
             A [`genjax.GenerativeFunction`][] that acts like `self` with a post-processing function to its return value.
@@ -1420,7 +1415,7 @@ class GenerativeFunction(Generic[R], Pytree):
                 return genjax.normal(x, 1.0) @ "z"
 
 
-            map_model = model.map(square, info="Square of normal")
+            map_model = model.map(square)
 
             # Use the map model
             key = jax.random.key(0)
@@ -1431,17 +1426,14 @@ class GenerativeFunction(Generic[R], Pytree):
         """
         import genjax
 
-        return genjax.map(f=f, info=info)(self)
+        return genjax.map(f=f)(self)
 
-    def contramap(
-        self, f: Callable[..., ArgTuple], *, info: str | None = None
-    ) -> "GenerativeFunction[R]":
+    def contramap(self, f: Callable[..., ArgTuple]) -> "GenerativeFunction[R]":
         """
         Specialized version of [`genjax.GenerativeFunction.dimap`][] where only the pre-processing function is applied.
 
         Args:
             f: A callable that preprocesses the arguments of the wrapped function. Note that `f` must return a _tuple_ of arguments, not a bare argument.
-            info: An optional string providing additional information about the `contramap` operation.
 
         Returns:
             A [`genjax.GenerativeFunction`][] that acts like `self` with a pre-processing function to its arguments.
@@ -1462,7 +1454,7 @@ class GenerativeFunction(Generic[R], Pytree):
                 return genjax.normal(x, 1.0) @ "z"
 
 
-            contramap_model = model.contramap(add_one, info="Add one to input")
+            contramap_model = model.contramap(add_one)
 
             # Use the contramap model
             key = jax.random.key(0)
@@ -1473,7 +1465,7 @@ class GenerativeFunction(Generic[R], Pytree):
         """
         import genjax
 
-        return genjax.contramap(f=f, info=info)(self)
+        return genjax.contramap(f=f)(self)
 
     #####################
     # GenSP / inference #

--- a/src/genjax/_src/generative_functions/combinators/dimap.py
+++ b/src/genjax/_src/generative_functions/combinators/dimap.py
@@ -110,7 +110,6 @@ class DimapCombinator(Generic[ArgTuple, R, S], GenerativeFunction[S]):
     inner: GenerativeFunction[R]
     argument_mapping: Callable[..., ArgTuple] = Pytree.static()
     retval_mapping: Callable[[tuple[Any, ...], ArgTuple, R], S] = Pytree.static()
-    info: str | None = Pytree.static(default=None)
 
     def simulate(
         self,
@@ -223,7 +222,6 @@ def dimap(
     post: Callable[[tuple[Any, ...], ArgTuple, R], S] = lambda _,
     _xformed,
     retval: retval,
-    info: str | None = None,
 ) -> Callable[[GenerativeFunction[R]], DimapCombinator[ArgTuple, R, S]]:
     """
     Returns a decorator that wraps a [`genjax.GenerativeFunction`][] and applies pre- and post-processing functions to its arguments and return value.
@@ -234,7 +232,6 @@ def dimap(
     Args:
         pre: A callable that preprocesses the arguments before passing them to the wrapped function. Note that `pre` must return a _tuple_ of arguments, not a bare argument. Default is the identity function.
         post: A callable that postprocesses the return value of the wrapped function. Default is the identity function.
-        info: An optional string providing additional information about the `dimap` operation.
 
     Returns:
         A decorator that takes a [`genjax.GenerativeFunction`][] and returns a new [`genjax.GenerativeFunction`][] with the same behavior but with the arguments and return value transformed according to `pre` and `post`.
@@ -254,7 +251,7 @@ def dimap(
 
 
         # Apply dimap to a generative function
-        @genjax.dimap(pre=pre_process, post=post_process, info="Square of normal")
+        @genjax.dimap(pre=pre_process, post=post_process)
         @genjax.gen
         def dimap_model(x, y):
             return genjax.normal(x, y) @ "z"
@@ -269,15 +266,13 @@ def dimap(
     """
 
     def decorator(f: GenerativeFunction[R]) -> DimapCombinator[ArgTuple, R, S]:
-        return DimapCombinator(f, pre, post, info)
+        return DimapCombinator(f, pre, post)
 
     return decorator
 
 
 def map(
     f: Callable[[R], S],
-    *,
-    info: str | None = None,
 ) -> Callable[[GenerativeFunction[R]], DimapCombinator[tuple[Any, ...], R, S]]:
     """
     Returns a decorator that wraps a [`genjax.GenerativeFunction`][] and applies a post-processing function to its return value.
@@ -286,7 +281,6 @@ def map(
 
     Args:
         f: A callable that postprocesses the return value of the wrapped function.
-        info: An optional string providing additional information about the `map` operation.
 
     Returns:
         A decorator that takes a [`genjax.GenerativeFunction`][] and returns a new [`genjax.GenerativeFunction`][] with the same behavior but with the return value transformed according to `f`.
@@ -319,13 +313,11 @@ def map(
     def post(_args, _xformed, x: R) -> S:
         return f(x)
 
-    return dimap(pre=lambda *args: args, post=post, info=info)
+    return dimap(pre=lambda *args: args, post=post)
 
 
 def contramap(
     f: Callable[..., ArgTuple],
-    *,
-    info: str | None = None,
 ) -> Callable[[GenerativeFunction[R]], DimapCombinator[ArgTuple, R, R]]:
     """
     Returns a decorator that wraps a [`genjax.GenerativeFunction`][] and applies a pre-processing function to its arguments.
@@ -334,7 +326,6 @@ def contramap(
 
     Args:
         f: A callable that preprocesses the arguments of the wrapped function. Note that `f` must return a _tuple_ of arguments, not a bare argument.
-        info: An optional string providing additional information about the `contramap` operation.
 
     Returns:
         A decorator that takes a [`genjax.GenerativeFunction`][] and returns a new [`genjax.GenerativeFunction`][] with the same behavior but with the arguments transformed according to `f`.
@@ -351,7 +342,7 @@ def contramap(
 
 
         # Apply contramap to a generative function
-        @genjax.contramap(add_one, info="Add one to input")
+        @genjax.contramap(add_one)
         @genjax.gen
         def contramap_model(x):
             return genjax.normal(x, 1.0) @ "z"
@@ -364,4 +355,4 @@ def contramap(
         print(trace.render_html())
         ```
     """
-    return dimap(pre=f, post=lambda _args, _xformed, ret: ret, info=info)
+    return dimap(pre=f, post=lambda _args, _xformed, ret: ret)

--- a/src/genjax/_src/generative_functions/combinators/dimap.py
+++ b/src/genjax/_src/generative_functions/combinators/dimap.py
@@ -296,7 +296,7 @@ def map(
 
 
         # Apply map to a generative function
-        @genjax.map(square, info="Square of normal")
+        @genjax.map(square)
         @genjax.gen
         def map_model(x):
             return genjax.normal(x, 1.0) @ "z"

--- a/src/genjax/_src/generative_functions/combinators/or_else.py
+++ b/src/genjax/_src/generative_functions/combinators/or_else.py
@@ -81,6 +81,4 @@ def or_else(
         idx = jnp.array(jnp.logical_not(b), dtype=int)
         return (idx, if_args, else_args)
 
-    return if_gen_fn.switch(else_gen_fn).contramap(
-        argument_mapping, info="Derived combinator (OrElse)"
-    )
+    return if_gen_fn.switch(else_gen_fn).contramap(argument_mapping)

--- a/tests/generative_functions/test_dimap_combinator.py
+++ b/tests/generative_functions/test_dimap_combinator.py
@@ -36,9 +36,7 @@ class TestDimapCombinator:
         def model(x, y, _):
             return genjax.normal(x, y) @ "z"
 
-        dimap_model = model.dimap(
-            pre=pre_process, post=post_process, info="Square of normal"
-        )
+        dimap_model = model.dimap(pre=pre_process, post=post_process)
 
         # Use the dimap model
         key = jax.random.key(0)


### PR DESCRIPTION
We never use this and I don't think that it buys us anything. If we want to provide good info, we should have treescope point to the function definition, yeah?

Let's reduce a touch of visual noise in the treescope output.