### PR TITLE
Clean up the usage of the trace primitive and remove global "handler stack".

### DIFF
--- a/src/genjax/_src/core/generative/generative_function.py
+++ b/src/genjax/_src/core/generative/generative_function.py
@@ -355,7 +355,7 @@ class GenerativeFunction(Generic[R], Pytree):
             @genjax.gen
             def weather_model():
                 temperature = genjax.normal(20.0, 5.0) @ "temperature"
-                is_sunny = genjax.bernoulli(probs=0.7) @ "is_sunny"
+                is_sunny = genjax.bernoulli(0.7) @ "is_sunny"
                 return {"temperature": temperature, "is_sunny": is_sunny}
 
 
@@ -1268,7 +1268,7 @@ class GenerativeFunction(Generic[R], Pytree):
 
             @genjax.gen
             def branch_2():
-                x = genjax.bernoulli(probs=0.3) @ "x2"
+                x = genjax.bernoulli(0.3) @ "x2"
 
 
             switch = branch_1.switch(branch_2)
@@ -1482,33 +1482,6 @@ class GenerativeFunction(Generic[R], Pytree):
         return marginal(selection=selection, algorithm=algorithm)(self)
 
 
-# NOTE: Setup a global handler stack for the `trace` callee sugar.
-# C.f. above.
-# This stack will not interact with JAX tracers at all
-# so it's safe, and will be resolved at JAX tracing time.
-GLOBAL_TRACE_OP_HANDLER_STACK: list[Callable[..., Any]] = []
-
-
-def handle_off_trace_stack(addr, gen_fn: GenerativeFunction[R], args) -> R:
-    if GLOBAL_TRACE_OP_HANDLER_STACK:
-        handler = GLOBAL_TRACE_OP_HANDLER_STACK[-1]
-        return handler(addr, gen_fn, args)
-    else:
-        raise Exception(
-            "Attempting to invoke trace outside of a tracing context.\nIf you want to invoke the generative function closure, and recieve a return value,\ninvoke it with a key."
-        )
-
-
-def push_trace_overload_stack(handler, fn):
-    def wrapped(*args):
-        GLOBAL_TRACE_OP_HANDLER_STACK.append(handler)
-        ret = fn(*args)
-        GLOBAL_TRACE_OP_HANDLER_STACK.pop()
-        return ret
-
-    return wrapped
-
-
 @Pytree.dataclass
 class IgnoreKwargs(Generic[R], GenerativeFunction[R]):
     """
@@ -1591,15 +1564,17 @@ class GenerativeFunctionClosure(Generic[R], GenerativeFunction[R]):
 
     # NOTE: Supports callee syntax, and the ability to overload it in callers.
     def __matmul__(self, addr) -> R:
+        from genjax._src.generative_functions.static import trace
+
         if self.kwargs:
             maybe_kwarged_gen_fn = self._with_kwargs()
-            return handle_off_trace_stack(
+            return trace(
                 addr,
                 maybe_kwarged_gen_fn,
                 (self.args, self.kwargs),
             )
         else:
-            return handle_off_trace_stack(
+            return trace(
                 addr,
                 self.gen_fn,
                 self.args,

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -834,9 +834,6 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
         constraint: ChoiceMap,
         argdiffs: Argdiffs,
     ) -> tuple[StaticTrace[R], Weight, Retdiff[R], EditRequest]:
-        syntax_sugar_handled = push_trace_overload_stack(
-            handler_trace_with_static, self.source
-        )
         (
             (
                 retval_diffs,
@@ -848,7 +845,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
                 ),
                 bwd_requests,
             ),
-        ) = update_transform(syntax_sugar_handled)(key, trace, constraint, argdiffs)
+        ) = update_transform(self.source)(key, trace, constraint, argdiffs)
         if not Diff.static_check_tree_diff(retval_diffs):
             retval_diffs = Diff.no_change(retval_diffs)
 

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -721,6 +721,7 @@ def regenerate_transform(source_fn):
 # Generative function #
 #######################
 
+
 @Pytree.dataclass
 class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
     """A `StaticGenerativeFunction` is a generative function which relies on program

--- a/src/genjax/_src/generative_functions/static.py
+++ b/src/genjax/_src/generative_functions/static.py
@@ -43,7 +43,7 @@ from genjax._src.core.generative import (
     Weight,
 )
 from genjax._src.core.generative.choice_map import ExtendedAddress
