### PR TITLE
Fix mix side-effecting issue (GEN-986)

### DIFF
--- a/src/genjax/_src/generative_functions/combinators/mixture.py
+++ b/src/genjax/_src/generative_functions/combinators/mixture.py
@@ -14,7 +14,7 @@
 
 
 from genjax._src.core.generative import GenerativeFunction
-from genjax._src.core.typing import TypeVar
+from genjax._src.core.generative.core import R
 from genjax._src.generative_functions.combinators.switch import (
     switch,
 )
@@ -22,8 +22,6 @@ from genjax._src.generative_functions.distributions.tensorflow_probability impor
     categorical,
 )
 from genjax._src.generative_functions.static import gen
-
-R = TypeVar("R")
 
 
 def mix(*gen_fns: GenerativeFunction[R]) -> GenerativeFunction[R]:
@@ -75,10 +73,9 @@ def mix(*gen_fns: GenerativeFunction[R]) -> GenerativeFunction[R]:
 
     inner_combinator_closure = switch(*gen_fns)
 
-    @gen
     def mixture_model(mixture_logits, *args) -> R:
         mix_idx = categorical(mixture_logits) @ "mixture_component"
         v = inner_combinator_closure(mix_idx, *args) @ "component_sample"
         return v
 
-    return mixture_model
+    return gen(mixture_model)

--- a/tests/generative_functions/test_mix_combinator.py
+++ b/tests/generative_functions/test_mix_combinator.py
@@ -40,11 +40,12 @@ class TestMixture:
         trace = mixture.simulate(key, (logits, (0.0,), (0.0,)))
 
         # Check structure
-        assert "mixture_component" in trace.get_choices()
-        assert ("component_sample", "y") in trace.get_choices()
+        chm = trace.get_choices()
+        assert "mixture_component" in chm
+        assert ("component_sample", "y") in chm
 
         # Test assessment
-        choices = C["mixture_component"].set(0) & C["component_sample"].set(1.0)
+        choices = C["mixture_component"].set(0) | C["component_sample", "y"].set(1.0)
         score, _ = mixture.assess(choices, (logits, (0.0,), (0.0,)))
         assert jnp.isfinite(score)
 

--- a/tests/generative_functions/test_mix_combinator.py
+++ b/tests/generative_functions/test_mix_combinator.py
@@ -1,0 +1,66 @@
+# Copyright 2023 MIT Probabilistic Computing Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import jax
+import jax.numpy as jnp
+
+import genjax
+from genjax import ChoiceMapBuilder as C
+
+
+class TestMixture:
+    def test_mix_basic(self):
+        # Define two simple component functions
+        @genjax.gen
+        def comp1(x):
+            return genjax.normal(x, 1.0) @ "y"
+
+        @genjax.gen
+        def comp2(x):
+            return genjax.normal(x + 2.0, 0.5) @ "y"
+
+        # Create mixture model
+        mixture = genjax.mix(comp1, comp2)
+
+        # Test simulation
+        key = jax.random.key(0)
+        logits = jnp.array([0.3, 0.7])
+        trace = mixture.simulate(key, (logits, (0.0,), (0.0,)))
+
+        # Check structure
+        assert "mixture_component" in trace.get_choices()
+        assert ("component_sample", "y") in trace.get_choices()
+
+        # Test assessment
+        choices = C["mixture_component"].set(0) & C["component_sample"].set(1.0)
+        score, _ = mixture.assess(choices, (logits, (0.0,), (0.0,)))
+        assert jnp.isfinite(score)
+
+    def test_mix_then_simulate(self):
+        """GEN-1025 brought up an issue where calling `genjax.mix` between two calls to simulate
+        would make the second call fail (somehow capturing the internal mix genfn)"""
+
+        @genjax.gen
+        def f():
+            return genjax.uniform(0.0, 1.1) @ "uniform"
+
+        @genjax.gen
+        def g2():
+            return f() @ "f"
+
+        key = jax.random.key(0)
+        tr = g2.simulate(key, ())
+        genjax.mix(genjax.flip, genjax.flip)
+        assert tr == g2.simulate(key, ())

--- a/tests/generative_functions/test_mix_combinator.py
+++ b/tests/generative_functions/test_mix_combinator.py
@@ -36,7 +36,7 @@ class TestMixture:
 
         # Test simulation
         key = jax.random.key(0)
-        logits = jnp.array([0.3, 0.7])
+        logits = jnp.array([-0.1, -0.2])
         trace = mixture.simulate(key, (logits, (0.0,), (0.0,)))
 
         # Check structure


### PR DESCRIPTION
This PR moves the `@gen` decorator down to a `gen(...)` call. Before doing this, beartype 0.18.0 would somehow capture the `mixture_model` function internally in such a way that calls to `simulate` (with nested models only, not single layer models) of a totally different model would try and call `mixture_model`.

This change gets around that issue.