### PR TITLE
Tighten up types on get_submap, get_subtrace (GEN-980)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1166,6 +1166,39 @@ http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 
 [[package]]
+name = "hypothesis"
+version = "6.126.0"
+description = "A library for property-based testing"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "hypothesis-6.126.0-py3-none-any.whl", hash = "sha256:323c58a773482a2b4ba4e35202560cfcba45e8a8e09e7ffb83c0f9bac5b544da"},
+    {file = "hypothesis-6.126.0.tar.gz", hash = "sha256:648b6215ee0468fa85eaee9dceb5b7766a5861c20ee4801bd904a2c02f1a6c9b"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+sortedcontainers = ">=2.1.0,<3.0.0"
+
+[package.extras]
+all = ["black (>=19.10b0)", "click (>=7.0)", "crosshair-tool (>=0.0.82)", "django (>=4.2)", "dpcontracts (>=0.4)", "hypothesis-crosshair (>=0.0.19)", "lark (>=0.10.1)", "libcst (>=0.3.16)", "numpy (>=1.19.3)", "pandas (>=1.1)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2025.1)", "watchdog (>=4.0.0)"]
+cli = ["black (>=19.10b0)", "click (>=7.0)", "rich (>=9.0.0)"]
+codemods = ["libcst (>=0.3.16)"]
+crosshair = ["crosshair-tool (>=0.0.82)", "hypothesis-crosshair (>=0.0.19)"]
+dateutil = ["python-dateutil (>=1.4)"]
+django = ["django (>=4.2)"]
+dpcontracts = ["dpcontracts (>=0.4)"]
+ghostwriter = ["black (>=19.10b0)"]
+lark = ["lark (>=0.10.1)"]
+numpy = ["numpy (>=1.19.3)"]
+pandas = ["pandas (>=1.1)"]
+pytest = ["pytest (>=4.6)"]
+pytz = ["pytz (>=2014.1)"]
+redis = ["redis (>=3.0.0)"]
+watchdog = ["watchdog (>=4.0.0)"]
+zoneinfo = ["tzdata (>=2025.1)"]
+
+[[package]]
 name = "idna"
 version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -4211,6 +4244,17 @@ files = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.5"
 description = "A modern CSS selector implementation for Beautiful Soup."
@@ -4684,4 +4728,4 @@ genstudio = ["genstudio"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<4.0"
-content-hash = "c213e23d9498f0a75a0ebc4977df0c46ba78d16a1094069a67b47ee6edef6533"
+content-hash = "749feda2ef0248bba2da6c3afce98ddfccb5ed57f2f4f05f9815430bb83e2f73"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.0.0"
+hypothesis = "^6.119.0"
 matplotlib = "^3.6.2"
 mypy = "^0.991"
 pytest = "^7.2.0"

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -16,7 +16,7 @@ import functools
 from abc import abstractmethod
 from dataclasses import dataclass
 from operator import or_
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 import jax.numpy as jnp
 import jax.tree_util as jtu
@@ -55,7 +55,7 @@ ExtendedAddressComponent = ExtendedStaticAddressComponent | DynamicAddressCompon
 
 # Addresses
 Address = AddressComponent | tuple[AddressComponent, ...]
-StaticAddress: TypeAlias = StaticAddressComponent | tuple[StaticAddressComponent, ...]
+StaticAddress = StaticAddressComponent | tuple[StaticAddressComponent, ...]
 ExtendedStaticAddress = (
     ExtendedStaticAddressComponent | tuple[ExtendedStaticAddressComponent, ...]
 )
@@ -940,7 +940,9 @@ class ChoiceMap(Pytree):
         pass
 
     def get_submap(self, *addresses: Address) -> "ChoiceMap":
-        addr = sum((a if isinstance(a, tuple) else (a,) for a in addresses), ())
+        addr = tuple(
+            label for a in addresses for label in (a if isinstance(a, tuple) else (a,))
+        )
         addr: tuple[AddressComponent, ...] = _validate_addr(
             addr, allow_partial_slice=True
         )

--- a/src/genjax/_src/core/generative/choice_map.py
+++ b/src/genjax/_src/core/generative/choice_map.py
@@ -165,7 +165,7 @@ class Selection(Pytree):
         assert sel("x") == Selection.at["y"]
         assert sel("z") == Selection.none()
 
-        # Querying the selection using [] returns a `Flag` representing whether or not the input matches:
+        # Querying the selection using [] returns a `bool` representing whether or not the input matches:
         assert sel["x"] == False
         assert sel["x", "y"] == True
 
@@ -337,14 +337,13 @@ class Selection(Pytree):
     def __getitem__(
         self,
         addr: StaticAddress,
-    ) -> Flag:
-        subselection = self(addr)
-        return subselection.check()
+    ) -> bool:
+        return self(addr).check()
 
     def __contains__(
         self,
         addr: StaticAddress,
-    ) -> Flag:
+    ) -> bool:
         return self[addr]
 
     @abstractmethod
