### PR TITLE
Add colab buttons, public colab link to notebook (GEN-1014, GEN-1015)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ On a Linux machine with a GPU, run the following command:
 pip install jax[cuda12]~=0.4.24
 ```
 
-### Quick example [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://console.cloud.google.com/vertex-ai/colab/notebooks?project=probcomp-caliban&activeNb=projects%2Fprobcomp-caliban%2Flocations%2Fus-west1%2Frepositories%2F09be0f8e-ccfd-4d34-a029-fed94d455c48)
+### Quick example [![Open In Colab](https://colab.research.google.com/drive/1KWMa5No95tMDYEdmA4N0iqVFD-UsCSgp?usp=sharing)
 
 
 The following code snippet defines a generative function called `beta_bernoulli` that

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ On a Linux machine with a GPU, run the following command:
 pip install jax[cuda12]~=0.4.24
 ```
 
-### Quick example [![Open In Colab](https://colab.research.google.com/drive/1KWMa5No95tMDYEdmA4N0iqVFD-UsCSgp?usp=sharing)
+### Quick example [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1KWMa5No95tMDYEdmA4N0iqVFD-UsCSgp?usp=sharing)
 
 
 The following code snippet defines a generative function called `beta_bernoulli` that

--- a/docs/cookbook/active/choice_maps.ipynb
+++ b/docs/cookbook/active/choice_maps.ipynb
@@ -8,7 +8,19 @@
     }
    },
    "source": [
-    "# Choice maps"
+    "# Choice maps [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/active/choice_maps.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/active/debugging.ipynb
+++ b/docs/cookbook/active/debugging.ipynb
@@ -4,9 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Debugging\n",
+    "# Debugging [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/active/debugging.ipynb)\n",
     "\n",
     "How can I debug my code? I want to add break points or print statements in my Jax/GenJax code but it  doesn't seem to work because of traced values and/or jit compilation. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/active/generative_function_interface.ipynb
+++ b/docs/cookbook/active/generative_function_interface.ipynb
@@ -4,7 +4,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# The generative function interface"
+    "# The generative function interface [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/active/generative_function_interface.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/active/intro.ipynb
+++ b/docs/cookbook/active/intro.ipynb
@@ -8,7 +8,19 @@
     }
    },
    "source": [
-    "# Introduction"
+    "# Introduction [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/active/intro.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/active/jax_basics.ipynb
+++ b/docs/cookbook/active/jax_basics.ipynb
@@ -4,7 +4,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# JAX Basics"
+    "# JAX Basics [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/active/jax_basics.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/expressivity/conditionals.ipynb
+++ b/docs/cookbook/inactive/expressivity/conditionals.ipynb
@@ -4,7 +4,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### How do I use conditionals in (Gen)JAX?"
+    "### How do I use conditionals in (Gen)JAX? [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/expressivity/conditionals.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/expressivity/custom_distribution.ipynb
+++ b/docs/cookbook/inactive/expressivity/custom_distribution.ipynb
@@ -8,7 +8,19 @@
     }
    },
    "source": [
-    "### How do I create a custom distribution in GenJAX?"
+    "### How do I create a custom distribution in GenJAX? [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/expressivity/custom_distribution.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/expressivity/iterating_computation.ipynb
+++ b/docs/cookbook/inactive/expressivity/iterating_computation.ipynb
@@ -8,7 +8,19 @@
     }
    },
    "source": [
-    "### I have a generative function with a single variable but 2000 observations, or I just want to use/apply it repeatedly. What do I do?"
+    "### I have a generative function with a single variable but 2000 observations, or I just want to use/apply it repeatedly. What do I do? [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/expressivity/iterating_computation.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/expressivity/masking.ipynb
+++ b/docs/cookbook/inactive/expressivity/masking.ipynb
@@ -8,7 +8,19 @@
     }
    },
    "source": [
-    "### I want more dynamic features but JAX only accepts arrays with statically known sizes, what do I do?"
+    "### I want more dynamic features but JAX only accepts arrays with statically known sizes, what do I do? [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/expressivity/masking.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/expressivity/mixture.ipynb
+++ b/docs/cookbook/inactive/expressivity/mixture.ipynb
@@ -8,7 +8,19 @@
     }
    },
    "source": [
-    "### How can I write a mixture of models in GenJAX?"
+    "### How can I write a mixture of models in GenJAX? [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/expressivity/mixture.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/expressivity/ravi_stack.ipynb
+++ b/docs/cookbook/inactive/expressivity/ravi_stack.ipynb
@@ -8,8 +8,20 @@
     }
    },
    "source": [
-    "## Nested approximate marginalisation & RAVI stacks \n",
+    "## Nested approximate marginalisation & RAVI stacks [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/expressivity/ravi_stack.ipynb)\n",
     "### How to be recursively wrong everywhere all the time yet correct at the end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/expressivity/stochastic_probabilities.ipynb
+++ b/docs/cookbook/inactive/expressivity/stochastic_probabilities.ipynb
@@ -8,7 +8,19 @@
     }
    },
    "source": [
-    "### How to create and use distributions with inexact likelihood evaluations"
+    "### How to create and use distributions with inexact likelihood evaluations [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/expressivity/stochastic_probabilities.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/expressivity/stochastic_probabilities_math.ipynb
+++ b/docs/cookbook/inactive/expressivity/stochastic_probabilities_math.ipynb
@@ -8,7 +8,23 @@
     }
    },
    "source": [
-    "### Details on random_weighted and estimate_logpdf"
+    "### Details on random_weighted and estimate_logpdf [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/expressivity/stochastic_probabilities_math.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/inference/custom_proposal.ipynb
+++ b/docs/cookbook/inactive/inference/custom_proposal.ipynb
@@ -8,7 +8,19 @@
     }
    },
    "source": [
-    "### I'm doing importance sampling as advised but it's bad, what can I do?"
+    "### I'm doing importance sampling as advised but it's bad, what can I do? [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/inference/custom_proposal.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/inference/importance_sampling.ipynb
+++ b/docs/cookbook/inactive/inference/importance_sampling.ipynb
@@ -8,7 +8,19 @@
     }
    },
    "source": [
-    "### I want to do my first inference task, how do I do it?"
+    "### I want to do my first inference task, how do I do it? [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/inference/importance_sampling.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/inference/mcmc.ipynb
+++ b/docs/cookbook/inactive/inference/mcmc.ipynb
@@ -8,7 +8,19 @@
     }
    },
    "source": [
-    "### What is MCMC? How do I use it? How do I write one?"
+    "### What is MCMC? How do I use it? How do I write one? [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/inference/mcmc.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {

--- a/docs/cookbook/inactive/library_author/dimap_combinator.ipynb
+++ b/docs/cookbook/inactive/library_author/dimap_combinator.ipynb
@@ -8,7 +8,19 @@
     }
    },
    "source": [
-    "### What is this magic?"
+    "### What is this magic? [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChiSym/genjax/blob/main/docs/cookbook/inactive/library_author/dimap_combinator.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet \"genjax[genstudio]\""
    ]
   },
   {


### PR DESCRIPTION
This PR:
- adds a public colab link to the README, vs our old enterprise one
- adds proper colab installation blocks to all notebooks
- adds "open in colab" buttons to all notebooks