### PR TITLE
Remove MaskSel, Flag => bool in a number of spots (GEN-979)

### DIFF
--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -176,22 +176,6 @@ class TestSelections:
         assert sel1 | sel1 == sel1
         assert sel2 | sel2 == sel2
 
-    def test_selection_mask(self):
-        sel = S["x"] | S["y"]
-        masked_sel = sel.mask(jnp.asarray(True))
-        assert masked_sel["x"]
-        assert masked_sel["y"]
-        assert not masked_sel["z"]
-
-        masked_sel = sel.mask(False)
-        assert not masked_sel["x"]
-        assert not masked_sel["y"]
-        assert not masked_sel["z"]
-
-        # bool works like flags
-        assert sel.mask(True) == sel.mask(True)
-        assert sel.mask(False) == sel.mask(False)
-
     def test_selection_filter(self):
         # Create a ChoiceMap
         chm = ChoiceMap.kw(x=1, y=2, z=3)
@@ -681,20 +665,19 @@ class TestChoiceMap:
         assert filtered.simplify() == C["x", "y"].set(maskv), "simplify removes filters"
 
         xyz = ChoiceMap.d({"x": 1, "y": 2, "z": 3})
-        or_chm = xyz.filter(S["x"]) | xyz.filter(S["y"].mask(jnp.array(True)))
-
-        xor_chm = xyz.filter(S["x"]) ^ xyz.filter(S["y"].mask(jnp.array(True)))
+        or_chm = xyz.filter(S["x"]) | xyz.filter(S["y"])
+        xor_chm = xyz.filter(S["x"]) ^ xyz.filter(S["y"])
 
         assert or_chm.simplify() == xor_chm.simplify(), "filters pushed down"
 
         assert or_chm["x"] == 1
-        assert or_chm["y"] == maskv
+        assert or_chm["y"] == 2
         with pytest.raises(ChoiceMapNoValueAtAddress, match="z"):
             or_chm["z"]
 
         assert or_chm.simplify() == ChoiceMap.d({
             "x": 1,
-            "y": maskv,
+            "y": 2,
         }), "filters pushed down"
 
         assert C["x"].set(None).simplify() == C["x"].set(None), "None is not filtered"

--- a/tests/generative_functions/test_switch_combinator.py
+++ b/tests/generative_functions/test_switch_combinator.py
@@ -92,9 +92,11 @@ class TestSwitch:
         key = jax.random.key(314159)
         jitted = jax.jit(switch.simulate)
         tr = jitted(key, (0, (), ()))
-        assert "y1" in tr.get_choices()
-        assert "y2" in tr.get_choices()
-        assert "y3" not in tr.get_choices()
+        chm = tr.get_choices()
+        assert "y1" in chm
+        assert "y2" in chm
+        assert "y3" in chm
+        assert chm["y3"] == genjax.Mask(jnp.array(False), jnp.array(False))
 
     def test_switch_combinator_importance(self):
         @genjax.gen


### PR DESCRIPTION
This PR:

- removes `MaskSel` (as selections should only be built to match against str addresses)
- changes the signature of Selection.check to return `bool` (no need to return a flag if we don't check against dynamic)
- fixes some `get_subselection` signatures that weren't taking `StaticAddressComponent`
- changes `ChoiceMap.has_value` to return a `bool`, `True` if the node is a non-`None` `Choice`, `False` otherwise. (This is only "hairy" for `SwitchChm`, and I've implemented it so this returns true if any of the branches have a value. Thoughts?)
- `ChoiceMap.filter` now takes a `Selection | Flag`, and `ChoiceMap.mask` passes through to `ChoiceMap.filter`.

This last one is a little weird, and maybe the two ideas need to stay separate. `mask` is an operation for leaves, `filter` is an operation for the `ChoiceMap`. we could have two implementations and use `tree_map` to make it really clear that we are trying to get down to the leaves. This is probably the way?