@@ -1301,14 +1300,14 @@ class ChoiceMap(Pytree):
         self,
         *addresses: Address,
     ) -> "ChoiceMap":
-        """TODO add some tests that we flatten out one layer of nested tuples, and that get_submap can now take multiple arguments."""
+        """Alias for `get_submap(*addresses)`."""
         return self.get_submap(*addresses)
 
     def __getitem__(
         self,
         addr: Address,
     ):
-        submap = self(addr)
+        submap = self.get_submap(addr)
         v = submap.get_value()
         if v is None:
             raise ChoiceMapNoValueAtAddress(addr)
@@ -1318,9 +1317,8 @@ class ChoiceMap(Pytree):
     def __contains__(
         self,
         addr: Address,
-    ) -> Flag:
-        submap = self(addr)
-        return submap.has_value()
+    ) -> bool:
+        return self.get_submap(addr).has_value()
 
     @property
     def at(self) -> _ChoiceMapBuilder:

--- a/src/genjax/_src/core/generative/generative_function.py
+++ b/src/genjax/_src/core/generative/generative_function.py
@@ -19,9 +19,9 @@ from typing import TYPE_CHECKING
 from deprecated import deprecated
 
 from genjax._src.core.generative.choice_map import (
+    Address,
     ChoiceMap,
     ChoiceMapConstraint,
-    ExtendedAddress,
     Selection,
 )
 from genjax._src.core.generative.core import (
@@ -193,7 +193,7 @@ class Trace(Generic[R], Pytree):
             selection,
         )
 
-    def get_subtrace(self, *addresses: ExtendedAddress) -> "Trace[Any]":
+    def get_subtrace(self, *addresses: Address) -> "Trace[Any]":
         """
         Return the subtrace having the supplied address. Specifying multiple addresses
         will apply the operation recursively.
@@ -209,7 +209,7 @@ class Trace(Generic[R], Pytree):
             lambda tr, addr: tr.get_inner_trace(addr), addresses, self
         )
 
-    def get_inner_trace(self, address: ExtendedAddress) -> "Trace[Any]":
+    def get_inner_trace(self, _address: Address) -> "Trace[Any]":
         """Override this method to provide `Trace.get_subtrace` support
         for those trace types that have substructure that can be addressed
         in this way."""

--- a/src/genjax/_src/core/generative/generative_function.py
+++ b/src/genjax/_src/core/generative/generative_function.py
@@ -195,6 +195,9 @@ class Trace(Generic[R], Pytree):
 
     def get_subtrace(self, *addresses: Address) -> "Trace[Any]":
         """
+
+        NOTE that this is just for debugging, so you don't have to know the specific fields that are in the trace. It's the "missing method" alongside get_args, get_choices, get_gen_fn, get_retval, get_score.
+
         Return the subtrace having the supplied address. Specifying multiple addresses
         will apply the operation recursively.
 
