### PR TITLE
fix math rendering in notebooks (GEN-987)

### DIFF
--- a/docs/js/mathjax.js
+++ b/docs/js/mathjax.js
@@ -5,10 +5,6 @@ window.MathJax = {
     processEscapes: true,
     processEnvironments: true
   },
-  options: {
-    ignoreHtmlClass: ".*|",
-    processHtmlClass: "arithmatex"
-  }
 };
 
 document$.subscribe(() => {


### PR DESCRIPTION
This is the missing second part of the fix; we need mathjax to look at ALL html, not just the ones flagged by mkdocs. (I tested this locally.)