### PR TITLE
Add mathjax support for $, $$ delimiters (GEN-975)

### DIFF
--- a/docs/js/mathjax.js
+++ b/docs/js/mathjax.js
@@ -1,7 +1,7 @@
 window.MathJax = {
   tex: {
-    inlineMath: [["\\(", "\\)"]],
-    displayMath: [["\\[", "\\]"]],
+    inlineMath: [['$','$'], ["\\(", "\\)"]],
+    displayMath: [['$$','$$'], ["\\[", "\\]"]],
     processEscapes: true,
     processEnvironments: true
   },


### PR DESCRIPTION
This PR adds support for $x$ and 

$$
x^2
$$

style delimiters on our docs site.