### PR TITLE
Take multiple address components in get_submap

### DIFF
--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -531,7 +531,7 @@ class TestChoiceMap:
         assert extended["a", "b"] == 1
 
         assert extended.get_value() is None
-        assert extended.get_submap("a").get_submap("b").get_value() == 1
+        assert extended.get_submap("a", "b").get_value() == 1
         assert ChoiceMap.empty().extend("a", "b").static_is_empty()
 
     def test_switch_chm(self):


### PR DESCRIPTION
This PR modifies get_submap to be able to take in either a single entry or multiple entries.

@littleredcomputer , unlike what you did for ChoiceMap I don't think I can provide a single tuple. wdyt? Is that okay?