@@ -212,7 +215,11 @@ class Trace(Generic[R], Pytree):
     def get_inner_trace(self, _address: Address) -> "Trace[Any]":
         """Override this method to provide `Trace.get_subtrace` support
         for those trace types that have substructure that can be addressed
-        in this way."""
+        in this way.
+
+        TODO add a note about why this is taking a full Address, not an AddressComponent
+
+        TODO I THINK we can solve this at the Static level by supporting a query on the first element of a tuple, and then iterating through the dict, dropping all keys that don't match OR don't have a tuple with that prefix, and maybe dropping tuples and then returning the same trace with a different dict? maybe?"""
         raise NotImplementedError(
             "This type of Trace object does not possess subtraces."
         )

--- a/src/genjax/_src/core/generative/generative_function.py
+++ b/src/genjax/_src/core/generative/generative_function.py
@@ -195,9 +195,6 @@ class Trace(Generic[R], Pytree):
 
     def get_subtrace(self, *addresses: Address) -> "Trace[Any]":
         """
-
-        NOTE that this is just for debugging, so you don't have to know the specific fields that are in the trace. It's the "missing method" alongside get_args, get_choices, get_gen_fn, get_retval, get_score.
-
         Return the subtrace having the supplied address. Specifying multiple addresses
         will apply the operation recursively.
 
@@ -217,9 +214,9 @@ class Trace(Generic[R], Pytree):
         for those trace types that have substructure that can be addressed
         in this way.
 
-        TODO add a note about why this is taking a full Address, not an AddressComponent
+        NOTE: `get_inner_trace` takes a full `Address` because, unlike `ChoiceMap`, if a user traces to a tupled address like ("a", "b"), then the resulting `StaticTrace` will store a sub-trace at this address, vs flattening it out.
 
-        TODO I THINK we can solve this at the Static level by supporting a query on the first element of a tuple, and then iterating through the dict, dropping all keys that don't match OR don't have a tuple with that prefix, and maybe dropping tuples and then returning the same trace with a different dict? maybe?"""
+        As a result, `tr.get_inner_trace(("a", "b"))` does not equal `tr.get_inner_trace("a").get_inner_trace("b")`."""
         raise NotImplementedError(
             "This type of Trace object does not possess subtraces."
         )

--- a/src/genjax/_src/generative_functions/combinators/dimap.py
+++ b/src/genjax/_src/generative_functions/combinators/dimap.py
@@ -24,7 +24,11 @@ from genjax._src.core.generative import (
     Update,
     Weight,
 )