-from genjax._src.core.generative.generative_function import R, push_trace_overload_stack
+from genjax._src.core.generative.generative_function import R
 from genjax._src.core.interpreters.forward import (
     InitialStylePrimitive,
     StatefulHandler,
@@ -724,17 +724,6 @@ def regenerate_transform(source_fn):
 #######################
 
 
-# Callee syntactic sugar handler.
-
-
-def handler_trace_with_static(
-    addr: StaticAddressComponent | StaticAddress,
-    gen_fn: GenerativeFunction[Any],
-    args: tuple[Any, ...],
-):
-    return trace(addr, gen_fn, args)
-
-
 @Pytree.dataclass
 class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
     """A `StaticGenerativeFunction` is a generative function which relies on program
@@ -802,10 +791,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
         key: PRNGKey,
         args: tuple[Any, ...],
     ) -> StaticTrace[R]:
-        syntax_sugar_handled = push_trace_overload_stack(
-            handler_trace_with_static, self.source
-        )
-        (args, retval, traces) = simulate_transform(syntax_sugar_handled)(key, args)
+        (args, retval, traces) = simulate_transform(self.source)(key, args)
         return StaticTrace(self, args, retval, traces)
 
     def generate(
@@ -815,11 +801,6 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
         args: tuple[Any, ...],
     ) -> tuple[StaticTrace[R], Weight]:
         assert isinstance(constraint, ChoiceMapConstraint), type(constraint)
-
-        syntax_sugar_handled = push_trace_overload_stack(
-            handler_trace_with_static, self.source
-        )
-
         (
             weight,
             # Trace.
@@ -828,7 +809,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
                 retval,
                 traces,
             ),
-        ) = generate_transform(syntax_sugar_handled)(key, constraint.choice_map, args)
+        ) = generate_transform(self.source)(key, constraint.choice_map, args)
         return StaticTrace(self, args, retval, traces), weight
 
     def project(
@@ -896,9 +877,6 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
         addressed: StaticDict,
         argdiffs: Argdiffs,
     ) -> tuple[StaticTrace[R], Weight, Retdiff[R], EditRequest]:
-        syntax_sugar_handled = push_trace_overload_stack(
-            handler_trace_with_static, self.source
-        )
         (
             (
                 retval_diffs,
@@ -910,9 +888,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
                 ),
                 bwd_requests,
             ),
-        ) = static_edit_request_transform(syntax_sugar_handled)(
-            key, trace, addressed, argdiffs
-        )
+        ) = static_edit_request_transform(self.source)(key, trace, addressed, argdiffs)
 
         def make_bwd_request(
             traces: dict[StaticAddress, Trace[R]],
@@ -941,9 +917,6 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
         edit_request: EditRequest,
         argdiffs: Argdiffs,
     ) -> tuple[StaticTrace[R], Weight, Retdiff[R], EditRequest]:
-        syntax_sugar_handled = push_trace_overload_stack(
-            handler_trace_with_static, self.source
-        )
         (
             (
                 retval_diffs,
@@ -955,7 +928,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
                 ),
                 bwd_requests,
             ),
-        ) = regenerate_transform(syntax_sugar_handled)(
+        ) = regenerate_transform(self.source)(
             key, trace, selection, edit_request, argdiffs
         )
 
@@ -1018,10 +991,7 @@ class StaticGenerativeFunction(Generic[R], GenerativeFunction[R]):
         sample: ChoiceMap,
         args: tuple[Any, ...],
     ) -> tuple[Score, R]:
-        syntax_sugar_handled = push_trace_overload_stack(
-            handler_trace_with_static, self.source
-        )
-        (retval, score) = assess_transform(syntax_sugar_handled)(sample, args)
+        (retval, score) = assess_transform(self.source)(sample, args)
         return (score, retval)
 
     def inline(self, *args):


### PR DESCRIPTION
The global "trace handler stack" was previously added so that `InterpretedGenerativeFunction` could also use the same `@` syntax as `StaticGenerativeFunction` -- but it causes an unintended issue with _printing_ the `Jaxpr` of `StaticGenerativeFunction`.

With this change, given a `StaticGenerativeFunction`:

```python
@gen
def model():
    x = normal(0.0, 1.0) @ "x"
```
one can inspect a lowered representation:

```python
make_jaxpr(model.source)()
```
without this change, this would error because of how the `trace_p` primitive was being used.