### PR TITLE
Remove docs on deprecated ^ for choicemaps (GEN-961)

### DIFF
--- a/docs/cookbook/active/choice_maps.ipynb
+++ b/docs/cookbook/active/choice_maps.ipynb
@@ -154,27 +154,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Yet another convenient function is that one can use `^` as a replacement for `|`. This will check that the two sub choice maps are disjoint."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "    bad_chm = C[\"v\"].set(0.5) ^ C[\"v\"].set(1)\n",
-    "    bad_chm[\"v\"]\n",
-    "except Exception as e:\n",
-    "    print(e)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This also works for hierarchical addresses"
+    "This also works for hierarchical addresses:"
    ]
   },
   {


### PR DESCRIPTION
This PR removes the docs claiming that ^ throws if the addresses clash — this is not true, and we have deprecated ^ (it now behaves like |)