-from genjax._src.core.generative.choice_map import ChoiceMap, ExtendedAddress, Selection
+from genjax._src.core.generative.choice_map import (
+    Address,
+    ChoiceMap,
+    Selection,
+)
 from genjax._src.core.interpreters.incremental import Diff, incremental
 from genjax._src.core.pytree import Pytree
 from genjax._src.core.typing import (
@@ -62,7 +66,7 @@ class DimapTrace(Generic[R, S], Trace[S]):
     def get_score(self) -> Score:
         return self.inner.get_score()
 
-    def get_inner_trace(self, address: ExtendedAddress) -> Trace[R]:
+    def get_inner_trace(self, address: Address) -> Trace[R]:
         return self.inner.get_inner_trace(address)
 
 

--- a/src/genjax/_src/generative_functions/combinators/mask.py
+++ b/src/genjax/_src/generative_functions/combinators/mask.py
@@ -29,7 +29,7 @@ from genjax._src.core.generative import (
     Update,
     Weight,
 )
-from genjax._src.core.generative.choice_map import ExtendedAddress, Selection
+from genjax._src.core.generative.choice_map import Address, Selection
 from genjax._src.core.interpreters.incremental import Diff
 from genjax._src.core.interpreters.staging import FlagOp
 from genjax._src.core.pytree import Pytree
@@ -104,7 +104,7 @@ class MaskTrace(Generic[R], Trace[Mask[R]]):
     def get_score(self):
         return self.score
 
-    def get_inner_trace(self, address: ExtendedAddress) -> Trace[R]:
+    def get_inner_trace(self, address: Address) -> Trace[R]:
         return self.inner.get_inner_trace(address)
 
 

--- a/src/genjax/_src/generative_functions/combinators/scan.py
+++ b/src/genjax/_src/generative_functions/combinators/scan.py
@@ -33,8 +33,8 @@ from genjax._src.core.generative import (
     Weight,
 )
 from genjax._src.core.generative.choice_map import (
+    Address,
     ChoiceMapConstraint,
-    ExtendedAddress,
 )
 from genjax._src.core.generative.functional_types import Mask
 from genjax._src.core.interpreters.incremental import Diff
@@ -94,7 +94,7 @@ class ScanTrace(Generic[Carry, Y], Trace[tuple[Carry, Y]]):
     def get_score(self):
         return self.score
 
-    def get_inner_trace(self, address: ExtendedAddress):
+    def get_inner_trace(self, address: Address):
         return self.inner.get_inner_trace(address)
 
 

--- a/src/genjax/_src/generative_functions/combinators/switch.py
+++ b/src/genjax/_src/generative_functions/combinators/switch.py
@@ -25,7 +25,7 @@ from genjax._src.core.generative import (
     Update,
     Weight,
 )
-from genjax._src.core.generative.choice_map import ExtendedAddress, Selection
+from genjax._src.core.generative.choice_map import Address, Selection
 from genjax._src.core.interpreters.incremental import Diff, NoChange, UnknownChange
 from genjax._src.core.interpreters.staging import multi_switch, tree_choose
 from genjax._src.core.pytree import Pytree
@@ -82,7 +82,7 @@ class SwitchTrace(Generic[R], Trace[R]):
     def get_score(self):
         return self.score
 
-    def get_inner_trace(self, address: ExtendedAddress):
+    def get_inner_trace(self, address: Address):
         assert isinstance(address, int)
         return self.subtraces[address]
 

--- a/src/genjax/_src/generative_functions/combinators/vmap.py
+++ b/src/genjax/_src/generative_functions/combinators/vmap.py
@@ -36,8 +36,8 @@ from genjax._src.core.generative import (
     Weight,
 )
 from genjax._src.core.generative.choice_map import (
+    Address,
     ChoiceMapConstraint,
-    ExtendedAddress,
     Selection,
 )
 from genjax._src.core.interpreters.incremental import Diff
@@ -92,7 +92,7 @@ class VmapTrace(Generic[R], Trace[R]):
     def get_score(self) -> Score:
         return self.score
 
-    def get_inner_trace(self, address: ExtendedAddress):
+    def get_inner_trace(self, address: Address):
         return self.inner.get_inner_trace(address)
 
 

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -42,7 +42,7 @@ from genjax._src.core.generative import (
     Update,
     Weight,
 )
-from genjax._src.core.generative.choice_map import ExtendedAddress
+from genjax._src.core.generative.choice_map import Address
 from genjax._src.core.generative.generative_function import R, push_trace_overload_stack
 from genjax._src.core.interpreters.forward import (
     InitialStylePrimitive,
@@ -104,7 +104,7 @@ class StaticTrace(Generic[R], Trace[R]):
             jnp.array([tr.get_score() for tr in self.subtraces.values()], copy=False),
         )
 
-    def get_inner_trace(self, address: ExtendedAddress):
+    def get_inner_trace(self, address: Address):
         if (
             isinstance(address, tuple)
             and len(address) == 1
@@ -123,7 +123,7 @@ class StaticTrace(Generic[R], Trace[R]):
 # Static (trie-like) edit request  #
 ####################################
 
-StaticDict: TypeAlias = dict[StaticAddressComponent | StaticAddress, EditRequest]
+StaticDict: TypeAlias = dict[StaticAddress, EditRequest]
 
 
 @Pytree.dataclass(match_args=True)
@@ -533,9 +533,7 @@ class StaticEditRequestHandler(StaticHandler):
             self.bwd_requests,
         )
 
-    def get_subrequest(
-        self, addr: StaticAddressComponent | StaticAddress
-    ) -> EditRequest:
+    def get_subrequest(self, addr: StaticAddress) -> EditRequest:
         return self.addressed.get(addr, EmptyRequest())
 
     def get_subtrace(
@@ -728,7 +726,7 @@ def regenerate_transform(source_fn):
 
 
 def handler_trace_with_static(
-    addr: StaticAddressComponent | StaticAddress,
+    addr: StaticAddress,
     gen_fn: GenerativeFunction[Any],
     args: tuple[Any, ...],
 ):

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -84,21 +84,6 @@ class StaticTrace(Generic[R], Trace[R]):
     retval: R
     subtraces: dict[StaticAddress, Trace[R]]
 
-    # If you trace like @ ("a", "b") you'll get
-    # {("a", "b"): tr}
-
-    #
-    # if you trace model @ "a" and model traces @ "b" you'll get
-    # {"a": StaticTrace({"b": tr}})
-
-    # this means that it's meaningful to call
-    # tr.get_subtrace(("a", "b"), ("c",))
-    #
-    # and that does NOT mean the same thing as
-    # tr.get_subtrace("a", "b", "c")
-
-    # choicemaps look like {"a": {"b": 1.0}}
-
     def get_args(self) -> tuple[Any, ...]:
         return self.args
 

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -84,6 +84,21 @@ class StaticTrace(Generic[R], Trace[R]):
     retval: R
     subtraces: dict[StaticAddress, Trace[R]]
 
+    # If you trace like @ ("a", "b") you'll get
+    # {("a", "b"): tr}
+
+    #
+    # if you trace model @ "a" and model traces @ "b" you'll get
+    # {"a": StaticTrace({"b": tr}})
+
+    # this means that it's meaningful to call
+    # tr.get_subtrace(("a", "b"), ("c",))
+    #
+    # and that does NOT mean the same thing as
+    # tr.get_subtrace("a", "b", "c")
+
+    # choicemaps look like {"a": {"b": 1.0}}
+
     def get_args(self) -> tuple[Any, ...]:
         return self.args
 

--- a/tests/core/test_choice_maps.py
+++ b/tests/core/test_choice_maps.py
@@ -1141,11 +1141,13 @@ class TestChoiceMap:
 
 dictionaries_for_choice_maps = st.deferred(
     lambda: st.dictionaries(
-        st.text(), st.floats(allow_nan=False) | st.lists(st.floats(allow_nan=False)) | dictionaries_for_choice_maps,
-        min_size=1
+        st.text(),
+        st.floats(allow_nan=False)
+        | st.lists(st.floats(allow_nan=False))
+        | dictionaries_for_choice_maps,
+        min_size=1,
     )
 )
-
 
 
 def all_paths(mapping):


### PR DESCRIPTION
This PR:
- adds hypothesis as a dev dependency and our first hypothesis tests (thanks to @DRMacIver !)
- cleans up our `Address` types. `Address` and `ExtendedStaticAddress` were pointing to a tuple only, when they should have followed the `component | tuple[component, ...]` pattern. This rippled some clean-up through the codebase
- changes various return types to `bool` that I'd left as `Flag`
- `ChoiceMap.get_submap` is now variadic, and can take multiple `Address` inputs (so, `component | tuple[component, ...]`). These will all be flattened out on query, just like `ChoiceMap` creation flattens out tupled addresses.
- `ChoiceMap.__call__` now simply calls `ChoiceMap.get_submap`
- `Trace.get_subtrace` and `Trace.get_inner_trace` no longer allowed ellipses (accomplished by changing `ExtendedAddress` to `Address` in these methods)